### PR TITLE
Improve clarity of example descriptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Examples
 --------
 
  * [ex1_basic](examples/ex1_basic.py) — Submitting jobs and collecting results via shorthand, keyword args, and `submit()`.
- * [ex2_nested](examples/ex2_nested.py) — Nested submissions where child work shares slot constraints with its parent.
+ * [ex2_nested](examples/ex2_nested.py) — Nesting submissions so child work shares slot constraints with its parent.
  * [ex3_death](examples/ex3_death.py) — Detecting when a worker process is killed unexpectedly via `SubmissionDied`.
  * [ex4_sleep_fn](examples/ex4_sleep_fn.py) — Gating work acceptance on an external condition using `sleep_fn`.
  * [ex5_callbacks](examples/ex5_callbacks.py) — Registering `when_done` callbacks and draining errors via `CallbackRaised`.
  * [ex6_environment](examples/ex6_environment.py) — Setting and unsetting environment variables in child processes via `env=`.
- * [ex7_timeouts](examples/ex7_timeouts.py) — Non-blocking polling, finite deadlines, and `Blocked` from `result()` and `submit()`.
- * [ex8_pdeathsig](examples/ex8_pdeathsig.py) — In Linux, using `preexec_fn` to call `prctl(PR_SET_PDEATHSIG)` so a child dies when its parent does.
- * [ex9_executor](examples/ex9_executor.py) — `JobserverExecutor` as a context manager supporting `map()` and `c.f.Future` cancellation.
+ * [ex7_timeouts](examples/ex7_timeouts.py) — Using non-blocking polling, finite deadlines, and `Blocked` from `result()` and `submit()`.
+ * [ex8_pdeathsig](examples/ex8_pdeathsig.py) — On Linux, using `preexec_fn` to call `prctl(PR_SET_PDEATHSIG)` so a child dies when its parent does.
+ * [ex9_executor](examples/ex9_executor.py) — Using `JobserverExecutor` as a context manager supporting `map()` and `c.f.Future` cancellation.
 
 Testing
 -------

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Examples
  * [ex5_callbacks](examples/ex5_callbacks.py) — Registering `when_done` callbacks and draining errors via `CallbackRaised`.
  * [ex6_environment](examples/ex6_environment.py) — Setting and unsetting environment variables in child processes via `env=`.
  * [ex7_timeouts](examples/ex7_timeouts.py) — Non-blocking polling, finite deadlines, and `Blocked` from `result()` and `submit()`.
- * [ex8_pdeathsig](examples/ex8_pdeathsig.py) — Using `preexec_fn` to call `prctl(PR_SET_PDEATHSIG)` so a child dies when its parent does.
+ * [ex8_pdeathsig](examples/ex8_pdeathsig.py) — In Linux, using `preexec_fn` to call `prctl(PR_SET_PDEATHSIG)` so a child dies when its parent does.
  * [ex9_executor](examples/ex9_executor.py) — `JobserverExecutor` as a context manager supporting `map()` and `c.f.Future` cancellation.
 
 Testing


### PR DESCRIPTION
This PR improves the wording and clarity of the example descriptions in the README to better communicate what each example demonstrates.

**Changes made:**

- **ex2_nested**: Changed "Nested submissions where" to "Nesting submissions so" for more natural phrasing
- **ex7_timeouts**: Restructured to emphasize the techniques being demonstrated ("Using non-blocking polling..." instead of "Non-blocking polling...")
- **ex8_pdeathsig**: Added platform clarification ("On Linux,") and improved phrasing to "using `preexec_fn`" for consistency
- **ex9_executor**: Changed "as a context manager" to "Using `JobserverExecutor` as a context manager" for parallel structure with other examples

These changes make the descriptions more consistent in style and clearer about what techniques or features each example teaches.

https://claude.ai/code/session_012ANprZaFqzmiLu4YrXdT7V