### PR TITLE
Clarify JobserverExecutor ownership and shutdown behavior

### DIFF
--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -41,6 +41,10 @@ class JobserverExecutor(concurrent.futures.Executor):
     manages slot acquisition and worker spawning via the Jobserver,
     while a thin receiver thread bridges results back to
     concurrent.futures.Future instances.
+
+    The executor does not own the jobserver passed to it.  shutdown()
+    releases only executor-internal resources (dispatcher process,
+    receiver thread, pipes).  The caller closes the Jobserver.
     """
 
     def __init__(self, jobserver: Jobserver) -> None:
@@ -161,7 +165,10 @@ class JobserverExecutor(concurrent.futures.Executor):
     def shutdown(
         self, wait: bool = True, *, cancel_futures: bool = False
     ) -> None:
-        """Shut down the executor, optionally cancelling pending futures."""
+        """Shut down the executor, optionally cancelling pending futures.
+
+        The Jobserver is not closed because the executor does not own it.
+        """
         with self._lock:
             already = self._shutdown
             self._shutdown = True


### PR DESCRIPTION
This PR improves documentation around the JobserverExecutor's relationship with the Jobserver instance passed to it.

**Summary**
Added clarifying docstring comments to explain that JobserverExecutor does not own the Jobserver instance and therefore does not close it during shutdown.

**Key changes**
- Updated the class docstring to explicitly state that the executor does not own the jobserver and that `shutdown()` only releases executor-internal resources (dispatcher process, receiver thread, pipes)
- Enhanced the `shutdown()` method docstring to clarify that the Jobserver is not closed because the executor does not own it

**Details**
These documentation changes make the ownership model explicit for users of the API, preventing potential resource leaks or double-close errors. The caller retains responsibility for closing the Jobserver instance.

https://claude.ai/code/session_01JjhUykqD8CqybbuZbDNuju