### PR TITLE
Add platform check for PR_SET_PDEATHSIG example

### DIFF
--- a/examples/ex8_pdeathsig.py
+++ b/examples/ex8_pdeathsig.py
@@ -13,7 +13,8 @@ import ctypes
 import ctypes.util
 import os
 import signal
-from logging import INFO, basicConfig, info
+import sys
+from logging import INFO, basicConfig, info, warning
 
 from jobserver import Jobserver
 
@@ -57,4 +58,7 @@ if __name__ == "__main__":
         level=INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
-    main()
+    if sys.platform == "linux":
+        main()
+    else:
+        warning("PR_SET_PDEATHSIG unavailable on %s; skipping", sys.platform)


### PR DESCRIPTION
This change adds a platform compatibility check to the `ex8_pdeathsig.py` example to handle systems where `PR_SET_PDEATHSIG` is not available.

**Summary of changes:**
- Added `sys` import to enable platform detection
- Added `warning` to logging imports for user-facing messages
- Wrapped the `main()` call with a platform check that only executes on Linux
- Added a warning message for non-Linux platforms explaining that `PR_SET_PDEATHSIG` is unavailable

**Implementation details:**
The example now gracefully handles execution on non-Linux systems by skipping the main functionality and logging an informative warning instead of failing. This improves the user experience when running the example on macOS, Windows, or other platforms where the `PR_SET_PDEATHSIG` prctl option is not supported.

https://claude.ai/code/session_015dZPZTqVCqZVqMbe3sFHbT