### PR TITLE
Eliminate pop(0) performance anti-pattern across codebase

### DIFF
--- a/jobserver/_jobserver.py
+++ b/jobserver/_jobserver.py
@@ -147,7 +147,7 @@ class Future(Generic[T]):
         self._wrapper: Optional[Wrapper[T]] = None
 
         # Populated by calls to when_done(...)
-        self._callbacks: list[tuple] = []
+        self._callbacks: deque[tuple] = deque()
 
     def __copy__(self) -> NoReturn:
         """Disallow copying as duplicates cannot sensibly share resources."""
@@ -248,7 +248,7 @@ class Future(Generic[T]):
         # Otherwise, we might obfuscate bugs within this module's logic
         assert self._connection is None and self._process is None, "Invariant"
         while self._callbacks:
-            internal, fn, args, kwargs = self._callbacks.pop(0)
+            internal, fn, args, kwargs = self._callbacks.popleft()
             if internal:
                 fn(*args, **kwargs)
             else:
@@ -474,7 +474,7 @@ class Jobserver:
         except Exception:
             # Unwinding any consumed slots on unexpected errors
             while tokens:
-                self._slots.put(tokens.pop(0))
+                self._slots.put(tokens.pop())
             raise
 
         # As above process.start() succeeded, now Future must restore tokens

--- a/jobserver/_queue.py
+++ b/jobserver/_queue.py
@@ -141,5 +141,5 @@ class MinimalQueue(Generic[T]):
             # Serialize outside the critical section
             send = [ForkingPickler.dumps(arg) for arg in args]
             with self._write_lock:
-                while send:
-                    self._writer.send_bytes(send.pop(0))
+                for item in send:
+                    self._writer.send_bytes(item)


### PR DESCRIPTION
- Future._callbacks: use deque with popleft() for O(1) removal
- Jobserver.submit error path: use pop() since token order is irrelevant
- MinimalQueue.put: iterate with for loop instead of mutating the list

https://claude.ai/code/session_01LgiKmghbPvwJRRGqAGHX38