### PR TITLE
Add resource cleanup and warnings for unclosed Jobserver instances

### DIFF
--- a/examples/ex1_basic.py
+++ b/examples/ex1_basic.py
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Example 1 shows submitting jobs and collecting results."""
 
-from logging import INFO, basicConfig, info
+from logging import INFO, basicConfig, captureWarnings, info
 
 from jobserver import Jobserver
 
@@ -41,4 +41,5 @@ if __name__ == "__main__":
         level=INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+    captureWarnings(True)
     main()

--- a/examples/ex2_nested.py
+++ b/examples/ex2_nested.py
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Example 2 shows nested submissions sharing slot constraints."""
 
-from logging import INFO, basicConfig, info
+from logging import INFO, basicConfig, captureWarnings, info
 from multiprocessing import get_all_start_methods
 
 from jobserver import Blocked, Jobserver
@@ -59,4 +59,5 @@ if __name__ == "__main__":
         level=INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+    captureWarnings(True)
     main()

--- a/examples/ex3_death.py
+++ b/examples/ex3_death.py
@@ -6,7 +6,7 @@
 """Example 3 shows detecting when a worker process dies unexpectedly."""
 
 import signal
-from logging import INFO, basicConfig, info
+from logging import INFO, basicConfig, captureWarnings, info
 
 from jobserver import Jobserver, SubmissionDied
 
@@ -40,4 +40,5 @@ if __name__ == "__main__":
         level=INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+    captureWarnings(True)
     main()

--- a/examples/ex4_sleep_fn.py
+++ b/examples/ex4_sleep_fn.py
@@ -11,7 +11,7 @@ Availability of RAM is a more common use case but ill-suited for an example.
 
 import os
 import tempfile
-from logging import INFO, basicConfig, info
+from logging import INFO, basicConfig, captureWarnings, info
 from typing import Optional
 
 from jobserver import Blocked, Jobserver
@@ -55,4 +55,5 @@ if __name__ == "__main__":
         level=INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+    captureWarnings(True)
     main()

