### PR TITLE
Simplify selector state management by removing cached map

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -477,8 +477,6 @@ class Jobserver:
     def _tracked(self) -> int:
         """Futures in the selector, excluding any slots entry.
 
-        Calls get_map() on demand rather than caching its result so as
-        not to depend on undocumented behavior of the returned view.
         Tolerates partial construction (returns 0 when __init__ raised
         before _selector was assigned) and a closed selector (get_map()
         returns None once close() has run).

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -25,7 +25,7 @@ from itertools import islice
 from multiprocessing.connection import Connection, wait
 from multiprocessing.context import BaseContext
 from multiprocessing.process import BaseProcess
-from selectors import EVENT_READ, DefaultSelector, SelectorKey
+from selectors import EVENT_READ, DefaultSelector
 from typing import Any, Generic, NoReturn, Optional, TypeVar, Union, cast
 
 from ._compat import ignore_sigpipe, sched_getaffinity0
@@ -401,9 +401,7 @@ def _unregister_sentinel(
         pass  # Already unregistered or selector closed
 
 
-def _initialize_selector(
-    slots: MinimalQueue,
-) -> tuple[DefaultSelector, Mapping[Any, SelectorKey]]:
+def _initialize_selector(slots: MinimalQueue) -> DefaultSelector:
     """Create a selector with slots pre-registered."""
     selector = DefaultSelector()
     selector.register(
@@ -411,7 +409,7 @@ def _initialize_selector(
         EVENT_READ,
         data=types.SimpleNamespace(done=noop),
     )
-    return selector, selector.get_map()
+    return selector
 
 
 class Jobserver:
@@ -421,7 +419,6 @@ class Jobserver:
         "_context",
         "_slots",
         "_selector",
-        "_selector_map",
         "_env",
         "_preexec_fn",
         "_sleep_fn",
@@ -466,10 +463,7 @@ class Jobserver:
         self._slots.put(*range(slots))
 
         # Tracks outstanding Futures via their process sentinels.
-        # _selector_map is the live view from get_map(), captured once
-        # so that post-close() access returns an empty view rather
-        # than the None that get_map() itself returns after close().
-        self._selector, self._selector_map = _initialize_selector(self._slots)
+        self._selector = _initialize_selector(self._slots)
 
         # Instance-level defaults for submit(...)
         # Defensive copy: consume any one-shot iterable and guard against
@@ -483,13 +477,18 @@ class Jobserver:
     def _tracked(self) -> int:
         """Futures in the selector, excluding any slots entry.
 
-        Safe to call on a partially-constructed instance: returns 0 when
-        __init__ raised before _selector_map was assigned.
+        Calls get_map() on demand rather than caching its result so as
+        not to depend on undocumented behavior of the returned view.
+        Tolerates partial construction (returns 0 when __init__ raised
+        before _selector was assigned) and a closed selector (get_map()
+        returns None once close() has run).
         """
-        if sm := getattr(self, "_selector_map", None):
-            # Omit ever-present self._slots.waitable()
-            return len(sm) - 1
-        return 0
+        selector = getattr(self, "_selector", None)
+        if selector is None:
+            return 0
+        sm = selector.get_map()  # None once the selector is closed
+        # Omit ever-present self._slots.waitable()
+        return len(sm) - 1 if sm else 0
 
     def __repr__(self) -> str:
         method = self._context.get_start_method()
@@ -545,7 +544,6 @@ class Jobserver:
         self._slots.close_put()
         self._slots.close_get()
         # Release the selector's underlying fd and all registrations.
-        # _selector_map survives close() as an empty live view.
         self._selector.close()
 
     def __getstate__(self) -> tuple:
@@ -571,7 +569,7 @@ class Jobserver:
             self._preexec_fn,
             self._sleep_fn,
         ) = state
-        self._selector, self._selector_map = _initialize_selector(self._slots)
+        self._selector = _initialize_selector(self._slots)
 
     # Use typing.Self once Python 3.11 is the minimum version
     def __copy__(self) -> "Jobserver":

--- a/test/test_resource_warning.py
+++ b/test/test_resource_warning.py
@@ -42,7 +42,7 @@ class TestResourceWarning(unittest.TestCase):
     def test_warning_emitted_with_running_future(self) -> None:
         """__del__ warns when outstanding Futures remain."""
         js = Jobserver(context=FAST, slots=1)
-        # One submit is enough: _selector_map retains the entry until
+        # One submit is enough: the selector retains the entry until
         # reclaim_resources() or __exit__, so the subprocess finishing
         # before del/gc does not create a race.
         _f = js.submit(fn=helper_return, args=(42,))


### PR DESCRIPTION
## Summary
This change simplifies the selector state management in the Jobserver class by removing the cached `_selector_map` attribute and instead calling `selector.get_map()` directly when needed.

## Key Changes
- Removed `SelectorKey` import from selectors module (no longer needed)
- Modified `_initialize_selector()` to return only the `DefaultSelector` instead of a tuple containing both the selector and its map
- Removed the `_selector_map` instance attribute from the Jobserver class
- Updated `_tracked()` method to call `selector.get_map()` directly, with proper handling for:
  - Partially constructed instances (when `_selector` hasn't been assigned yet)
  - Closed selectors (when `get_map()` returns `None`)
- Updated both `__init__()` and `__setstate__()` to work with the simplified return value
- Updated test comment to reflect the new implementation

## Implementation Details
The key insight is that `selector.get_map()` already handles the closed selector case by returning `None`, so there's no need to cache the map separately. The `_tracked()` method now:
1. Checks if `_selector` exists (handles partial construction)
2. Calls `get_map()` to get the current map state
3. Returns 0 if the map is `None` (selector is closed) or calculates the count minus 1 for the slots entry

This reduces complexity and eliminates the need to maintain a separate cached reference.

https://claude.ai/code/session_01JvTrBFbKwWSQkYFXfezvFi