### PR TITLE
Add clarifying comment about lock protection for queue reads

### DIFF
--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -182,6 +182,8 @@ class MinimalQueue(Generic[T]):
         try:
             if not self._reader.poll(deadline_to_timeout(deadline)):
                 raise queue.Empty
+            # Reading under the lock preserves frame integrity if multiple
+            # readers ever shared a large-object queue; harmless single-reader
             recv = self._reader.recv_bytes()
         finally:
             self._read_lock.release()


### PR DESCRIPTION
## Summary
Added a clarifying comment to document why the `recv_bytes()` call is performed while holding the read lock in the queue's `get()` method.

## Key Changes
- Added inline comment explaining that reading under the lock preserves frame integrity in case multiple readers ever share a large-object queue, and noting that this is harmless for the current single-reader use case

## Implementation Details
The comment is placed immediately before the `recv_bytes()` call to clarify the locking strategy. This is a documentation-only change that helps future maintainers understand the design decision to hold the lock during the receive operation, even though the current implementation only has a single reader.

https://claude.ai/code/session_01AUQNay1HxEcaFJufaPPN12