### PR TITLE
Refactor callback exception handling in Future.when_done()

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -223,7 +223,11 @@ class Future(Generic[T]):
                 (
                     __priority,
                     self._callback_seqno,
-                    fn if __internal else functools.partial(_possibly_raises, fn),
+                    (
+                        fn
+                        if __internal
+                        else functools.partial(_possibly_raises, fn)
+                    ),
                     args,
                     kwargs,
                 ),

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -7,6 +7,7 @@
 
 import abc
 import concurrent.futures
+import functools
 import heapq
 import os
 import queue
@@ -121,6 +122,20 @@ class ExceptionWrapper(Wrapper[T]):
         raise self._raised
 
 
+def _possibly_raises(fn, *args, **kwargs) -> None:
+    """Call fn(*args, **kwargs), wrapping any Exception in CallbackRaised."""
+    try:
+        fn(*args, **kwargs)
+    except Exception as e:
+        # A re-entrant when_done() on an already-completed future
+        # triggers a nested _issue_callbacks(); without this
+        # guard the caller sees CallbackRaised wrapping another
+        # CallbackRaised instead of one layer around the cause.
+        if isinstance(e, CallbackRaised):
+            raise
+        raise CallbackRaised() from e
+
+
 # Callback priorities for the Future heapq-based callback queue.
 # Token restoration fires first, user callbacks in the middle,
 # and sentinel cleanup fires last.
@@ -208,8 +223,7 @@ class Future(Generic[T]):
                 (
                     __priority,
                     self._callback_seqno,
-                    __internal,
-                    fn,
+                    fn if __internal else functools.partial(_possibly_raises, fn),
                     args,
                     kwargs,
                 ),
@@ -310,24 +324,10 @@ class Future(Generic[T]):
             self._rlock.release()
 
     def _issue_callbacks(self):
-        # Only a non-internal callback may cause CallbackRaised
-        # Otherwise, we might obfuscate bugs within this module's logic
         assert self._connection is None and self._process is None, "Invariant"
         while self._callbacks:
-            _, _, internal, fn, args, kwargs = heapq.heappop(self._callbacks)
-            if internal:
-                fn(*args, **kwargs)
-            else:
-                try:
-                    fn(*args, **kwargs)
-                except Exception as e:
-                    # A re-entrant when_done() on an already-completed future
-                    # triggers a nested _issue_callbacks(); without this
-                    # guard the caller sees CallbackRaised wrapping another
-                    # CallbackRaised instead of one layer around the cause.
-                    if isinstance(e, CallbackRaised):
-                        raise
-                    raise CallbackRaised() from e
+            _, _, fn, args, kwargs = heapq.heappop(self._callbacks)
+            fn(*args, **kwargs)
 
     def result(self, timeout: Optional[float] = None) -> T:
         """

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -130,6 +130,8 @@ _PRIORITY_USER = 1
 _PRIORITY_CLEANUP = 2
 
 
+# Only a non-internal callback may cause CallbackRaised
+# Otherwise, we might obfuscate bugs within this module's logic
 def _possibly_raises(fn, *args, **kwargs) -> None:
     """Call fn(*args, **kwargs), wrapping any Exception in CallbackRaised."""
     try:

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -122,6 +122,14 @@ class ExceptionWrapper(Wrapper[T]):
         raise self._raised
 
 
+# Callback priorities for the Future heapq-based callback queue.
+# Token restoration fires first, user callbacks in the middle,
+# and sentinel cleanup fires last.
+_PRIORITY_TOKEN = 0
+_PRIORITY_USER = 1
+_PRIORITY_CLEANUP = 2
+
+
 def _possibly_raises(fn, *args, **kwargs) -> None:
     """Call fn(*args, **kwargs), wrapping any Exception in CallbackRaised."""
     try:
@@ -134,14 +142,6 @@ def _possibly_raises(fn, *args, **kwargs) -> None:
         if isinstance(e, CallbackRaised):
             raise
         raise CallbackRaised() from e
-
-
-# Callback priorities for the Future heapq-based callback queue.
-# Token restoration fires first, user callbacks in the middle,
-# and sentinel cleanup fires last.
-_PRIORITY_TOKEN = 0
-_PRIORITY_USER = 1
-_PRIORITY_CLEANUP = 2
 
 
 class Future(Generic[T]):


### PR DESCRIPTION
## Summary
Refactored the callback exception handling logic in `Future._issue_callbacks()` by extracting the wrapping behavior into a separate `_possibly_raises()` function and using `functools.partial()` to apply it selectively at callback registration time rather than at invocation time.

## Key Changes
- Added new `_possibly_raises()` helper function that wraps non-internal callback execution and converts exceptions to `CallbackRaised`
- Modified `Future.when_done()` to wrap user callbacks (non-internal) with `functools.partial(_possibly_raises, fn)` at registration time
- Simplified `Future._issue_callbacks()` by removing the internal/external callback distinction logic and exception handling, now treating all callbacks uniformly
- Updated the callback tuple structure to remove the `__internal` flag, reducing from 6 to 5 elements per callback entry

## Implementation Details
- The `_possibly_raises()` function preserves the existing exception handling behavior: it re-raises `CallbackRaised` exceptions directly (to avoid double-wrapping in re-entrant scenarios) and wraps other exceptions in `CallbackRaised`
- By applying the wrapper at registration time via `functools.partial()`, the distinction between internal and user callbacks is encoded in the callback itself rather than requiring runtime checks
- This change maintains backward compatibility and the same exception semantics while improving code clarity and reducing complexity in the hot path (`_issue_callbacks()`)

https://claude.ai/code/session_01QEnt7MhWCZ2XH15jJcVbmM