### PR TITLE
Extract MinimalQueue and utilities into separate _queue module

### DIFF
--- a/ci
+++ b/ci
@@ -9,6 +9,9 @@ for ex in examples/*.py; do
     PYTHONPATH=. uv run "$ex"
 done
 
+# Unit testing runs the queue tests
+uv run -m unittest -v jobserver.test_queue
+
 # Unit testing runs the executor tests
 uv run -m unittest -v jobserver.test_executor
 

--- a/jobserver/__init__.py
+++ b/jobserver/__init__.py
@@ -45,6 +45,7 @@ from ._jobserver import (
     MinimalQueue,
     SubmissionDied,
 )
+from ._queue import absolute_deadline, resolve_context
 from ._executor import JobserverExecutor
 
 __all__ = (
@@ -55,4 +56,6 @@ __all__ = (
     "JobserverExecutor",
     "MinimalQueue",
     "SubmissionDied",
+    "absolute_deadline",
+    "resolve_context",
 )

--- a/jobserver/_executor.py
+++ b/jobserver/_executor.py
@@ -19,8 +19,8 @@ from ._jobserver import (
     CallbackRaised,
     Future,
     Jobserver,
-    MinimalQueue,
 )
+from ._queue import MinimalQueue
 
 from . import _request
 from . import _response

--- a/jobserver/_jobserver.py
+++ b/jobserver/_jobserver.py
@@ -15,11 +15,11 @@ import types
 from typing import Any, Generic, NoReturn, Optional, TypeVar, Union
 
 # Implementation depends upon an explicit subset of multiprocessing
-from multiprocessing import get_context
 from multiprocessing.connection import Connection, wait
 from multiprocessing.context import BaseContext
 from multiprocessing.process import BaseProcess
-from multiprocessing.reduction import ForkingPickler  # type: ignore
+
+from ._queue import MinimalQueue, absolute_deadline, resolve_context
 
 __all__ = (
     "Blocked",
@@ -247,126 +247,6 @@ class Future(Generic[T]):
 
         assert self._wrapper is not None
         return self._wrapper.unwrap()
-
-
-def absolute_deadline(relative_timeout: Optional[float]) -> float:
-    """
-    Convert relative_timeout in seconds into a monotonic, absolute deadline.
-
-    A large, absolute timeout is returned whenever relative_timeout is None.
-    """
-    # Cannot be Inf nor sys.float_info.max nor sys.maxsize / 1000
-    # nor _PyTime_t per https://stackoverflow.com/questions/45704243!
-    return time.monotonic() + (
-        (60 * 60 * 24 * 7)  # 604.8k seconds ought to be enough for anyone
-        if relative_timeout is None
-        else relative_timeout
-    )
-
-
-def resolve_context(context: Union[None, str, BaseContext]) -> BaseContext:
-    """Return a multiprocessing BaseContext, resolving None/str as needed."""
-    if context is None or isinstance(context, str):
-        return get_context(context)
-    return context
-
-
-class MinimalQueue(Generic[T]):
-    """
-    An unbounded SimpleQueue-variant with minimal function needed by Jobserver.
-
-    Vanilla multiprocessing.SimpleQueue lacks timeout on get(...).
-    Vanilla multiprocessing.Queue has wildly undesired threading machinery.
-    Both get(...) and put(...) detect and report when one end hangs up.
-    """
-
-    __slots__ = ("_reader", "_writer", "_read_lock", "_write_lock")
-
-    def __init__(self, context: Union[None, str, BaseContext] = None) -> None:
-        """Use given context with default of multiprocessing.get_context()."""
-        context = resolve_context(context)
-        reader, writer = context.Pipe(duplex=False)
-        self._reader: Optional[Connection] = reader
-        self._writer: Optional[Connection] = writer
-        self._read_lock = context.Lock()
-        self._write_lock = context.Lock()
-
-    def __copy__(self) -> "MinimalQueue":
-        """Shallow copies return the original MinimalQueue unchanged."""
-        # Because any "copy" should and can only mutate same pipe/locks
-        return self
-
-    def __deepcopy__(self, _: Any) -> "MinimalQueue":
-        """Deep copies return the original MinimalQueue unchanged."""
-        # Because any "copy" should and can only mutate same pipe/locks
-        return self
-
-    def waitable(self) -> int:
-        """The object on which to wait(...) to get(...) new data."""
-        assert self._reader is not None, "waitable() after close_get()"
-        return self._reader.fileno()
-
-    def close_get(self) -> None:
-        """Close the receiving end; get() may no longer be called.
-
-        Closes the underlying pipe end so EOF propagates on crash.
-        """
-        if self._reader is not None:
-            self._reader.close()
-            self._reader = None
-            # _read_lock must NOT be set to None here.  In spawn/forkserver
-            # mode, setting it to None would drop the last parent-side
-            # reference, causing CPython to call sem_unlink() on the named
-            # semaphore before the child process has had a chance to open it,
-            # producing FileNotFoundError during the child's unpickling.
-
-    def close_put(self) -> None:
-        """Close the sending end; put() may no longer be called.
-
-        Closes the underlying pipe end so EOF propagates on crash.
-        """
-        if self._writer is not None:
-            self._writer.close()
-            self._writer = None
-            # _write_lock must NOT be set to None here; same race condition
-            # as described in close_get().
-
-    def get(self, timeout: Optional[float] = None) -> T:
-        """
-        Get one object from the queue raising queue.Empty if unavailable.
-
-        Raises EOFError on exhausted queue whenever sending half has hung up.
-        """
-        assert self._reader is not None, "get() after close_get()"
-        # Accounting for lock acquisition time is easiest with a deadline
-        # and conditionals repeatedly checking for negative situations
-        # Otherwise, this turns into an unpleasantly messy stretch of code
-        deadline = absolute_deadline(relative_timeout=timeout)
-        if not self._read_lock.acquire(block=True, timeout=timeout):
-            raise queue.Empty
-        try:
-            if not self._reader.poll(deadline - time.monotonic()):
-                raise queue.Empty
-            recv = self._reader.recv_bytes()
-        finally:
-            self._read_lock.release()
-
-        # Deserialize outside the critical section
-        return ForkingPickler.loads(recv)
-
-    def put(self, *args: T) -> None:
-        """
-        Put zero or more objects into the queue, contiguously.
-
-        Raises BrokenPipeError if the receiving half has hung up.
-        """
-        assert self._writer is not None, "put() after close_put()"
-        if args:
-            # Serialize outside the critical section
-            send = [ForkingPickler.dumps(arg) for arg in args]
-            with self._write_lock:
-                while send:
-                    self._writer.send_bytes(send.pop(0))
 
 
 # Appears as a default argument in Jobserver to simplify some logic therein

--- a/jobserver/_queue.py
+++ b/jobserver/_queue.py
@@ -1,0 +1,144 @@
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""MinimalQueue and related utility functions."""
+
+import queue
+import time
+from typing import Any, Generic, Optional, TypeVar, Union
+
+# Implementation depends upon an explicit subset of multiprocessing
+from multiprocessing import get_context
+from multiprocessing.connection import Connection
+from multiprocessing.context import BaseContext
+from multiprocessing.reduction import ForkingPickler  # type: ignore
+
+__all__ = (
+    "MinimalQueue",
+    "absolute_deadline",
+    "resolve_context",
+)
+
+T = TypeVar("T")
+
+
+def absolute_deadline(relative_timeout: Optional[float]) -> float:
+    """
+    Convert relative_timeout in seconds into a monotonic, absolute deadline.
+
+    A large, absolute timeout is returned whenever relative_timeout is None.
+    """
+    # Cannot be Inf nor sys.float_info.max nor sys.maxsize / 1000
+    # nor _PyTime_t per https://stackoverflow.com/questions/45704243!
+    return time.monotonic() + (
+        (60 * 60 * 24 * 7)  # 604.8k seconds ought to be enough for anyone
+        if relative_timeout is None
+        else relative_timeout
+    )
+
+
+def resolve_context(context: Union[None, str, BaseContext]) -> BaseContext:
+    """Return a multiprocessing BaseContext, resolving None/str as needed."""
+    if context is None or isinstance(context, str):
+        return get_context(context)
+    return context
+
+
+class MinimalQueue(Generic[T]):
+    """
+    An unbounded SimpleQueue-variant with minimal function needed by Jobserver.
+
+    Vanilla multiprocessing.SimpleQueue lacks timeout on get(...).
+    Vanilla multiprocessing.Queue has wildly undesired threading machinery.
+    Both get(...) and put(...) detect and report when one end hangs up.
+    """
+
+    __slots__ = ("_reader", "_writer", "_read_lock", "_write_lock")
+
+    def __init__(self, context: Union[None, str, BaseContext] = None) -> None:
+        """Use given context with default of multiprocessing.get_context()."""
+        context = resolve_context(context)
+        reader, writer = context.Pipe(duplex=False)
+        self._reader: Optional[Connection] = reader
+        self._writer: Optional[Connection] = writer
+        self._read_lock = context.Lock()
+        self._write_lock = context.Lock()
+
+    def __copy__(self) -> "MinimalQueue":
+        """Shallow copies return the original MinimalQueue unchanged."""
+        # Because any "copy" should and can only mutate same pipe/locks
+        return self
+
+    def __deepcopy__(self, _: Any) -> "MinimalQueue":
+        """Deep copies return the original MinimalQueue unchanged."""
+        # Because any "copy" should and can only mutate same pipe/locks
+        return self
+
+    def waitable(self) -> int:
+        """The object on which to wait(...) to get(...) new data."""
+        assert self._reader is not None, "waitable() after close_get()"
+        return self._reader.fileno()
+
+    def close_get(self) -> None:
+        """Close the receiving end; get() may no longer be called.
+
+        Closes the underlying pipe end so EOF propagates on crash.
+        """
+        if self._reader is not None:
+            self._reader.close()
+            self._reader = None
+            # _read_lock must NOT be set to None here.  In spawn/forkserver
+            # mode, setting it to None would drop the last parent-side
+            # reference, causing CPython to call sem_unlink() on the named
+            # semaphore before the child process has had a chance to open it,
+            # producing FileNotFoundError during the child's unpickling.
+
+    def close_put(self) -> None:
+        """Close the sending end; put() may no longer be called.
+
+        Closes the underlying pipe end so EOF propagates on crash.
+        """
+        if self._writer is not None:
+            self._writer.close()
+            self._writer = None
+            # _write_lock must NOT be set to None here; same race condition
+            # as described in close_get().
+
+    def get(self, timeout: Optional[float] = None) -> T:
+        """
+        Get one object from the queue raising queue.Empty if unavailable.
+
+        Raises EOFError on exhausted queue whenever sending half has hung up.
+        """
+        assert self._reader is not None, "get() after close_get()"
+        # Accounting for lock acquisition time is easiest with a deadline
+        # and conditionals repeatedly checking for negative situations
+        # Otherwise, this turns into an unpleasantly messy stretch of code
+        deadline = absolute_deadline(relative_timeout=timeout)
+        if not self._read_lock.acquire(block=True, timeout=timeout):
+            raise queue.Empty
+        try:
+            if not self._reader.poll(deadline - time.monotonic()):
+                raise queue.Empty
+            recv = self._reader.recv_bytes()
+        finally:
+            self._read_lock.release()
+
+        # Deserialize outside the critical section
+        return ForkingPickler.loads(recv)
+
+    def put(self, *args: T) -> None:
+        """
+        Put zero or more objects into the queue, contiguously.
+
+        Raises BrokenPipeError if the receiving half has hung up.
+        """
+        assert self._writer is not None, "put() after close_put()"
+        if args:
+            # Serialize outside the critical section
+            send = [ForkingPickler.dumps(arg) for arg in args]
+            with self._write_lock:
+                while send:
+                    self._writer.send_bytes(send.pop(0))

--- a/jobserver/test_executor.py
+++ b/jobserver/test_executor.py
@@ -25,7 +25,8 @@ from multiprocessing import get_all_start_methods
 
 from ._executor import JobserverExecutor
 from ._request import Submit
-from ._jobserver import Jobserver, MinimalQueue
+from ._jobserver import Jobserver
+from ._queue import MinimalQueue
 
 # Most tests use the fastest start method.  On Python 3.12+ "fork" is
 # deprecated when the process is multi-threaded, so fall back to

--- a/jobserver/test_jobserver.py
+++ b/jobserver/test_jobserver.py
@@ -23,9 +23,9 @@ from ._jobserver import (
     CallbackRaised,
     Future,
     Jobserver,
-    MinimalQueue,
     SubmissionDied,
 )
+from ._queue import MinimalQueue
 
 T = typing.TypeVar("T")
 
@@ -207,34 +207,6 @@ class JobserverTest(unittest.TestCase):
                 # copy.copy(...) and copy.deepcopy(...) return the original.
                 self.assertIs(js1, js2)
                 self.assertIs(js1, js3)
-
-    # No behavioral assertions made around pickling, however.
-    # Indeed, disabling pickling MinimalQueues empirically breaks many tests.
-    def test_duplication_minimalqueue(self) -> None:
-        """Copying of MinimalQueue is explicitly allowed."""
-        for method in get_all_start_methods():
-            with self.subTest(method=method):
-                mq1 = MinimalQueue(context=method)  # type: MinimalQueue[int]
-                mq2 = copy.copy(mq1)
-                mq3 = copy.deepcopy(mq1)
-                mq1.put(1)
-                mq2.put(2)
-                mq3.put(3)
-                self.assertEqual(1, mq3.get())
-                self.assertEqual(2, mq2.get())
-                self.assertEqual(3, mq1.get())
-                # Though copying is allowed, it is degenerate in that
-                # copy.copy(...) and copy.deepcopy(...) return the original.
-                self.assertIs(mq1, mq2)
-                self.assertIs(mq1, mq3)
-
-    def test_close_get_and_close_put_are_idempotent(self) -> None:
-        """close_get() and close_put() are safe to call more than once."""
-        mq: MinimalQueue[int] = MinimalQueue()
-        mq.close_get()
-        mq.close_get()  # second call must not raise
-        mq.close_put()
-        mq.close_put()  # second call must not raise
 
     # Motivated by multiprocessing.Connection mentioning a possible 32MB limit
     def test_large_objects(self) -> None:

--- a/jobserver/test_queue.py
+++ b/jobserver/test_queue.py
@@ -1,0 +1,97 @@
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Tests for MinimalQueue, resolve_context, and absolute_deadline.
+
+MinimalQueue is tested heavily via the Jobserver and JobserverExecutor
+tests hence this test file is brief.
+"""
+import copy
+import time
+import unittest
+
+from multiprocessing import get_all_start_methods, get_context
+from multiprocessing.context import BaseContext
+
+from ._queue import MinimalQueue, absolute_deadline, resolve_context
+
+
+class MinimalQueueTest(unittest.TestCase):
+    """Unit tests for MinimalQueue."""
+
+    def test_duplication_minimalqueue(self) -> None:
+        """Copying of MinimalQueue is explicitly allowed."""
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                mq1 = MinimalQueue(context=method)  # type: MinimalQueue[int]
+                mq2 = copy.copy(mq1)
+                mq3 = copy.deepcopy(mq1)
+                mq1.put(1)
+                mq2.put(2)
+                mq3.put(3)
+                self.assertEqual(1, mq3.get())
+                self.assertEqual(2, mq2.get())
+                self.assertEqual(3, mq1.get())
+                # Though copying is allowed, it is degenerate in that
+                # copy.copy(...) and copy.deepcopy(...) return the original.
+                self.assertIs(mq1, mq2)
+                self.assertIs(mq1, mq3)
+
+    def test_close_get_and_close_put_are_idempotent(self) -> None:
+        """close_get() and close_put() are safe to call more than once."""
+        mq: MinimalQueue[int] = MinimalQueue()
+        mq.close_get()
+        mq.close_get()  # second call must not raise
+        mq.close_put()
+        mq.close_put()  # second call must not raise
+
+
+class ResolveContextTest(unittest.TestCase):
+    """Unit tests for resolve_context."""
+
+    def test_none_returns_default_context(self) -> None:
+        """None resolves to the default multiprocessing context."""
+        ctx = resolve_context(None)
+        self.assertIsInstance(ctx, BaseContext)
+
+    def test_string_returns_named_context(self) -> None:
+        """A start-method string resolves to the named context."""
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                ctx = resolve_context(method)
+                self.assertIsInstance(ctx, BaseContext)
+
+    def test_context_passes_through(self) -> None:
+        """An existing BaseContext is returned unchanged."""
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                original = get_context(method)
+                self.assertIs(resolve_context(original), original)
+
+
+class AbsoluteDeadlineTest(unittest.TestCase):
+    """Unit tests for absolute_deadline."""
+
+    def test_none_yields_large_deadline(self) -> None:
+        """None timeout produces a deadline far in the future."""
+        before = time.monotonic()
+        deadline = absolute_deadline(None)
+        self.assertGreater(deadline, before + 86400)
+
+    def test_zero_yields_near_now(self) -> None:
+        """Zero timeout produces a deadline near the current time."""
+        before = time.monotonic()
+        deadline = absolute_deadline(0)
+        after = time.monotonic()
+        self.assertGreaterEqual(deadline, before)
+        self.assertLessEqual(deadline, after + 0.01)
+
+    def test_positive_offset(self) -> None:
+        """A positive timeout offsets from the current monotonic time."""
+        before = time.monotonic()
+        deadline = absolute_deadline(5.0)
+        after = time.monotonic()
+        self.assertGreaterEqual(deadline, before + 5.0)
+        self.assertLessEqual(deadline, after + 5.0 + 0.01)


### PR DESCRIPTION
## Summary
Refactors the codebase to extract `MinimalQueue`, `absolute_deadline`, and `resolve_context` from `_jobserver.py` into a new dedicated `_queue.py` module. This improves code organization by separating queue implementation concerns from jobserver logic.

## Key Changes
- **New module `jobserver/_queue.py`**: Contains the complete implementation of `MinimalQueue` class and utility functions `absolute_deadline()` and `resolve_context()`
- **Updated `jobserver/_jobserver.py`**: Removed queue-related code and now imports from `_queue` module
- **Updated `jobserver/__init__.py`**: Exports `absolute_deadline` and `resolve_context` as public API alongside existing exports
- **New test file `jobserver/test_queue.py`**: Dedicated unit tests for `MinimalQueue`, `resolve_context`, and `absolute_deadline` (previously tested indirectly through jobserver tests)
- **Updated test files**: Adjusted imports in `test_jobserver.py`, `test_executor.py`, and `_executor.py` to import from `_queue` module
- **Updated CI**: Added explicit test run for the new `test_queue` module

## Notable Details
- The `MinimalQueue` implementation remains functionally identical; this is purely a refactoring for better code organization
- Tests for `MinimalQueue` duplication and `close_get()`/`close_put()` idempotency were moved from `test_jobserver.py` to the new `test_queue.py`
- All three extracted utilities are now part of the public API via `__init__.py`
- No behavioral changes to any functionality

https://claude.ai/code/session_01A1UehMN8jGi717ZS144hng