### PR TITLE
Format code and extend black linting to tests directory

### DIFF
--- a/ci
+++ b/ci
@@ -16,7 +16,7 @@ uvx --from flake8 flake8 jobserver/ examples/ tests/
 uvx --from "mypy>0.770" mypy jobserver/ examples/
 
 # Then, check for formatting issues
-uvx --from "black<25" black --check --line-length 79 --verbose jobserver/ examples/
+uvx --from "black<25" black --check --line-length 79 --verbose jobserver/ examples/ tests/
 
 # Last, verify the source distribution builds correctly
 uvx --from build python -m build --sdist

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -97,9 +97,7 @@ def helper_nonblocking(mq: MinimalQueue[str]) -> str:
     return mq.get(timeout=60.0)
 
 
-def helper_callback(
-    lizt: typing.List, index: int, increment: int
-) -> None:
+def helper_callback(lizt: typing.List, index: int, increment: int) -> None:
     """Helper permitting tests to observe callbacks firing."""
     lizt[index] += increment
 
@@ -141,9 +139,7 @@ def helper_recurse(js: Jobserver, max_depth: int) -> int:
     if max_depth < 1:
         return 0
     try:
-        f = js.submit(
-            fn=helper_recurse, args=(js, max_depth - 1), timeout=0
-        )
+        f = js.submit(fn=helper_recurse, args=(js, max_depth - 1), timeout=0)
     except Blocked:
         return 0
     return 1 + f.result(timeout=None)

--- a/tests/test_executor_lifecycle.py
+++ b/tests/test_executor_lifecycle.py
@@ -344,8 +344,7 @@ class TestResourceLeaks(unittest.TestCase):
             # Wait for the dispatcher to be alive
             deadline = time.monotonic() + 5
             while (
-                not exe._dispatcher.is_alive()
-                and time.monotonic() < deadline
+                not exe._dispatcher.is_alive() and time.monotonic() < deadline
             ):
                 time.sleep(0.01)
             self.assertTrue(exe._dispatcher.is_alive())

--- a/tests/test_jobserver_worker.py
+++ b/tests/test_jobserver_worker.py
@@ -280,8 +280,10 @@ class TestJobserverWorker(unittest.TestCase):
 
                 with self.assertRaises(RuntimeError) as c:
                     js.submit(
-                        fn=len, args=((),),
-                        sleep_fn=raises_error, timeout=5,
+                        fn=len,
+                        args=((),),
+                        sleep_fn=raises_error,
+                        timeout=5,
                     )
                 self.assertIn("sleep_fn failed", str(c.exception))
                 f.done(timeout=5)
@@ -293,9 +295,7 @@ class TestJobserverWorker(unittest.TestCase):
         for method in get_all_start_methods():
             with self.subTest(method=method):
                 # env: child sees key without submit() specifying it
-                js = Jobserver(
-                    context=method, slots=1, env={key: "FROM_INIT"}
-                )
+                js = Jobserver(context=method, slots=1, env={key: "FROM_INIT"})
                 f = js.submit(fn=os.getenv, args=(key, "SENTINEL"))
                 self.assertEqual("FROM_INIT", f.result())
 
@@ -309,9 +309,7 @@ class TestJobserverWorker(unittest.TestCase):
                 self.assertEqual("PREEXEC_FN", g.result())
 
                 # sleep_fn: a vetoing fn blocks every submit()
-                js = Jobserver(
-                    context=method, slots=1, sleep_fn=lambda: 99.0
-                )
+                js = Jobserver(context=method, slots=1, sleep_fn=lambda: 99.0)
                 with self.assertRaises(Blocked):
                     js.submit(fn=len, timeout=0.0)
 
@@ -322,9 +320,7 @@ class TestJobserverWorker(unittest.TestCase):
         for method in get_all_start_methods():
             with self.subTest(method=method):
                 # env override: submit-level value replaces the init default
-                js = Jobserver(
-                    context=method, slots=1, env={key: "FROM_INIT"}
-                )
+                js = Jobserver(context=method, slots=1, env={key: "FROM_INIT"})
                 f = js.submit(
                     fn=os.getenv,
                     args=(key, "SENTINEL"),
@@ -346,10 +342,6 @@ class TestJobserverWorker(unittest.TestCase):
                 self.assertEqual("SENTINEL", g.result())
 
                 # sleep_fn override: submit-level permissive fn unblocks work
-                js = Jobserver(
-                    context=method, slots=1, sleep_fn=lambda: 99.0
-                )
-                h = js.submit(
-                    fn=len, args=((1,),), sleep_fn=lambda: None
-                )
+                js = Jobserver(context=method, slots=1, sleep_fn=lambda: 99.0)
+                h = js.submit(fn=len, args=((1,),), sleep_fn=lambda: None)
                 self.assertEqual(1, h.result())


### PR DESCRIPTION
This PR applies code formatting improvements and extends linting coverage to the tests directory.

**Key changes:**

- **Code formatting**: Reformatted function calls and definitions to improve readability by breaking long parameter lists across multiple lines consistently
  - `js.submit()` calls now have each parameter on its own line
  - `Jobserver()` constructor calls simplified to single-line format where appropriate
  - Function definitions with multiple parameters reformatted for consistency

- **Linting coverage**: Extended black code formatter checks to include the `tests/` directory in the CI pipeline, ensuring test code maintains the same formatting standards as the main codebase

**Files modified:**
- `tests/test_jobserver_worker.py`: Reformatted `js.submit()` and `Jobserver()` calls
- `tests/helpers.py`: Reformatted function definitions and `js.submit()` calls
- `tests/test_executor_lifecycle.py`: Reformatted multi-line conditional expression
- `ci`: Added `tests/` directory to black formatter invocation

No functional changes were made; this is purely a formatting and linting configuration update.

https://claude.ai/code/session_01USxeFBpD2jiZtrts5TtXiV