### PR TITLE
Prevent double-wrapping of CallbackRaised in re-entrant callbacks

### DIFF
--- a/jobserver/_jobserver.py
+++ b/jobserver/_jobserver.py
@@ -232,6 +232,12 @@ class Future(Generic[T]):
                 try:
                     fn(*args, **kwargs)
                 except Exception as e:
+                    # A re-entrant when_done() on an already-done future
+                    # triggers a nested _issue_callbacks(); without this
+                    # guard the caller sees CallbackRaised wrapping another
+                    # CallbackRaised instead of one layer around the cause.
+                    if isinstance(e, CallbackRaised):
+                        raise
                     raise CallbackRaised() from e
 
     def result(self, timeout: Optional[float] = None) -> T:

--- a/tests/test_jobserver.py
+++ b/tests/test_jobserver.py
@@ -840,3 +840,22 @@ class JobserverTest(unittest.TestCase):
         # Now the future can complete normally
         f.done(timeout=10)
         self.assertIsNone(f.result())
+
+    def test_reentrant_callback_raised_no_double_wrap(self) -> None:
+        """Re-entrant when_done() with a raising inner callback must not double-wrap.
+
+        If a callback calls when_done() on an already-done future and that inner
+        callback raises, the caller must see CallbackRaised(cause=<original>),
+        not CallbackRaised(cause=CallbackRaised(cause=<original>)).
+        """
+        js = Jobserver(slots=1)
+        f = js.submit(fn=len, args=((1,),), timeout=5)
+        f.done(timeout=5)
+
+        def outer() -> None:
+            f.when_done(lambda: 1 / 0)  # raises ZeroDivisionError immediately
+
+        with self.assertRaises(CallbackRaised) as c:
+            f.when_done(outer)
+        self.assertIsInstance(c.exception.__cause__, ZeroDivisionError)
+        self.assertNotIsInstance(c.exception.__cause__, CallbackRaised)


### PR DESCRIPTION
## Summary
Fix an issue where re-entrant `when_done()` calls on already-done futures would double-wrap exceptions in `CallbackRaised`, causing the original exception to be buried under multiple layers of wrapping.

## Changes
- **jobserver/_jobserver.py**: Added a guard in `_issue_callbacks()` to detect when a callback raises `CallbackRaised` and re-raise it directly instead of wrapping it again. This handles the case where a callback invokes `when_done()` on an already-done future, which triggers a nested `_issue_callbacks()` call.

- **tests/test_jobserver.py**: Added `test_reentrant_callback_raised_no_double_wrap()` to verify that when a re-entrant callback raises an exception, the caller receives `CallbackRaised` with the original exception as the direct cause, not wrapped in another `CallbackRaised`.

## Implementation Details
The fix checks if an exception caught during callback execution is already a `CallbackRaised` instance. If so, it re-raises it as-is rather than wrapping it again. This preserves the exception chain while preventing the double-wrapping that occurred when nested `_issue_callbacks()` calls each added their own `CallbackRaised` wrapper.

https://claude.ai/code/session_01NigFY7a873vnvgexV8o8vn