--- a/examples/ex5_callbacks.py
+++ b/examples/ex5_callbacks.py
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Example 5 shows callbacks, exception handling, and CallbackRaised."""
 
-from logging import INFO, basicConfig, info
+from logging import INFO, basicConfig, captureWarnings, info
 
 from jobserver import CallbackRaised, Jobserver
 
@@ -70,4 +70,5 @@ if __name__ == "__main__":
         level=INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+    captureWarnings(True)
     main()

--- a/examples/ex6_environment.py
+++ b/examples/ex6_environment.py
@@ -6,7 +6,7 @@
 """Example 6 shows environment variable injection for child processes."""
 
 import os
-from logging import INFO, basicConfig, info
+from logging import INFO, basicConfig, captureWarnings, info
 
 from jobserver import Jobserver
 
@@ -42,4 +42,5 @@ if __name__ == "__main__":
         level=INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+    captureWarnings(True)
     main()

--- a/examples/ex7_timeouts.py
+++ b/examples/ex7_timeouts.py
@@ -6,7 +6,7 @@
 """Example 7 shows non-blocking polling, finite deadlines, and Blocked."""
 
 import time
-from logging import INFO, basicConfig, info
+from logging import INFO, basicConfig, captureWarnings, info
 
 from jobserver import Blocked, Jobserver
 
@@ -53,4 +53,5 @@ if __name__ == "__main__":
         level=INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+    captureWarnings(True)
     main()

--- a/examples/ex8_pdeathsig.py
+++ b/examples/ex8_pdeathsig.py
@@ -14,7 +14,7 @@ import ctypes.util
 import os
 import signal
 import sys
-from logging import INFO, basicConfig, info, warning
+from logging import INFO, basicConfig, captureWarnings, info, warning
 
 from jobserver import Jobserver
 
@@ -58,6 +58,7 @@ if __name__ == "__main__":
         level=INFO,
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
+    captureWarnings(True)
     if sys.platform == "linux":
         main()
     else:

--- a/examples/ex9_executor.py
+++ b/examples/ex9_executor.py
@@ -8,7 +8,7 @@
 import os
 import time
 from concurrent.futures import CancelledError
-from logging import DEBUG, INFO, basicConfig, getLogger, info
+from logging import DEBUG, INFO, basicConfig, captureWarnings, getLogger, info
 
 from jobserver import Jobserver, JobserverExecutor
 
@@ -55,4 +55,5 @@ if __name__ == "__main__":
     # Configure logging, showing lifecycle messages, and announce startup
     process_start()
     getLogger("jobserver").setLevel(DEBUG)
+    captureWarnings(True)
     main()

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -448,7 +448,7 @@ class Jobserver:
         n = len(self._selector_map)
         if n > 0:
             warnings.warn(
-                f"unclosed {self!r} with {n} outstanding future(s)",
+                f"unclosed {self!r}",
                 ResourceWarning,
                 stacklevel=2,
                 source=self,

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -7,7 +7,6 @@
 
 import abc
 import concurrent.futures
-import warnings
 import functools
 import heapq
 import os
@@ -16,6 +15,7 @@ import signal
 import threading
 import time
 import types
+import warnings
 from collections import deque
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from itertools import islice

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -448,7 +448,7 @@ class Jobserver:
         n = len(self._selector_map)
         if n > 0:
             warnings.warn(
-                f"unclosed {self!r}",
+                f"Finalizing {self!r} with running Future(s)",
                 ResourceWarning,
                 stacklevel=2,
                 source=self,

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -445,6 +445,11 @@ class Jobserver:
         return f"Jobserver({method!r}, tracked={n})"
 
     def __del__(self) -> None:
+        """Emit ResourceWarning if any Futures are still running.
+
+        A Jobserver with no undone Futures is implicitly closed upon
+        finalization; one with running Futures emits a ResourceWarning.
+        """
         n = len(self._selector_map)
         if n > 0:
             warnings.warn(

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -7,6 +7,7 @@
 
 import abc
 import concurrent.futures
+import warnings
 import functools
 import heapq
 import os
@@ -442,6 +443,18 @@ class Jobserver:
         method = self._context.get_start_method()
         n = len(self._selector_map)
         return f"Jobserver({method!r}, tracked={n})"
+
+    def __del__(self) -> None:
+        n = len(self._selector_map)
+        if n > 0:
+            warnings.warn(
+                f"unclosed {self!r} with {n} outstanding future(s)",
+                ResourceWarning,
+                stacklevel=2,
+                source=self,
+            )
+        self._slots.close_put()
+        self._slots.close_get()
 
     def __enter__(self) -> "Jobserver":
         return self


### PR DESCRIPTION
## Summary
This PR adds a `__del__` destructor to the `Jobserver` class that ensures proper cleanup of resources and warns users when a Jobserver is finalized with running futures. Additionally, all example scripts are updated to capture warnings for better visibility during execution.

## Key Changes
- **Added `__del__` method to Jobserver class**: Implements resource cleanup by closing both put and get slots, and emits a `ResourceWarning` if the Jobserver is being finalized while still tracking running futures
- **Updated all example scripts**: Added `captureWarnings(True)` to enable visibility of warnings during example execution, helping users understand proper resource management patterns

## Implementation Details
- The destructor checks if there are any tracked futures (`_selector_map`) and warns with the Jobserver's repr and a clear message about running futures
- Uses Python's standard `warnings` module with `ResourceWarning` category to follow Python conventions for resource cleanup issues
- The `stacklevel=2` parameter ensures the warning points to the caller's code rather than the destructor itself
- All 9 example scripts are consistently updated to capture warnings, promoting best practices for resource management

https://claude.ai/code/session_01QJFjTagpvFrGjHH41QtgGT