### PR TITLE
Document pickling semantics in Jobserver.__getstate__

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -573,7 +573,10 @@ class Jobserver:
         self._selector.close()
 
     def __getstate__(self) -> tuple:
-        """Get instance state without exposing in-flight Futures."""
+        """Get instance state without exposing in-flight Futures.
+
+        Only capture configuration and slots to allow nesting.
+        """
         # Required because Futures can be neither copied nor pickled
         # Without custom handling of Futures, submit(...) would fail
         # whenever an instance is part of an argument to a sub-Process


### PR DESCRIPTION
Adds a one-line note to the `Jobserver.__getstate__` docstring clarifying that only configuration and the shared slots queue are captured — in-flight Futures are intentionally dropped — because this is what enables nested submission.

This follows the audit on #209, which concluded that dropping in-flight Futures is working-as-intended (not a bug) and should be downgraded to a doc note. Notably, the originally-suggested `__reduce__`-raises fix was explicitly rejected since it would break nested submission.

Closes #209

https://claude.ai/code/session_011WfzpNWLSLZucnV2K34Z6Z

---
_Generated by [Claude Code](https://claude.ai/code/session_011WfzpNWLSLZucnV2K34Z6Z)_