### PR TITLE
Trim low-value comments, dead pass, and tautological repr asserts

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -57,8 +57,6 @@ SleepFn = Callable[[], Optional[float]]
 class Blocked(Exception):
     """Reports that Jobserver.submit(...) or Future.result(...) is blocked."""
 
-    pass
-
 
 class CallbackRaised(Exception):
     """
@@ -76,8 +74,6 @@ class CallbackRaised(Exception):
     processing to perform after seeing the 1st, 2nd, or Nth error.
     """
 
-    pass
-
 
 class SubmissionDied(Exception):
     """
@@ -86,8 +82,6 @@ class SubmissionDied(Exception):
     Work that is killed, terminated, interrupted, etc. raises this exception.
     Exactly what has transpired is not reported.  Do not attempt to recover.
     """
-
-    pass
 
 
 class Wrapper(abc.ABC, Generic[T]):
@@ -184,7 +178,6 @@ class Future(Generic[T]):
         assert connection is not None  # Becomes None after Connection.close()
         self._connection: Optional[Connection] = connection
 
-        # Becomes non-None after result is obtained
         self._wrapper: Optional[Wrapper[T]] = None
 
         # Populated by calls to when_done(...).  A heapq ordered by
@@ -413,8 +406,6 @@ def _initialize_selector(
 ) -> tuple[DefaultSelector, Mapping[Any, SelectorKey]]:
     """Create a selector with slots pre-registered."""
     selector = DefaultSelector()
-    # The SimpleNamespace provides the done() that
-    # reclaim_resources() calls on all selector keys.
     selector.register(
         slots.waitable(),
         EVENT_READ,

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -103,7 +103,6 @@ class MinimalQueue(Generic[T]):
     def __getstate__(
         self,
     ) -> tuple[Optional[Connection], Optional[Connection]]:
-        # Locks are omitted; each process creates its own after unpickling.
         return (self._reader, self._writer)
 
     def __setstate__(

--- a/test/test_executor_basic.py
+++ b/test/test_executor_basic.py
@@ -39,11 +39,6 @@ def setUpModule() -> None:
     silence_forkserver()
 
 
-# ================================================================
-# Submit and Result
-# ================================================================
-
-
 class TestSubmitAndResult(unittest.TestCase):
     """Submit and Result."""
 
@@ -83,11 +78,6 @@ class TestSubmitAndResult(unittest.TestCase):
                 f = exe.submit(len, (1,))
                 self.assertIsInstance(f, concurrent.futures.Future)
                 f.result(timeout=TIMEOUT)
-
-
-# ================================================================
-# Exception Propagation
-# ================================================================
 
 
 class TestExceptionPropagation(unittest.TestCase):
@@ -181,11 +171,6 @@ class TestExceptionPropagation(unittest.TestCase):
                 self.assertEqual(b"x" * 10, result[:10])
 
 
-# ================================================================
-# Future State Queries
-# ================================================================
-
-
 class TestFutureStateQueries(unittest.TestCase):
     """Future State Queries."""
 
@@ -239,11 +224,6 @@ class TestFutureStateQueries(unittest.TestCase):
                 self.assertTrue(f.done())
                 self.assertFalse(f.running())
                 self.assertFalse(f.cancelled())
-
-
-# ================================================================
-# Callbacks
-# ================================================================
 
 
 class TestCallbacks(unittest.TestCase):
@@ -402,11 +382,6 @@ class TestCallbacks(unittest.TestCase):
                 event.wait(timeout=TIMEOUT)
             for f in futures:
                 self.assertIs(f, mapping[id(f)])
-
-
-# ================================================================
-# map()
-# ================================================================
 
 
 class TestMap(unittest.TestCase):

--- a/test/test_executor_concurrency.py
+++ b/test/test_executor_concurrency.py
@@ -41,11 +41,6 @@ def setUpModule() -> None:
     silence_forkserver()
 
 
-# ================================================================
-# Concurrency Stress
-# ================================================================
-
-
 class TestConcurrencyStress(unittest.TestCase):
     """Concurrency Stress."""
 
@@ -122,11 +117,6 @@ class TestConcurrencyStress(unittest.TestCase):
                     self._threaded_submit_stress(exe)
         finally:
             sys.setswitchinterval(old)
-
-
-# ================================================================
-# wait() and as_completed() Integration
-# ================================================================
 
 
 class TestWaitAndAsCompleted(unittest.TestCase):
@@ -233,11 +223,6 @@ class TestWaitAndAsCompleted(unittest.TestCase):
                 # Just verify no crash
 
 
-# ================================================================
-# Multiprocessing Start Method Coverage
-# ================================================================
-
-
 class TestStartMethods(unittest.TestCase):
     """Start method coverage."""
 
@@ -287,11 +272,6 @@ class TestStartMethods(unittest.TestCase):
                     f = exe.submit(len, (1,))
                     exe.shutdown(wait=True)
                     self.assertTrue(f.done())
-
-
-# ================================================================
-# Edge Cases (CPython Bug Reports)
-# ================================================================
 
 
 class TestEdgeCases(unittest.TestCase):
@@ -351,11 +331,6 @@ class TestEdgeCases(unittest.TestCase):
             elapsed = time.monotonic() - t0
             # Should return promptly, not block for ages
             self.assertLess(elapsed, 10)
-
-
-# ================================================================
-# Internal Invariants
-# ================================================================
 
 
 class TestInternalInvariants(unittest.TestCase):

--- a/test/test_executor_lifecycle.py
+++ b/test/test_executor_lifecycle.py
@@ -43,11 +43,6 @@ def setUpModule() -> None:
     silence_forkserver()
 
 
-# ================================================================
-# Cancellation
-# ================================================================
-
-
 class TestCancellation(unittest.TestCase):
     """Cancellation."""
 
@@ -115,11 +110,6 @@ class TestCancellation(unittest.TestCase):
                 exe.shutdown(wait=True)
 
 
-# ================================================================
-# Selective Cancellation (_handle_request)
-# ================================================================
-
-
 class TestSelectiveCancel(unittest.TestCase):
     """Selective cancel via _request.Cancel(work_id=...)."""
 
@@ -155,11 +145,6 @@ class TestSelectiveCancel(unittest.TestCase):
                 responses.get(timeout=1).work_id,
             }
             self.assertEqual({1, 2}, ids)
-
-
-# ================================================================
-# Shutdown Semantics
-# ================================================================
 
 
 class TestShutdown(unittest.TestCase):
@@ -306,11 +291,6 @@ class TestShutdown(unittest.TestCase):
             exe.shutdown(wait=True)
 
 
-# ================================================================
-# Resource Leak Detection
-# ================================================================
-
-
 class TestResourceLeaks(unittest.TestCase):
     """Resource Leak Detection."""
 
@@ -445,11 +425,6 @@ class TestResourceLeaks(unittest.TestCase):
             time.sleep(0.2)
             # shutdown() must not raise despite BrokenPipeError
             exe.shutdown(wait=True)
-
-
-# ================================================================
-# Owned Jobserver
-# ================================================================
 
 
 class TestOwnedJobserver(unittest.TestCase):

--- a/test/test_jobserver_map.py
+++ b/test/test_jobserver_map.py
@@ -48,8 +48,6 @@ class TestJobserverMap(unittest.TestCase):
     def setUpClass(cls):
         silence_forkserver()
 
-    # ---- Empty / no-op inputs ----
-
     def test_empty_inputs(self) -> None:
         """map() with empty or None inputs yields nothing."""
         with Jobserver(context=FAST, slots=2) as js:
@@ -69,8 +67,6 @@ class TestJobserverMap(unittest.TestCase):
                         )
                     )
                     self.assertEqual(results, [])
