### PR TITLE
Improve error handling, robustness, and code quality

### DIFF
--- a/src/jobserver/_compat.py
+++ b/src/jobserver/_compat.py
@@ -24,7 +24,12 @@ def sched_getaffinity0() -> int:
     Falls back to os.cpu_count() when os.sched_getaffinity is
     not available (e.g. PyPy, macOS).
     """
+    # The sched_getaffinity syscall may exist on some container runtimes
+    # yet raise OSError when invoked, so fall back on failure.
     if hasattr(os, "sched_getaffinity"):
-        return len(os.sched_getaffinity(0))
+        try:
+            return len(os.sched_getaffinity(0))
+        except OSError:
+            pass
     # os.cpu_count() can return None
     return os.cpu_count() or 1

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -441,17 +441,20 @@ class Jobserver:
         The env, preexec_fn, and sleep_fn parameters set instance-level
         defaults for submit(...).  See submit() for preexec_fn semantics.
         """
-        # Obtain some multiprocessing Context and the slot-tracking queue
-        self._context = resolve_context(context)
-        self._slots: MinimalQueue[int] = MinimalQueue(self._context)
-
-        # Issue one token for each requested slot
+        # Validate arguments before allocating OS resources so that
+        # invalid inputs cannot leave pipes or semaphores behind.
         if slots is None:
             slots = sched_getaffinity0()
         if not isinstance(slots, int):
             raise TypeError(f"slots: int, got {type(slots).__name__}")
         if slots < 1:
             raise ValueError(f"slots must be >= 1, got {slots!r}")
+
+        # Obtain some multiprocessing Context and the slot-tracking queue
+        self._context = resolve_context(context)
+        self._slots: MinimalQueue[int] = MinimalQueue(self._context)
+
+        # Issue one token for each requested slot
         self._slots.put(*range(slots))
 
         # Tracks outstanding Futures via their process sentinels.

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -473,10 +473,14 @@ class Jobserver:
         self._sleep_fn = sleep_fn
 
     def _tracked(self) -> int:
-        """Futures in the selector, excluding any slots entry."""
-        if self._selector_map:
+        """Futures in the selector, excluding any slots entry.
+
+        Safe to call on a partially-constructed instance: returns 0 when
+        __init__ raised before _selector_map was assigned.
+        """
+        if sm := getattr(self, "_selector_map", None):
             # Omit ever-present self._slots.waitable()
-            return len(self._selector_map) - 1
+            return len(sm) - 1
         return 0
 
     def __repr__(self) -> str:
@@ -490,16 +494,21 @@ class Jobserver:
         A Jobserver with no undone Futures is implicitly closed upon
         finalization; one with running Futures emits a ResourceWarning.
         """
-        tracked = self._tracked()
-        if tracked > 0:
+        # _tracked() tolerates partial construction; hasattr guards
+        # the remaining resource accesses.
+        if (tracked := self._tracked()) > 0:
             warnings.warn(
                 f"Finalizing {self!r} with {tracked} running Futures",
                 ResourceWarning,
                 stacklevel=2,
                 source=self,
             )
-        self._slots.close_put()
-        self._slots.close_get()
+        if hasattr(self, "_slots"):
+            self._slots.close_put()
+            self._slots.close_get()
+        # Matches the cleanup in __exit__.
+        if hasattr(self, "_selector"):
+            self._selector.close()
 
     def __enter__(self) -> "Jobserver":
         return self

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -239,7 +239,13 @@ class Future(Generic[T]):
         with self._rlock:
             heapq.heappush(
                 self._callbacks,
-                (priority, self._callback_seqno, fn, args, kwargs or {}),
+                (
+                    priority,
+                    self._callback_seqno,
+                    fn,
+                    args,
+                    {} if kwargs is None else kwargs,
+                ),
             )
             self._callback_seqno += 1
             if self._connection is None:

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -98,7 +98,7 @@ class Wrapper(abc.ABC, Generic[T]):
     @abc.abstractmethod
     def unwrap(self) -> T:
         """Raise any wrapped Exception otherwise return some result."""
-        raise NotImplementedError()
+        ...
 
 
 # Down the road, ResultWrapper might be extended with "big object"

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -221,7 +221,7 @@ class Future(Generic[T]):
         Registered callback functions can accept a Future as an argument.
         May raise CallbackRaised from at most this new callback.
         """
