### PR TITLE
Add instance-level defaults for submit() parameters

### DIFF
--- a/jobserver/_jobserver.py
+++ b/jobserver/_jobserver.py
@@ -334,7 +334,7 @@ class Jobserver:
         # mutation of the caller's container after __init__ returns.
         # Mappings expose .items(); plain iterables are already pairs.
         items = env.items() if isinstance(env, Mapping) else env
-        self._env: tuple[tuple[str, Optional[str]], ...] = tuple(items)
+        self._env = tuple(items)
         self._preexec_fn = preexec_fn
         self._sleep_fn = sleep_fn
 


### PR DESCRIPTION
## Summary
This change adds support for instance-level default values for the `env`, `preexec_fn`, and `sleep_fn` parameters in the `Jobserver.submit()` method. These defaults can be set during `Jobserver` initialization and will be used for any `submit()` calls that don't explicitly provide these parameters.

## Key Changes
- **Extended `__slots__`**: Added `_env`, `_preexec_fn`, and `_sleep_fn` to store instance-level defaults
- **Updated `__init__` signature**: Added keyword-only parameters `env`, `preexec_fn`, and `sleep_fn` with sensible defaults
- **Defensive copying**: The `env` parameter is converted to a tuple to prevent mutation of caller's containers and handle both Mapping and Iterable types
- **Updated pickling support**: Modified `__getstate__()` and `__setstate__()` to preserve the new instance attributes when the Jobserver is pickled/unpickled
- **Enhanced `submit()` method**: 
  - Changed parameter types to accept `None` as a sentinel value
  - Added logic to resolve `None` values to instance defaults
  - Updated docstring to document the override behavior
- **Improved type hints**: More precise type annotations for the optional parameters

## Implementation Details
- The `env` parameter intelligently handles both Mapping and Iterable types by checking for `.items()` method
- A defensive copy of `env` is made during initialization to guard against external mutations
- The `None` sentinel pattern allows callers to explicitly override instance defaults while maintaining backward compatibility
- Pickling state tuple size increased from 3 to 6 elements with appropriate assertion updates

https://claude.ai/code/session_01R5GXFdJ8N8SmDaWPEZV7G8