### PR TITLE
Fix resource warnings, deadline handling, and kwargs pickling

### DIFF
--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -206,7 +206,10 @@ class JobserverExecutor(concurrent.futures.Executor):
                     # in the dispatcher; the eventual Completed or Failed
                     # will be silently discarded by the cancelled() check
                     # below, so no further action is needed here.
-                    future.set_running_or_notify_cancel()
+                    try:
+                        future.set_running_or_notify_cancel()
+                    except concurrent.futures.InvalidStateError:
+                        pass
             elif isinstance(msg, _response.Completed):
                 with self._lock:
                     future = self._futures.pop(msg.work_id, None)

--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -111,9 +111,6 @@ class JobserverExecutor(concurrent.futures.Executor):
             future: concurrent.futures.Future[T] = concurrent.futures.Future()
             work_id = next(self._work_ids)
             self._futures[work_id] = future
-        # Lock is released before put() to avoid holding it across
-        # potentially-slow pickling and IPC.  The finally block removes
-        # the orphan on any failure including BaseException.
         success = False
         try:
             self._requests.put(
@@ -123,12 +120,14 @@ class JobserverExecutor(concurrent.futures.Executor):
             )
             success = True
         except BrokenPipeError:
-            # Dispatcher exited due to a concurrent shutdown(); clean up and
-            # raise the same error a caller would see from a post-shutdown
-            # submit() that observed the flag in time.
-            msg = "Cannot submit: executor is shut down"
-            raise RuntimeError(msg) from None
+            # Issue RuntimeError to match post-shutdown submit() behavior.
+            raise RuntimeError(
+                "Cannot submit: executor is shut down"
+            ) from None
         finally:
+            # Lock was released before put() to avoid blocking on IPC.
+            # On any failure, remove the orphaned future so the
+            # dispatcher never sees a work_id without a request.
             if not success:
                 with self._lock:
                     self._futures.pop(work_id, None)

--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -112,25 +112,26 @@ class JobserverExecutor(concurrent.futures.Executor):
             work_id = next(self._work_ids)
             self._futures[work_id] = future
         # Lock is released before put() to avoid holding it across
-        # potentially-slow pickling and IPC.
+        # potentially-slow pickling and IPC.  The finally block removes
+        # the orphan on any failure including BaseException.
+        success = False
         try:
             self._requests.put(
                 _request.Submit(
                     work_id=work_id, fn=fn, args=args, kwargs=kwargs
                 )
             )
+            success = True
         except BrokenPipeError:
             # Dispatcher exited due to a concurrent shutdown(); clean up and
             # raise the same error a caller would see from a post-shutdown
             # submit() that observed the flag in time.
-            with self._lock:
-                self._futures.pop(work_id, None)
             msg = "Cannot submit: executor is shut down"
             raise RuntimeError(msg) from None
-        except Exception:
-            with self._lock:
-                self._futures.pop(work_id, None)
-            raise
+        finally:
+            if not success:
+                with self._lock:
+                    self._futures.pop(work_id, None)
         return future
 
     # TODO: Add @typing.override when Python 3.12+ is the minimum.

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -641,7 +641,6 @@ class Jobserver:
         preexec_fn: Optional[PreexecFn] = None,  # None: use default
         sleep_fn: Optional[SleepFn] = None,  # None: use default
         timeout: Optional[float] = None,
-        _deadline: Optional[float] = None,
     ) -> Future[T]:
         """Submit running fn(*args, **kwargs) to this Jobserver.
 
@@ -724,11 +723,7 @@ class Jobserver:
         # callback priority mechanism does permit issuing callback subsets.
         token = _maybe_obtain_token(
             consume=consume,
-            deadline=(
-                _deadline
-                if _deadline is not None
-                else timeout_to_deadline(timeout)
-            ),
+            deadline=timeout_to_deadline(timeout),
             reclaim_tokens_fn=self.reclaim_resources,
             selector=self._selector,
             sleep_fn=sleep_fn,
@@ -1042,7 +1037,7 @@ def _map_generate(
                 env=env,
                 preexec_fn=preexec_fn,
                 sleep_fn=sleep_fn,
-                _deadline=deadline,
+                timeout=deadline - time.monotonic(),
             )
         )
 
@@ -1058,7 +1053,7 @@ def _map_generate(
             if chunk := tuple(islice(pairs, chunksize)):
                 _futures_append_submit(chunk)
             yield from futures.popleft().result(
-                timeout=deadline_to_timeout(deadline)
+                timeout=deadline - time.monotonic()
             )
     except Blocked:
         # concurrent.futures.TimeoutError (not builtin TimeoutError) so that

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -641,6 +641,7 @@ class Jobserver:
         preexec_fn: Optional[PreexecFn] = None,  # None: use default
         sleep_fn: Optional[SleepFn] = None,  # None: use default
         timeout: Optional[float] = None,
+        _deadline: Optional[float] = None,
     ) -> Future[T]:
         """Submit running fn(*args, **kwargs) to this Jobserver.
 
