### PR TITLE
Remove MinimalQueue from public API exports

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -38,7 +38,6 @@ __all__ = (
     "CallbackRaised",
     "Future",
     "Jobserver",
-    "MinimalQueue",
     "SubmissionDied",
 )
 


### PR DESCRIPTION
## Summary
Removed `MinimalQueue` from the module's public API by deleting it from the `__all__` export list in `src/jobserver/_jobserver.py`.

## Changes
- Removed `"MinimalQueue"` from the `__all__` tuple, making it no longer part of the public API surface

## Details
This change indicates that `MinimalQueue` is being treated as an internal implementation detail rather than a public interface. Users importing from this module will no longer see `MinimalQueue` as an officially supported export.

https://claude.ai/code/session_01XQRfRptuTLMvxQG7yz5Y1z