-
-    # ---- Basic functionality ----
 
     def test_argses_only(self) -> None:
         """map() with argses only works like builtin map."""
@@ -153,8 +149,6 @@ class TestJobserverMap(unittest.TestCase):
             self.assertTrue(hasattr(result, "__next__"))
             self.assertEqual(next(result), 1)
 
-    # ---- Chunksize ----
-
     def test_chunksize(self) -> None:
         """Various chunksize values produce correct ordered results."""
         with Jobserver(context=FAST, slots=2) as js:
@@ -195,8 +189,6 @@ class TestJobserverMap(unittest.TestCase):
                     with self.assertRaises(ValueError):
                         js.map(fn=len, argses=[], chunksize=cs)
 
-    # ---- Buffersize ----
-
     def test_buffersize(self) -> None:
         """Various buffersize values produce correct ordered results."""
         with Jobserver(context=FAST, slots=4) as js:
@@ -236,8 +228,6 @@ class TestJobserverMap(unittest.TestCase):
                     with self.assertRaises(ValueError):
                         js.map(fn=len, argses=[], buffersize=bs)
 
-    # ---- Timeout semantics ----
-
     def test_timeout_sufficient(self) -> None:
         """timeout=None and generous timeout both work."""
         with Jobserver(context=FAST, slots=2) as js:
@@ -276,8 +266,6 @@ class TestJobserverMap(unittest.TestCase):
             it = js.map(fn=_slow_identity, argses=argses, timeout=0.5)
             with self.assertRaises(concurrent.futures.TimeoutError):
                 list(it)
-
-    # ---- Error propagation ----
 
     def test_exception_propagates(self) -> None:
         """Exception raised by fn surfaces from __next__, all start methods."""
@@ -327,8 +315,6 @@ class TestJobserverMap(unittest.TestCase):
             with self.assertRaises(ValueError):
                 next(it)
 
-    # ---- Argument validation ----
-
     def test_non_iterable_argses_element_raises(self) -> None:
         """map() raises TypeError for non-iterable argses elements."""
         with Jobserver(context=FAST, slots=2) as js:
