### PR TITLE
Add GIL caveat notes to concurrent callback tests

### DIFF
--- a/jobserver/test.py
+++ b/jobserver/test.py
@@ -799,6 +799,9 @@ class JobserverTest(unittest.TestCase):
         A callback that registers another callback via when_done()
         triggers a nested _issue_callbacks() invocation.  All callbacks
         must fire in registration order, exactly once.
+
+        NB: The CPython GIL may prevent this test from failing even if
+        Future had no explicit locking.
         """
         js = Jobserver(slots=1)
         f = js.submit(fn=len, args=((1, 2),), timeout=5)


### PR DESCRIPTION
This change adds clarifying documentation to two test methods that verify callback behavior in concurrent scenarios.

**Summary:**
Added notes to the docstrings of `test_concurrent_when_done_with_done()` and `test_reentrant_when_done_nests_issue_callbacks()` to document an important caveat about test reliability.

**Key changes:**
- Added a note to `test_concurrent_when_done_with_done()` explaining that the CPython GIL may mask synchronization issues in the Future implementation
- Added the same caveat note to `test_reentrant_when_done_nests_issue_callbacks()`

**Details:**
These notes clarify that while the tests verify correct callback behavior, the CPython Global Interpreter Lock (GIL) may prevent the tests from failing even if the Future class lacks proper explicit locking. This is important context for developers maintaining or debugging these tests, as it explains a potential limitation in test coverage for thread-safety issues.

https://claude.ai/code/session_018Fkkf9Cnn1CryHpMpKHhFw