### PR TITLE
Change Failed.exc type from BaseException to Exception

### DIFF
--- a/src/jobserver/_response.py
+++ b/src/jobserver/_response.py
@@ -32,7 +32,7 @@ class Failed(typing.NamedTuple):
     """Work finished with an exception."""
 
     work_id: int
-    exc: BaseException
+    exc: Exception
 
 
 class Cancelled(typing.NamedTuple):


### PR DESCRIPTION
## Summary
Updated the type annotation for the `exc` field in the `Failed` named tuple to use `Exception` instead of `BaseException`.

## Changes
- Changed `Failed.exc` type annotation from `BaseException` to `Exception` in `src/jobserver/_response.py`

## Details
This change narrows the exception type that can be stored in a `Failed` response object. By using `Exception` instead of `BaseException`, the code now explicitly indicates that only standard exceptions (not system-exiting exceptions like `KeyboardInterrupt`, `SystemExit`, or `GeneratorExit`) should be captured in failed work responses. This provides better type safety and clearer intent about what exceptions are expected to be handled by the jobserver's failure handling mechanism.

https://claude.ai/code/session_01Rqim4qmZ2nBEyaYxwfFGqW