### PR TITLE
Update CI comments for mypy typehinting checks

### DIFF
--- a/ci
+++ b/ci
@@ -12,7 +12,7 @@ done
 # Then, linting (PEP8, imports, bugbear, pyupgrade)
 uvx ruff check
 
-# Then, Typehint linting requires a new-enough mypy
+# Then, typehint with a newer mypy
 uvx --from "mypy>1.18" mypy
 
 # Then, check for formatting issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ Issues = "https://github.com/RhysU/jobserver/issues"
 line-length = 79
 target-version = ["py39", "py310", "py311", "py312", "py313", "py314"]
 
+# NB: Typehinting tests are tedious relative to the benefits they provide.
 [tool.mypy]
 files = ["src", "examples"]  # test/ deliberately excluded
 


### PR DESCRIPTION
This PR updates the comments in the CI configuration to better reflect the current state of typehinting validation.

**Changes made:**
- Clarified the mypy version requirement comment from "requires a new-enough mypy" to "with a newer mypy"
- Added a note explaining that typehinting tests are tedious relative to their benefits

**Details:**
These are documentation-only changes to the CI script that improve clarity around the mypy typehinting validation step. The note provides context for future maintainers about the trade-offs of the current typehinting testing approach.

https://claude.ai/code/session_01TLNpSVY4gCW6u5UvhetLXJ