### PR TITLE
Clarify docstring for __exit__ callback draining behavior

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -547,7 +547,7 @@ class Jobserver:
         return self
 
     def __exit__(self, *exc: Any) -> None:
-        """Clean up slots and drain all callbacks.
+        """Clean up slots and drain ready callbacks.
 
         Never raises CallbackRaised.  Calls reclaim_resources()
         repeatedly until every ready callback has been attempted.


### PR DESCRIPTION
## Summary
Updated the docstring for the `Jobserver.__exit__` method to more accurately describe its callback handling behavior.

## Changes
- Modified the `__exit__` method docstring to clarify that it drains "ready callbacks" rather than "all callbacks"
- This change better reflects the actual implementation, which only processes callbacks that are ready, not necessarily all queued callbacks

## Details
The docstring now more precisely documents the method's behavior. The implementation calls `reclaim_resources()` repeatedly until every *ready* callback has been attempted, not all callbacks in general. This clarification helps users understand the exact semantics of resource cleanup during context manager exit.

https://claude.ai/code/session_016T5JACubcLWVSubWmB9BYm