-        return self._when_done(
+        self._when_done(
             fn=functools.partial(_callback_wrapper, fn),
             args=args,
             kwargs=kwargs,

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -204,12 +204,14 @@ class Future(Generic[T]):
     def __copy__(self) -> NoReturn:
         """Disallow copying as duplicates cannot sensibly share resources."""
         # In particular, which copy would call self._process.join()?
-        raise NotImplementedError("Futures cannot be copied.")
+        # TypeError matches Python convention for operations unsupported
+        # by a type, e.g. copy.copy(threading.Lock()).
+        raise TypeError("Futures cannot be copied.")
 
     def __reduce__(self) -> NoReturn:
         """Disallow pickling as duplicates cannot sensibly share resources."""
-        # In particular, because pickles create copies
-        raise NotImplementedError("Futures cannot be pickled.")
+        # In particular, because pickles create copies.
+        raise TypeError("Futures cannot be pickled.")
 
     def when_done(self, fn: Callable, *args: Any, **kwargs: Any) -> None:
         """

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -30,7 +30,7 @@ T = TypeVar("T")
 # Cannot use float('inf'), sys.float_info.max, sys.maxsize/1000, nor the
 # _PyTime_t max; all overflow somewhere in the call chain.
 # See https://stackoverflow.com/q/45704243
-_MAX_TIMEOUT_SECS = float((2**31 - 1) / 1000)  # INT_MAX ms ≈ 24.85 days
+_MAX_TIMEOUT_SECS = (2**31 - 1) / 1000  # INT_MAX ms ≈ 24.85 days
 
 
 def absolute_deadline(relative_timeout: Optional[float]) -> float:

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -61,6 +61,17 @@ def resolve_context(context: Union[None, str, BaseContext]) -> BaseContext:
     return context
 
 
+def _conn_repr(conn: Optional[Connection]) -> str:
+    """Describe a pipe end for MinimalQueue.__repr__, tolerating closed fds."""
+    if conn is None:
+        return "closed"
+    # fileno() raises ValueError/OSError on a closed fd.
+    try:
+        return f"open(fd={conn.fileno()})"
+    except (ValueError, OSError):
+        return "open(fd=closed)"
+
+
 class MinimalQueue(Generic[T]):
     """
     An unbounded SimpleQueue-variant with minimal functionality.
@@ -83,11 +94,10 @@ class MinimalQueue(Generic[T]):
         self._write_lock = context.Lock()
 
     def __repr__(self) -> str:
-        rd = self._reader
-        wr = self._writer
-        r = "closed" if rd is None else f"open(fd={rd.fileno()})"
-        w = "closed" if wr is None else f"open(fd={wr.fileno()})"
-        return f"MinimalQueue(reader={r}, writer={w})"
+        return (
+            f"MinimalQueue(reader={_conn_repr(self._reader)},"
+            f" writer={_conn_repr(self._writer)})"
+        )
 
     def __enter__(self) -> "MinimalQueue":
         return self

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -106,6 +106,16 @@ class MinimalQueue(Generic[T]):
         self.close_put()
         self.close_get()
 
+    def __del__(self) -> None:
+        """Close pipe ends in a defined order on finalization."""
+        # A partially-constructed instance whose __init__ raised before
+        # _reader/_writer were assigned surfaces as AttributeError here.
+        try:
+            self.close_put()
+            self.close_get()
+        except AttributeError:
+            pass
+
     def __copy__(self) -> "MinimalQueue":
         """Shallow copies return the original MinimalQueue unchanged."""
         # Because any "copy" should and can only mutate same pipe/locks

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -325,18 +325,18 @@ class TestJobserverBasic(unittest.TestCase):
                 with Jobserver(context=method, slots=3) as js:
                     f = js.submit(fn=len, args=((1, 2, 3),))
                     # Cannot copy a Future
-                    with self.assertRaises(NotImplementedError):
+                    with self.assertRaises(TypeError):
                         copy.copy(f)
-                    with self.assertRaises(NotImplementedError):
+                    with self.assertRaises(TypeError):
                         copy.deepcopy(f)
                     # Cannot pickle a Future
-                    with self.assertRaises(NotImplementedError):
+                    with self.assertRaises(TypeError):
                         pickle.dumps(f)
                     # Cannot submit a Future as part of additional work
                     # (as a consequence of the above when pickling
                     # required)
                     if method != "fork":
-                        with self.assertRaises(NotImplementedError):
+                        with self.assertRaises(TypeError):
                             js.submit(fn=type, args=(f,))
 
     # No behavioral assertions made around pickling, however.


### PR DESCRIPTION
This PR makes several improvements to error handling, resource management, and code quality across the jobserver codebase.

## Summary
The changes focus on three main areas: (1) using more appropriate exception types for unsupported operations, (2) improving robustness during partial object construction and finalization, and (3) minor code quality improvements.

## Key Changes

**Exception Type Improvements:**
- Changed `NotImplementedError` to `TypeError` in `Future.__copy__()` and `Future.__reduce__()` to match Python conventions for operations unsupported by a type (e.g., `copy.copy(threading.Lock())`)
- Changed abstract method stub in `Wrapper.unwrap()` from `raise NotImplementedError()` to `...` (ellipsis)

**Resource Management & Robustness:**
- Reordered `Jobserver.__init__()` to validate arguments before allocating OS resources (pipes, semaphores), preventing resource leaks on invalid input
- Enhanced `Jobserver._tracked()` to safely handle partial construction using `getattr()` with a default
- Improved `Jobserver.__del__()` to guard resource cleanup with `hasattr()` checks and added `_selector.close()` cleanup
- Added `MinimalQueue.__del__()` to ensure pipe ends are closed in a defined order during finalization, with graceful handling of partially-constructed instances
- Added `_conn_repr()` helper function to safely describe pipe ends in `MinimalQueue.__repr__()`, handling closed file descriptors

**Code Quality:**
- Removed unnecessary `return` statement in `Future.when_done()`
- Improved `Future._when_done()` formatting for better readability
- Refactored `MinimalQueue.__repr__()` to use the new `_conn_repr()` helper, reducing duplication
- Removed unnecessary `float()` cast in `_MAX_TIMEOUT_SECS` definition
- Enhanced `sched_getaffinity0()` to catch `OSError` exceptions from the syscall and fall back to `os.cpu_count()`, improving compatibility with container runtimes
- Improved docstring for `_tracked()` to document its tolerance for partial construction
- Updated test expectations to match new `TypeError` exceptions

## Notable Implementation Details
- The `_conn_repr()` function gracefully handles both `ValueError` and `OSError` when calling `fileno()` on closed connections
- The `sched_getaffinity0()` fallback now handles cases where the syscall exists but raises `OSError` in certain container environments
- Resource cleanup in `__del__` methods uses `hasattr()` checks to tolerate exceptions during partial construction

https://claude.ai/code/session_01GFrqM3JrM1nSKaAVMFK54q