### PR TITLE
Optimize reclaim_resources to batch check ready sentinels

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -504,23 +504,11 @@ class Jobserver:
         May raise CallbackRaised from at most one registered callback.
         See CallbackRaised documentation for callback error semantics.
         """
-        # Build a reverse map from each wait()-able object to its Future.
-        # Both the pipe Connection and the process sentinel (int fd) signal
-        # completion; including both ensures we find futures whose worker has
-        # written its result but not yet fully exited.
-        waitable_to_future: dict = {}
-        for future, sentinel in self._future_sentinels.items():
-            waitable_to_future[sentinel] = future
-            if future._connection is not None:
-                waitable_to_future[future._connection] = future
-
-        # One wait() call with timeout=0 returns only the ready waitables,
-        # so done() is called O(k) times for k ready futures rather than O(N).
-        seen: set = set()
-        for w in wait(list(waitable_to_future), timeout=0):
-            future = waitable_to_future[w]
-            if future not in seen:
-                seen.add(future)
+        # One wait() call identifies which sentinels are ready in O(1)/O(k).
+        # Snapshot items() so callbacks mutating _future_sentinels are safe.
+        ready = set(wait(list(self._future_sentinels.values()), timeout=0))
+        for future, sentinel in tuple(self._future_sentinels.items()):
+            if sentinel in ready:
                 future.done()
 
     def submit(

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -504,9 +504,24 @@ class Jobserver:
         May raise CallbackRaised from at most one registered callback.
         See CallbackRaised documentation for callback error semantics.
         """
-        # Copy of keys() required to prevent concurrent modification
-        for future in tuple(self._future_sentinels.keys()):
-            future.done()
+        # Build a reverse map from each wait()-able object to its Future.
+        # Both the pipe Connection and the process sentinel (int fd) signal
+        # completion; including both ensures we find futures whose worker has
+        # written its result but not yet fully exited.
+        waitable_to_future: dict = {}
+        for future, sentinel in self._future_sentinels.items():
+            waitable_to_future[sentinel] = future
+            if future._connection is not None:
+                waitable_to_future[future._connection] = future
+
+        # One wait() call with timeout=0 returns only the ready waitables,
+        # so done() is called O(k) times for k ready futures rather than O(N).
+        seen: set = set()
+        for w in wait(list(waitable_to_future), timeout=0):
+            future = waitable_to_future[w]
+            if future not in seen:
+                seen.add(future)
+                future.done()
 
     def submit(
         self,

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -504,9 +504,12 @@ class Jobserver:
         May raise CallbackRaised from at most one registered callback.
         See CallbackRaised documentation for callback error semantics.
         """
-        # One wait() call identifies which sentinels are ready in O(1)/O(k).
-        # Snapshot items() so callbacks mutating _future_sentinels are safe.
-        ready = set(wait(list(self._future_sentinels.values()), timeout=0))
+        # Strategy: one wait() identifies the k ready sentinels in one shot,
+        # so done() is called O(k) times rather than O(N).  sentinel-ready
+        # implies connection-ready, so sentinel alone is sufficient to detect
+        # completion.  Snapshot items() since done() triggers a callback that
+        # mutates _future_sentinels.
+        ready = set(wait(self._future_sentinels.values(), timeout=0))
         for future, sentinel in tuple(self._future_sentinels.items()):
             if sentinel in ready:
                 future.done()


### PR DESCRIPTION
## Summary
Improved the performance of `reclaim_resources()` by using `wait()` to efficiently identify ready sentinels in a single operation, rather than calling `done()` on every future regardless of readiness.

## Key Changes
- Replaced O(N) iteration that calls `done()` on all futures with an O(k) approach using `concurrent.futures.wait()` to identify only the k ready sentinels
- Changed from checking `future.done()` to checking if the sentinel is in the ready set before calling `future.done()`
- Updated the loop to iterate over `items()` instead of just `keys()` to access both future and sentinel for comparison
- Enhanced comments to explain the optimization strategy and why sentinel-readiness is sufficient to detect completion

## Implementation Details
- Uses `wait(self._future_sentinels.values(), timeout=0)` to perform a non-blocking check that returns all ready sentinels in one shot
- Maintains the snapshot pattern with `tuple()` to prevent concurrent modification issues when `done()` triggers callbacks that mutate `_future_sentinels`
- Leverages the fact that sentinel-ready implies connection-ready, so checking only the sentinel is sufficient for detecting completion

https://claude.ai/code/session_01Pu2SBz3pXJ2S9jDUCxMGx7