### PR TITLE
Optimize selector management by pre-registering slots waitable

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -24,7 +24,7 @@ from itertools import islice
 from multiprocessing.connection import Connection, wait
 from multiprocessing.context import BaseContext
 from multiprocessing.process import BaseProcess
-from selectors import EVENT_READ, DefaultSelector
+from selectors import EVENT_READ, DefaultSelector, SelectorKey
 from typing import Any, Generic, NoReturn, Optional, TypeVar, Union
 
 from ._compat import ignore_sigpipe, sched_getaffinity0
@@ -375,6 +375,21 @@ def _unregister_sentinel(
         pass  # Already unregistered or selector closed
 
 
+def _initialize_selector(
+    slots: MinimalQueue,
+) -> tuple[DefaultSelector, Mapping[Any, SelectorKey]]:
+    """Create a selector with slots pre-registered."""
+    selector = DefaultSelector()
+    # The SimpleNamespace provides the done() that
+    # reclaim_resources() calls on all selector keys.
+    selector.register(
+        slots.waitable(),
+        EVENT_READ,
+        data=types.SimpleNamespace(done=noop),
+    )
+    return selector, selector.get_map()
+
+
 class Jobserver:
     """A Jobserver exposing a Future interface built atop multiprocessing."""
 
@@ -427,8 +442,7 @@ class Jobserver:
         # _selector_map is the live view from get_map(), captured once
         # so that post-close() access returns an empty view rather
         # than the None that get_map() itself returns after close().
-        self._selector = DefaultSelector()
-        self._selector_map = self._selector.get_map()
+        self._selector, self._selector_map = _initialize_selector(self._slots)
 
         # Instance-level defaults for submit(...)
         # Defensive copy: consume any one-shot iterable and guard against
@@ -439,10 +453,17 @@ class Jobserver:
         self._preexec_fn = preexec_fn
         self._sleep_fn = sleep_fn
 
+    def _tracked(self) -> int:
+        """Futures in the selector, excluding any slots entry."""
+        if self._selector_map:
+            # Omit ever-present self._slots.waitable()
+            return len(self._selector_map) - 1
+        return 0
+
     def __repr__(self) -> str:
         method = self._context.get_start_method()
-        n = len(self._selector_map)
-        return f"Jobserver({method!r}, tracked={n})"
+        tracked = self._tracked()
+        return f"Jobserver({method!r}, tracked={tracked})"
 
     def __del__(self) -> None:
         """Emit ResourceWarning if any Futures are still running.
@@ -450,10 +471,10 @@ class Jobserver:
         A Jobserver with no undone Futures is implicitly closed upon
         finalization; one with running Futures emits a ResourceWarning.
         """
-        n = len(self._selector_map)
-        if n > 0:
+        tracked = self._tracked()
+        if tracked > 0:
             warnings.warn(
-                f"Finalizing {self!r} with running Future(s)",
+                f"Finalizing {self!r} with {tracked} running Futures",
                 ResourceWarning,
                 stacklevel=2,
                 source=self,
@@ -514,8 +535,7 @@ class Jobserver:
             self._preexec_fn,
             self._sleep_fn,
         ) = state
-        self._selector = DefaultSelector()
-        self._selector_map = self._selector.get_map()
+        self._selector, self._selector_map = _initialize_selector(self._slots)
 
     # Use typing.Self once Python 3.11 is the minimum version
     def __copy__(self) -> "Jobserver":
@@ -558,7 +578,7 @@ class Jobserver:
         # a non-blocking poll returning only the k ready entries.
         # done() triggers callbacks mutating the selector.
         for key, _ in self._selector.select(timeout=0):
-            assert isinstance(key.data, Future), type(key.data)
+            assert hasattr(key.data, "done"), type(key.data)
             key.data.done()
 
     def submit(
@@ -861,16 +881,11 @@ def _obtain_tokens(
                 raise Blocked() from None
 
             # (6) ...then block until some interesting event.
-            # O(k) via the persistent selector: temporarily register
-            # the slots waitable (1 epoll_ctl ADD), block in one
-            # epoll_wait returning k ready fds, then unregister
-            # (1 epoll_ctl DEL).  No O(N) rebuild of the interest set.
-            waitable = slots.waitable()
-            selector.register(waitable, EVENT_READ)
-            try:
-                selector.select(timeout=deadline - monotonic)
-            finally:
-                selector.unregister(waitable)
+            # O(k) via the persistent selector:
+            # _initialize_selector() places slots.waitable() once
+            # so only one epoll_wait
+            # is needed here.  No rebuilding of the interest set.
+            selector.select(timeout=deadline - monotonic)
 
     assert len(retval) == consume, "Postcondition"
     return retval

--- a/test/test_jobserver_concurrency.py
+++ b/test/test_jobserver_concurrency.py
@@ -36,6 +36,7 @@ class TestJobserverConcurrency(unittest.TestCase):
         """
         with Jobserver(slots=4) as js:
             errors: list[Exception] = []
+            futures: list[Future] = []
 
             def call_done(future: Future, barrier: threading.Barrier) -> None:
                 barrier.wait()
@@ -47,6 +48,7 @@ class TestJobserverConcurrency(unittest.TestCase):
             # Repeat to increase chance of hitting the race window
             for _ in range(10):
                 f = js.submit(fn=time.sleep, args=(0.05,), timeout=5)
+                futures.append(f)
                 barrier = threading.Barrier(2)
                 t = threading.Thread(target=call_done, args=(f, barrier))
                 t.start()
@@ -55,8 +57,8 @@ class TestJobserverConcurrency(unittest.TestCase):
 
             # Drain futures left incomplete when the race caused an
             # exception
-            for key in list(js._selector_map.values()):
-                key.data.wait(timeout=10)
+            for f in futures:
+                f.wait(timeout=10)
             self.assertEqual(
                 errors, [], f"Concurrent wait() crashed: {errors}"
             )


### PR DESCRIPTION
## Summary
This PR optimizes the jobserver's selector management by pre-registering the slots waitable object once during initialization, rather than repeatedly registering and unregistering it during token acquisition. This reduces syscall overhead and simplifies the code.

## Key Changes

- **New `_initialize_selector()` function**: Extracts selector initialization logic into a dedicated function that creates a `DefaultSelector` and pre-registers the slots waitable with a no-op `done()` callback via `SimpleNamespace`.

- **Simplified `_obtain_tokens()` loop**: Removes the temporary register/unregister pattern in the blocking loop. The slots waitable is now always registered, eliminating repeated `epoll_ctl` ADD/DEL syscalls. The selector just calls `select()` directly.

- **Updated `__init__` and `__setstate__`**: Both now use `_initialize_selector()` to set up the selector and its map consistently.

- **New `_tracked()` helper method**: Calculates the number of tracked futures by excluding the ever-present slots entry from the selector map. This provides accurate tracking of actual futures being monitored.

- **Improved `__repr__` and `__del__`**: Now use `_tracked()` to report only actual futures, not the internal slots entry. The warning message in `__del__` is more informative.

- **Relaxed assertion in `reclaim_resources()`**: Changed from `isinstance(key.data, Future)` to `hasattr(key.data, "done")` to accommodate the slots entry which uses a `SimpleNamespace` with a `done()` method.

- **Test improvements**: Updated `test_concurrent_done_no_crash` to maintain a list of futures and properly wait on them, rather than accessing internal selector map details.

## Implementation Details

The optimization changes the selector lifecycle from:
- Create empty selector
- For each token acquisition: register slots, select, unregister slots

To:
- Create selector with slots pre-registered
- For each token acquisition: just select

This reduces the number of syscalls from O(k) per acquisition (where k is the number of ready futures) to O(1) for the slots registration, improving performance in high-concurrency scenarios.

https://claude.ai/code/session_01QAdA6bPtsan4eaKX5voizo