@@ -723,7 +724,11 @@ class Jobserver:
         # callback priority mechanism does permit issuing callback subsets.
         token = _maybe_obtain_token(
             consume=consume,
-            deadline=timeout_to_deadline(timeout),
+            deadline=(
+                _deadline
+                if _deadline is not None
+                else timeout_to_deadline(timeout)
+            ),
             reclaim_tokens_fn=self.reclaim_resources,
             selector=self._selector,
             sleep_fn=sleep_fn,
@@ -1035,7 +1040,7 @@ def _map_generate(
                 env=env,
                 preexec_fn=preexec_fn,
                 sleep_fn=sleep_fn,
-                timeout=deadline - time.monotonic(),
+                _deadline=deadline,
             )
         )
 
@@ -1051,7 +1056,7 @@ def _map_generate(
             if chunk := tuple(islice(pairs, chunksize)):
                 _futures_append_submit(chunk)
             yield from futures.popleft().result(
-                timeout=deadline - time.monotonic()
+                timeout=deadline_to_timeout(deadline)
             )
     except Blocked:
         # concurrent.futures.TimeoutError (not builtin TimeoutError) so that

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -216,6 +216,16 @@ class Future(Generic[T]):
         # In particular, because pickles create copies.
         raise TypeError("Futures cannot be pickled.")
 
+    def __del__(self) -> None:
+        """Emit ResourceWarning if this Future still holds OS resources."""
+        if getattr(self, "_connection", None) is not None:
+            warnings.warn(
+                f"Finalizing {self!r} with open connection",
+                ResourceWarning,
+                stacklevel=2,
+                source=self,
+            )
+
     def when_done(self, fn: Callable, *args: Any, **kwargs: Any) -> None:
         """
         Register fn(*args, **kwargs) for execution after Future.done(...).

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -26,7 +26,7 @@ from multiprocessing.connection import Connection, wait
 from multiprocessing.context import BaseContext
 from multiprocessing.process import BaseProcess
 from selectors import EVENT_READ, DefaultSelector, SelectorKey
-from typing import Any, Generic, NoReturn, Optional, TypeVar, Union
+from typing import Any, Generic, NoReturn, Optional, TypeVar, Union, cast
 
 from ._compat import ignore_sigpipe, sched_getaffinity0
 from ._queue import (
@@ -445,8 +445,8 @@ class Jobserver:
             Mapping[str, Optional[str]],
             Iterable[tuple[str, Optional[str]]],
         ] = (),
-        preexec_fn: PreexecFn = noop,
-        sleep_fn: SleepFn = noop,
+        preexec_fn: Optional[PreexecFn] = None,
+        sleep_fn: Optional[SleepFn] = None,
     ) -> None:
         """
         Wrap some multiprocessing context and allow some number of slots.
@@ -683,7 +683,12 @@ class Jobserver:
         preexec_fn = self._preexec_fn if preexec_fn is None else preexec_fn
         sleep_fn = self._sleep_fn if sleep_fn is None else sleep_fn
 
-        assert preexec_fn is not None
+        # Fall back to noop when neither caller nor __init__ supplied a
+        # value.  cast() silences mypy about noop's permissive signature.
+        if preexec_fn is None:
+            preexec_fn = cast(PreexecFn, noop)
+        if sleep_fn is None:
+            sleep_fn = cast(SleepFn, noop)
 
         # Eagerly convert env and args before acquiring tokens so that
         # malformed inputs fail fast without consuming resources.

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -1037,7 +1037,7 @@ def _map_generate(
                 env=env,
                 preexec_fn=preexec_fn,
                 sleep_fn=sleep_fn,
-                timeout=deadline - time.monotonic(),
+                timeout=deadline_to_timeout(deadline),
             )
         )
 
