### PR TITLE
Fix PEP reference number in CallbackRaised docstring

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -54,7 +54,7 @@ class CallbackRaised(Exception):
     """
     Reports an Exception raised from callbacks registered with a Future.
 
-    Instances of this type must have non-None __cause__ members (see PEP 3154).
+    Instances of this type must have non-None __cause__ members (see PEP 3134).
     The __cause__ member will be the Exception raised by client code.
 
     When raised by some method, e.g. by Future.done(...), Future.wait(...),


### PR DESCRIPTION
## Summary
Corrected an incorrect PEP reference number in the docstring for the `CallbackRaised` exception class.

## Changes
- Updated PEP reference from PEP 3154 to PEP 3134 in the `CallbackRaised` class docstring
  - PEP 3134 is the correct PEP that defines exception chaining and the `__cause__` attribute
  - PEP 3154 does not exist and was likely a typo

## Details
The docstring for `CallbackRaised` documents that instances must have non-None `__cause__` members. The reference to PEP 3134 ("Exception Chaining and Embedded Tracebacks") is the correct specification for this behavior, not PEP 3154.

https://claude.ai/code/session_01HT2toqGztvqcSVgjdUdd4e