### PR TITLE
Update documentation link to reflect module rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Purpose
 This Jobserver is similar in spirit to multiprocessing.Pool or
 concurrent.futures.Executor with a few differences:
 
- * First, the [implementation](jobserver/impl.py) choices are based upon the [GNU Make
+ * First, the [implementation](jobserver/_jobserver.py) choices are based upon the [GNU Make
    Jobserver](https://www.gnu.org/software/make/manual/html_node/POSIX-Jobserver.html).
  * Second, as a result, the Jobserver is "nestable" meaning that resource
    constraints will be shared with work submitted by other work.


### PR DESCRIPTION
## Summary
Updated the README documentation to reference the correct module path following a refactoring of the jobserver implementation module.

## Changes
- Updated the implementation module reference in README.md from `jobserver/impl.py` to `jobserver/_jobserver.py`

## Details
This change corrects the documentation link to point to the actual location of the jobserver implementation after the module was renamed from `impl.py` to `_jobserver.py`. This ensures users and developers can easily navigate to the correct source file when reviewing the implementation details mentioned in the README.

https://claude.ai/code/session_01W9eJfsbRWhPJgTw7ikoBPD