### PR TITLE
Set Ruff target Python version to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ include = ["jobserver*"]
 
 [tool.ruff]
 line-length = 79
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["B", "E", "F", "I", "UP", "W"]


### PR DESCRIPTION
This change updates the Ruff linter configuration to explicitly target Python 3.9 as the minimum supported version.

**Changes made:**
- Added `target-version = "py39"` to the `[tool.ruff]` configuration in `pyproject.toml`

**Details:**
Setting the target version helps Ruff apply version-specific linting rules and suggestions. This ensures that the codebase is checked for compatibility with Python 3.9 and later versions, allowing Ruff to flag any code patterns that may not be compatible with earlier Python versions.

https://claude.ai/code/session_013UueksPDR5pRaxtiHE1Tbm