### PR TITLE
Replace zip_longest with generator expressions in map method

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -17,7 +17,7 @@ import time
 import types
 from collections import deque
 from collections.abc import Callable, Iterable, Iterator, Mapping
-from itertools import islice, zip_longest
+from itertools import islice
 
 # Implementation depends upon an explicit subset of multiprocessing
 from multiprocessing.connection import Connection, wait
@@ -678,9 +678,9 @@ class Jobserver:
         if argses is not None and kwargses is not None:
             pairs = _strict_zip(argses, kwargses)
         elif kwargses is not None:
-            pairs = zip_longest((), kwargses, fillvalue=())
+            pairs = (((), kw) for kw in kwargses)
         else:
-            pairs = zip_longest(argses or (), (), fillvalue={})
+            pairs = ((args, {}) for args in (argses or ()))
 
         collected = list(pairs) if buffersize is None else None
         return _map_generate(


### PR DESCRIPTION
## Summary
Simplified the implementation of the `map` method by replacing `zip_longest` calls with more straightforward generator expressions, eliminating the need for the `zip_longest` import.

## Key Changes
- Removed `zip_longest` from itertools imports
- Replaced `zip_longest((), kwargses, fillvalue=())` with a generator expression `(((), kw) for kw in kwargses)`
- Replaced `zip_longest(argses or (), (), fillvalue={})` with a generator expression `((args, {}) for args in (argses or ()))`

## Implementation Details
The generator expressions are functionally equivalent to the previous `zip_longest` calls but more explicit about their intent:
- When only `kwargses` is provided, pair each keyword argument dict with an empty tuple for args
- When only `argses` is provided, pair each args tuple with an empty dict for kwargs

This change improves code clarity by making the pairing logic more direct and reduces unnecessary dependencies on `itertools.zip_longest`.

https://claude.ai/code/session_015qkqp3uhTmrEERziJL2FKC