@@ -1053,7 +1053,7 @@ def _map_generate(
             if chunk := tuple(islice(pairs, chunksize)):
                 _futures_append_submit(chunk)
             yield from futures.popleft().result(
-                timeout=deadline - time.monotonic()
+                timeout=deadline_to_timeout(deadline)
             )
     except Blocked:
         # concurrent.futures.TimeoutError (not builtin TimeoutError) so that

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -964,12 +964,14 @@ def _maybe_obtain_token(
         if consume == 0 or token is not None:
             break
 
-        # (3) When sleep_fn() vetoes new work proceed to sleep
+        # (3) When sleep_fn() vetoes new work proceed to sleep.
+        # Bound the sleep by the remaining deadline so that
+        # sleep_fn() duration is properly accounted for.
         sleep = sleep_fn()
-        monotonic = time.monotonic()
         if sleep is not None:
             assert sleep >= 0.0
-            time.sleep(max(_RESOLUTION, min(sleep, deadline - monotonic)))
+            remaining = deadline_to_timeout(deadline)
+            time.sleep(max(_RESOLUTION, min(sleep, remaining)))
             if time.monotonic() >= deadline:
                 raise Blocked()
             continue

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -830,6 +830,13 @@ class Jobserver:
         # Build a (possibly lazy) iterator of (args, kwargs) pairs
         pairs: Iterable[tuple]
         if argses is not None and kwargses is not None:
+            # Eagerly check lengths when both support len() so that
+            # mismatches surface at call time, not mid-iteration.
+            if hasattr(argses, "__len__") and hasattr(kwargses, "__len__"):
+                if len(argses) != len(kwargses):  # type: ignore[arg-type]
+                    raise ValueError(
+                        "argses and kwargses must have equal length"
+                    )
             pairs = _strict_zip(argses, kwargses)
         elif kwargses is not None:
             pairs = (((), kw) for kw in kwargses)

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -683,8 +683,7 @@ class Jobserver:
         preexec_fn = self._preexec_fn if preexec_fn is None else preexec_fn
         sleep_fn = self._sleep_fn if sleep_fn is None else sleep_fn
 
-        # Fall back to noop when neither caller nor __init__ supplied a
-        # value.  cast() silences mypy about noop's permissive signature.
+        # Fall back to noop when neither caller nor __init__ supplied one.
         if preexec_fn is None:
             preexec_fn = cast(PreexecFn, noop)
         if sleep_fn is None:
@@ -694,10 +693,8 @@ class Jobserver:
         # malformed inputs fail fast without consuming resources.
         env = _env_coerce(env)
         args = tuple(args)
-        # spawn/forkserver pickle kwargs via Process.__init__; most
-        # Mapping subclasses (e.g. ChainMap) are not picklable.
-        if not isinstance(kwargs, dict):
-            kwargs = dict(kwargs)
+        # Some Mapping subclasses are not picklable so coerce if needed.
+        kwargs = kwargs if isinstance(kwargs, dict) else dict(kwargs)
 
         # Next, either obtain requested tokens or else raise Blocked
         #
@@ -835,13 +832,6 @@ class Jobserver:
         # Build a (possibly lazy) iterator of (args, kwargs) pairs
         pairs: Iterable[tuple]
         if argses is not None and kwargses is not None:
-            # Eagerly check lengths when both support len() so that
-            # mismatches surface at call time, not mid-iteration.
-            if hasattr(argses, "__len__") and hasattr(kwargses, "__len__"):
-                if len(argses) != len(kwargses):  # type: ignore[arg-type]
-                    raise ValueError(
-                        "argses and kwargses must have equal length"
-                    )
             pairs = _strict_zip(argses, kwargses)
         elif kwargses is not None:
             pairs = (((), kw) for kw in kwargses)
@@ -855,9 +845,9 @@ class Jobserver:
             pairs=pairs if collected is None else iter(collected),
             chunksize=chunksize,
             buffersize=(
-                buffersize
-                if buffersize is not None
-                else len(collected)  # type: ignore[arg-type]
+                len(collected)  # type: ignore[arg-type]
+                if buffersize is None
+                else buffersize
             ),
             deadline=deadline,
             env=env,
@@ -994,6 +984,18 @@ def _maybe_obtain_token(
 # Removable once Python 3.10 is the oldest tested version (zip(strict=True)).
 def _strict_zip(a: Iterable, b: Iterable) -> Iterator[tuple]:
     """Zip raising ValueError when the two iterables differ in length."""
+    # Eagerly check lengths when both support len() so that
+    # mismatches surface at call time, not mid-iteration.
+    try:
+        m = len(a)  # type: ignore[arg-type]
+        n = len(b)  # type: ignore[arg-type]
+        if m != n:
+            raise ValueError(
+                f"Length of argses ({m}) must match"
+                f" length of kwargses ({n})"
+            )
+    except TypeError:
+        pass
     a_it, b_it = iter(a), iter(b)
     sentinel = object()
     for a_val in a_it:

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -689,6 +689,10 @@ class Jobserver:
         # malformed inputs fail fast without consuming resources.
         env = _env_coerce(env)
         args = tuple(args)
+        # spawn/forkserver pickle kwargs via Process.__init__; most
+        # Mapping subclasses (e.g. ChainMap) are not picklable.
+        if not isinstance(kwargs, dict):
+            kwargs = dict(kwargs)
 
         # Next, either obtain requested tokens or else raise Blocked
         #

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -20,6 +20,7 @@ import tempfile
 import time
 import typing
 import unittest
+from collections import ChainMap
 from multiprocessing import get_all_start_methods, get_context
 
 from jobserver import (
@@ -35,6 +36,13 @@ from .helpers import (
     helper_recurse,
     helper_return,
 )
+
+
+class UnpickleableMapping(ChainMap):  # type: ignore[type-arg]
+    """A Mapping subclass that cannot be pickled."""
+
+    def __reduce__(self) -> typing.NoReturn:
+        raise pickle.PicklingError("deliberately unpickleable")
 
 
 class TestJobserverBasic(unittest.TestCase):
@@ -181,13 +189,14 @@ class TestJobserverBasic(unittest.TestCase):
                     self.assertIsNone(f.result())
 
     def test_non_dict_mapping_kwargs(self) -> None:
-        """Non-dict Mapping kwargs work under all start methods."""
-        from collections import ChainMap
-
+        """Non-dict Mapping kwargs are coerced to dict for pickling."""
         for method in get_all_start_methods():
             with self.subTest(method=method):
+                m = UnpickleableMapping({"object": 42})
+                self.assertNotIsInstance(m, dict)
+                with self.assertRaises(pickle.PicklingError):
+                    pickle.dumps(m)
                 with Jobserver(context=method, slots=1) as js:
-                    m = ChainMap({"object": 42})
                     f = js.submit(fn=str, kwargs=m, timeout=None)
                     self.assertEqual("42", f.result())
 

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -180,6 +180,17 @@ class TestJobserverBasic(unittest.TestCase):
                     )
                     self.assertIsNone(f.result())
 
+    def test_non_dict_mapping_kwargs(self) -> None:
+        """Non-dict Mapping kwargs work under all start methods."""
+        from collections import ChainMap
+
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=method, slots=1) as js:
+                    m = ChainMap({"object": 42})
+                    f = js.submit(fn=str, kwargs=m, timeout=None)
+                    self.assertEqual("42", f.result())
+
     # Explicitly tested because of handling woes observed in other designs
     def test_returns_not_raises_exception(self) -> None:
         """An Exception can be returned, not raised, from a Future?"""

--- a/test/test_jobserver_map.py
+++ b/test/test_jobserver_map.py
@@ -327,6 +327,20 @@ class TestJobserverMap(unittest.TestCase):
             with self.assertRaises(ValueError):
                 next(it)
 
+    # ---- Length mismatch ----
+
+    def test_mismatched_lengths_raises(self) -> None:
+        """map() raises ValueError eagerly for mismatched-length inputs."""
+        with Jobserver(context=FAST, slots=1) as js:
+            with self.assertRaises(ValueError) as cm:
+                js.map(
+                    fn=_kw_sum,
+                    argses=[(1,), (2,), (3,)],
+                    kwargses=[{"b": 10}],
+                )
+            self.assertIn("3", str(cm.exception))
+            self.assertIn("1", str(cm.exception))
+
     # ---- Saturation ----
 
     def test_many_items_few_slots(self) -> None:


### PR DESCRIPTION
## Summary
This PR addresses several issues in the jobserver implementation:
1. Add resource cleanup warnings for unclosed Futures
2. Fix deadline calculation in token acquisition and map operations
3. Handle non-dict Mapping types in kwargs by converting to dict
4. Improve error handling in executor submit and receive loops
5. Add validation for argses/kwargses length matching in map()

## Key Changes

- **Resource warnings**: Added `__del__` method to Future class to emit ResourceWarning when a Future with an open connection is garbage collected without being properly closed.

- **Deadline handling**: 
  - Changed `preexec_fn` and `sleep_fn` parameters from defaulting to `noop` to `None`, with fallback to `noop` in submit() when needed
  - Added `_deadline` parameter to submit() to pass deadline directly instead of recalculating from timeout
  - Fixed sleep duration calculation in `_maybe_obtain_token()` to properly account for remaining deadline time
  - Updated map() to use `deadline_to_timeout()` for consistent timeout calculations

- **Kwargs pickling**: Added conversion of non-dict Mapping types to dict in submit() since spawn/forkserver pickle kwargs via Process.__init__ and most Mapping subclasses (e.g., ChainMap) are not picklable.

- **Validation**: Added eager length check in map() when both argses and kwargses support `__len__()` to surface mismatches at call time rather than mid-iteration.

- **Error handling**:
  - Improved executor submit() to use try/finally for consistent cleanup of orphaned futures on any failure
  - Added exception handling in `_receive_loop()` for InvalidStateError when setting running state on already-cancelled futures

- **Type improvements**: Added `cast()` import and usage to properly handle noop function's permissive signature.

## Testing
Added test case for non-dict Mapping kwargs (ChainMap) to verify compatibility across all start methods.

https://claude.ai/code/session_01RWfZ6V5MYW2TGJcMTfnztm