### PR TITLE
Fix typo in _worker_entrypoint docstring

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -701,7 +701,7 @@ class Jobserver:
 
 
 def _worker_entrypoint(send, env, preexec_fn, fn, *args, **kwargs) -> None:
-    """Entry point for workers to fun fn(...) due to some  submit(...)."""
+    """Entry point for workers to run fn(...) due to some submit(...)."""
     ignore_sigpipe()
 
     # Wrapper usage tracks whether a value was returned or raised


### PR DESCRIPTION
Fixes #114.

Corrects two issues in the `_worker_entrypoint` docstring:
- `"to fun fn"` → `"to run fn"`
- Remove double space before `submit(...)`

https://claude.ai/code/session_01GZec9HtJ2y8zqq4JJLtxn2