### PR TITLE
Remove callbacks parameter from Jobserver.submit()

### DIFF
--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -342,7 +342,6 @@ def _dispatch_pending(
                 fn=item.fn,
                 args=item.args,
                 kwargs=dict(item.kwargs),
-                callbacks=True,
                 timeout=0,
             )
         except Blocked:

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -542,7 +542,6 @@ class Jobserver:
         *,
         args: Iterable = (),
         kwargs: Mapping[str, Any] = types.MappingProxyType({}),
-        callbacks: bool = True,
         consume: int = 1,
         env: Union[
             None,
@@ -558,7 +557,6 @@ class Jobserver:
         """Submit running fn(*args, **kwargs) to this Jobserver.
 
         Raises Blocked when insufficient resources available to accept work.
-        This method issues callbacks on completed work when callbacks is True.
         Timeout is given in seconds with None meaning block indefinitely.
 
         When consume == 0, no job slot is consumed by the submission.
@@ -582,8 +580,6 @@ class Jobserver:
             raise TypeError(f"args: Iterable, got {type(args).__name__}")
         if not isinstance(kwargs, Mapping):
             raise TypeError(f"kwargs: Mapping, got {type(kwargs).__name__}")
-        if not isinstance(callbacks, bool):
-            raise TypeError(f"callbacks: bool, got {type(callbacks).__name__}")
 
         # Resolve None to the instance-level default for each optional param
         env = self._env if env is None else env
@@ -594,11 +590,10 @@ class Jobserver:
         assert preexec_fn is not None
 
         # Next, either obtain requested tokens or else raise Blocked
-        # Work submission only reclaims tokens when callbacks are enabled
         tokens = _obtain_tokens(
             consume=consume,
             deadline=absolute_deadline(timeout),
-            reclaim_tokens_fn=self.reclaim_resources if callbacks else noop,
+            reclaim_tokens_fn=self.reclaim_resources,
             selector=self._selector,
             sleep_fn=sleep_fn,
             slots=self._slots,

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -13,8 +13,10 @@ normal operation, slot exhaustion, timeouts, and edge-case payloads.
 import contextlib
 import copy
 import itertools
+import os
 import pickle
 import sys
+import tempfile
 import time
 import typing
 import unittest
@@ -27,6 +29,7 @@ from jobserver import (
 )
 
 from .helpers import (
+    barrier_wait,
     helper_callback,
     helper_nonblocking,
     helper_recurse,
@@ -59,91 +62,109 @@ class TestJobserverBasic(unittest.TestCase):
                 # Prepare how callbacks will be observed
                 mutable = [0, 0, 0]
 
-                # Prepare work filling all slots
-                context = get_context(method)
-                with Jobserver(context=context, slots=3) as js:
-                    f = js.submit(
-                        fn=len,
-                        args=((1, 2, 3),),
-                        callbacks=False,
-                        consume=1,
-                        timeout=None,
-                    )
-                    f.when_done(helper_callback, mutable, 0, 1)
-                    g = js.submit(
-                        fn=str,
-                        kwargs=dict(object=2),
-                        callbacks=False,
-                        consume=1,
-                        timeout=None,
-                    )
-                    g.when_done(helper_callback, mutable, 1, 2)
-                    g.when_done(helper_callback, mutable, 1, 3)
-                    h = js.submit(
-                        fn=len,
-                        args=((1,),),
-                        callbacks=False,
-                        consume=1,
-                        timeout=None,
-                    )
-                    h.when_done(
-                        helper_callback, lizt=mutable, index=2, increment=7
-                    )
+                # Use a barrier file to hold worker slots open during
+                # Blocked tests; workers block until the file appears.
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    barrier_path = os.path.join(tmpdir, "go")
 
-                    # Try too much work given fixed slot count
-                    with self.assertRaises(Blocked):
-                        js.submit(
-                            fn=len,
-                            args=((),),
-                            callbacks=False,
+                    # Prepare work filling all slots
+                    context = get_context(method)
+                    with Jobserver(context=context, slots=3) as js:
+                        f = js.submit(
+                            fn=barrier_wait,
+                            args=(barrier_path,),
                             consume=1,
+                            timeout=None,
+                        )
+                        f.when_done(helper_callback, mutable, 0, 1)
+                        g = js.submit(
+                            fn=barrier_wait,
+                            args=(barrier_path,),
+                            consume=1,
+                            timeout=None,
+                        )
+                        g.when_done(helper_callback, mutable, 1, 2)
+                        g.when_done(helper_callback, mutable, 1, 3)
+                        h = js.submit(
+                            fn=barrier_wait,
+                            args=(barrier_path,),
+                            consume=1,
+                            timeout=None,
+                        )
+                        h.when_done(
+                            helper_callback, lizt=mutable, index=2, increment=7
+                        )
+
+                        # Try too much work given fixed slot count
+                        with self.assertRaises(Blocked):
+                            js.submit(
+                                fn=len,
+                                args=((),),
+                                consume=1,
+                                timeout=0,
+                            )
+
+                        # Confirm zero-consumption requests accepted
+                        # immediately
+                        i = js.submit(
+                            fn=len,
+                            args=((1, 2, 3, 4),),
+                            consume=0,
                             timeout=0,
                         )
 
-                    # Confirm zero-consumption requests accepted immediately
-                    i = js.submit(
-                        fn=len,
-                        args=((1, 2, 3, 4),),
-                        callbacks=False,
-                        consume=0,
-                        timeout=0,
-                    )
+                        # Again, try too much work given fixed slot count
+                        with self.assertRaises(Blocked):
+                            js.submit(
+                                fn=len,
+                                args=((),),
+                                consume=1,
+                                timeout=0,
+                            )
 
-                    # Again, try too much work given fixed slot count
-                    with self.assertRaises(Blocked):
-                        js.submit(
-                            fn=len,
-                            args=((),),
-                            callbacks=False,
-                            consume=1,
-                            timeout=0,
+                        # Release all workers by creating the barrier file
+                        open(barrier_path, "w").close()
+
+                        # Confirm results and callbacks
+                        self.assertEqual("released", g.result())
+                        self.assertEqual(
+                            mutable[1], 5, "Two callbacks observed"
                         )
-
-                    # Confirm results in something other than submission order
-                    self.assertEqual("2", g.result())
-                    self.assertEqual(mutable[1], 5, "Two callbacks observed")
-                    if check_done:
-                        self.assertTrue(f.wait())
-                    self.assertTrue(h.wait())  # No check_done guard!
-                    self.assertEqual(mutable[2], 7)
-                    self.assertEqual(1, h.result())
-                    self.assertEqual(1, h.result(), "Multiple calls OK")
-                    h.when_done(
-                        helper_callback, lizt=mutable, index=2, increment=11
-                    )
-                    self.assertEqual(
-                        mutable[2], 18, "Callback after completion"
-                    )
-                    self.assertEqual(1, h.result())
-                    self.assertTrue(h.wait())
-                    self.assertEqual(mutable[2], 18, "Callbacks idempotent")
-                    self.assertEqual(4, i.result(), "Zero-consumption request")
-                    if check_done:
-                        self.assertTrue(g.wait())
-                        self.assertTrue(g.wait(), "Multiple calls OK")
-                    self.assertEqual(3, f.result())
-                    self.assertEqual(mutable[0], 1, "One callback observed")
-                    self.assertEqual(4, i.result(), "Zero-consumption repeat")
+                        if check_done:
+                            self.assertTrue(f.wait())
+                        self.assertTrue(h.wait())  # No check_done guard!
+                        self.assertEqual(mutable[2], 7)
+                        self.assertEqual("released", h.result())
+                        self.assertEqual(
+                            "released", h.result(), "Multiple calls OK"
+                        )
+                        h.when_done(
+                            helper_callback,
+                            lizt=mutable,
+                            index=2,
+                            increment=11,
+                        )
+                        self.assertEqual(
+                            mutable[2], 18, "Callback after completion"
+                        )
+                        self.assertEqual("released", h.result())
+                        self.assertTrue(h.wait())
+                        self.assertEqual(
+                            mutable[2], 18, "Callbacks idempotent"
+                        )
+                        self.assertEqual(
+                            4, i.result(), "Zero-consumption request"
+                        )
+                        if check_done:
+                            self.assertTrue(g.wait())
+                            self.assertTrue(g.wait(), "Multiple calls OK")
+                        self.assertEqual("released", f.result())
+                        self.assertEqual(
+                            mutable[0], 1, "One callback observed"
+                        )
+                        self.assertEqual(
+                            4, i.result(), "Zero-consumption repeat"
+                        )
 
     # Explicitly tested because of handling woes observed in other designs
     def test_returns_none(self) -> None:
@@ -270,8 +291,8 @@ class TestJobserverBasic(unittest.TestCase):
                 with Jobserver(context=context, slots=slots) as js:
                     # Alternate between submissions with/without timeouts
                     kwargs: list[dict[str, typing.Any]] = [
-                        dict(callbacks=True, timeout=None),
-                        dict(callbacks=True, timeout=1000),
+                        dict(timeout=None),
+                        dict(timeout=1000),
                     ]
                     fs = [
                         js.submit(fn=len, args=("x" * i,), **(kwargs[i % 2]))

--- a/test/test_jobserver_concurrency.py
+++ b/test/test_jobserver_concurrency.py
@@ -32,7 +32,7 @@ class TestJobserverConcurrency(unittest.TestCase):
         Two threads calling wait() on the same Future concurrently must not
         cause an AttributeError or AssertionError.  This naturally happens
         when one thread calls reclaim_resources() while another is inside
-        submit() with callbacks=True.
+        submit().
         """
         with Jobserver(slots=4) as js:
             errors: list[Exception] = []


### PR DESCRIPTION
This PR removes the `callbacks` parameter from the `Jobserver.submit()` method, simplifying the API by making callback invocation the default and only behavior.

## Summary
The `callbacks` parameter was previously used to control whether completion callbacks would be invoked on submitted work. This change removes that parameter entirely, making callbacks always enabled. This simplifies the API surface and removes unnecessary complexity from the codebase.

## Key Changes
- Removed the `callbacks: bool = True` parameter from `Jobserver.submit()`
- Removed the `callbacks` parameter validation logic
- Removed the conditional logic that only reclaimed tokens when `callbacks=True`; tokens are now always reclaimed via `self.reclaim_resources`
- Updated all call sites to remove the `callbacks` argument:
  - Test files (`test_jobserver_basic.py`, `test_jobserver_concurrency.py`)
  - Internal executor code (`_executor.py`)
- Updated docstrings to remove references to the `callbacks` parameter
- Refactored test logic to use a barrier file mechanism (`barrier_wait` helper) instead of simple functions, allowing tests to properly control worker execution timing

## Implementation Details
- The `reclaim_tokens_fn` parameter in `_obtain_tokens()` is now always set to `self.reclaim_resources` instead of conditionally using a `noop` function
- Tests were enhanced with a temporary directory and barrier file pattern to properly synchronize worker threads during blocking tests, replacing the previous approach of using simple computation functions

https://claude.ai/code/session_01FaJLERndZhrPKUALcDSjAF