### PR TITLE
Add py.typed marker for PEP 561 compliance

### DIFF
--- a/test/test_py_typed.py
+++ b/test/test_py_typed.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""PEP 561 compliance: py.typed marker must exist (GitHub issue #119)."""
+
+import importlib.resources
+import unittest
+
+
+class TestPyTyped(unittest.TestCase):
+    """The py.typed marker file is required for PEP 561 compliance."""
+
+    def test_py_typed_exists(self) -> None:
+        """py.typed marker file must exist in the installed package."""
+        ref = importlib.resources.files("jobserver").joinpath("py.typed")
+        self.assertTrue(ref.is_file(), "src/jobserver/py.typed is missing")

--- a/test/test_py_typed.py
+++ b/test/test_py_typed.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""PEP 561 compliance: py.typed marker must exist (GitHub issue #119)."""
+"""PEP 561 compliance: py.typed marker must exist in the package."""
 
 import importlib.resources
 import unittest


### PR DESCRIPTION
## Summary
This PR adds PEP 561 compliance to the jobserver package by including a `py.typed` marker file and a corresponding test to ensure its presence.

## Changes
- Added `src/jobserver/py.typed` marker file to indicate the package supports type hints (PEP 561)
- Added `test/test_py_typed.py` with a test case that verifies the marker file exists in the installed package

## Details
The `py.typed` marker file is an empty file required by PEP 561 to indicate that a package includes inline type hints and should be used by type checkers. The test ensures this file is present and accessible when the package is installed, preventing accidental removal in future releases.

Addresses GitHub issue #119.

https://claude.ai/code/session_01Y49wvraJEdwUTeRFfMg4Ke