@@ -349,8 +335,6 @@ class TestJobserverMap(unittest.TestCase):
                 )
             self.assertIn("kwargses[1]", str(cm.exception))
 
-    # ---- Length mismatch ----
-
     def test_mismatched_lengths_raises(self) -> None:
         """map() raises ValueError eagerly for mismatched-length inputs."""
         with Jobserver(context=FAST, slots=1) as js:
@@ -362,8 +346,6 @@ class TestJobserverMap(unittest.TestCase):
                 )
             self.assertIn("3", str(cm.exception))
             self.assertIn("1", str(cm.exception))
-
-    # ---- Saturation ----
 
     def test_many_items_few_slots(self) -> None:
         """Many work items with few slots completes without deadlock."""

--- a/test/test_str_repr.py
+++ b/test/test_str_repr.py
@@ -25,7 +25,7 @@ class TestFutureRepr(unittest.TestCase):
             r = repr(f)
             self.assertIn("running", r)
             self.assertIn("pid=", r)
-            self.assertEqual(str(f), repr(f))
+
             f.result()
 
     def test_done_future(self) -> None:
@@ -35,7 +35,6 @@ class TestFutureRepr(unittest.TestCase):
             r = repr(f)
             self.assertIn("done", r)
             self.assertIn("pid=None", r)
-            self.assertEqual(str(f), repr(f))
 
 
 class TestJobserverRepr(unittest.TestCase):
@@ -46,7 +45,6 @@ class TestJobserverRepr(unittest.TestCase):
             r = repr(js)
             self.assertTrue(r.startswith("Jobserver('"))
             self.assertIn("tracked=0", r)
-            self.assertEqual(str(js), repr(js))
 
     def test_with_tracked(self) -> None:
         with Jobserver(slots=2) as js:
@@ -66,7 +64,7 @@ class TestJobserverExecutorRepr(unittest.TestCase):
             self.assertIn("pending=", r)
             self.assertIn("jobserver=", r)
             self.assertIn("Jobserver(", r)
-            self.assertEqual(str(ex), repr(ex))
+
             ex.shutdown(wait=True)
 
     def test_shutdown(self) -> None:
@@ -76,7 +74,6 @@ class TestJobserverExecutorRepr(unittest.TestCase):
             r = repr(ex)
             self.assertIn("shutdown", r)
             self.assertIn("jobserver=", r)
-            self.assertEqual(str(ex), repr(ex))
 
 
 class TestMinimalQueueRepr(unittest.TestCase):
@@ -88,18 +85,15 @@ class TestMinimalQueueRepr(unittest.TestCase):
             self.assertIn("reader=open", r)
             self.assertIn("writer=open", r)
             self.assertIn("fd=", r)
-            self.assertEqual(str(mq), repr(mq))
 
     def test_closed_reader(self) -> None:
         with MinimalQueue() as mq:
             mq.close_get()
             self.assertIn("reader=closed", repr(mq))
             self.assertIn("writer=open", repr(mq))
-            self.assertEqual(str(mq), repr(mq))
 
     def test_closed_writer(self) -> None:
         with MinimalQueue() as mq:
             mq.close_put()
             self.assertIn("reader=open", repr(mq))
             self.assertIn("writer=closed", repr(mq))
-            self.assertEqual(str(mq), repr(mq))


### PR DESCRIPTION
## Summary

Pure-cleanup pass with no behavior changes. Net **−109 lines** across 7 files (no files added or removed).

## Changes

**`src/jobserver/_jobserver.py`**
- Drop the redundant `pass` body from `Blocked`, `CallbackRaised`, and `SubmissionDied`. Each already has a docstring, which is a sufficient class body.
- Drop two comments that just restated the adjacent code (one near `Future._wrapper`, one near `_initialize_selector`).

**`src/jobserver/_queue.py`**
- Drop one comment in `MinimalQueue.__getstate__` that restated the adjacent code.

**`test/test_executor_basic.py`, `test/test_executor_concurrency.py`, `test/test_executor_lifecycle.py`, `test/test_jobserver_map.py`**
- Drop the decorative `# === ... ===` and `# ---- ... ----` section banners. Each banner sat directly above a class whose docstring already named the section.

**`test/test_str_repr.py`**
- Drop eight `self.assertEqual(str(x), repr(x))` assertions. They exercise Python's default `object.__str__` fallback (which calls `__repr__`) rather than anything in this codebase, so they assert a CPython invariant rather than a project invariant.

## Test plan

- [x] `UV_PYTHON=3.11 ./ci` — `Ran 187 tests` → `OK` → `All checks passed!`
- [x] `UV_PYTHON=3.12 ./ci` — `Ran 187 tests` → `OK` → `All checks passed!`
- [x] `UV_PYTHON=3.13 ./ci` — `Ran 187 tests` → `OK` → `All checks passed!`
- [x] `UV_PYTHON=3.14 ./ci` — `Ran 187 tests` → `OK` → `All checks passed!`

https://claude.ai/code/session_01XXSGnRwkda94jNwaLKBTgM