### PR TITLE
Fix busy-spin in obtain-token loop on a contested sentinel (#250)

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -986,6 +986,9 @@ def _maybe_obtain_token(
         raise ValueError(f"consume must be 0 or 1, got {consume!r}")
     # Acquire the requested token or raise Blocked when impossible
     token: Optional[int] = None
+    # Ready fds the previous pass could not reclaim
+    # If they recur, back off to avoid busy spinning
+    stall_fds: set[int] = set()
     while True:
         # (1) Eagerly clean up any completed work to avoid deadlocks
         reclaim_tokens_fn()
@@ -1020,7 +1023,22 @@ def _maybe_obtain_token(
             # _initialize_selector() places slots.waitable() once
             # so only one epoll_wait
             # is needed here.  No rebuilding of the interest set.
-            selector.select(timeout=deadline - monotonic)
+            keys_events = selector.select(timeout=deadline - monotonic)
+
+            # (7) A sentinel wakeup normally means a child exited and the next
+            # reclaim_tokens_fn() pass will restore its slot, so loop at once.
+            # But if that Future's lock is held elsewhere, reclaim cannot
+            # complete it and its sentinel stays ready, so re-select()ing would
+            # peg a CPU.  Back off only when a sentinel-only wakeup repeats
+            # fds the prior pass failed to reclaim, bounded by the deadline.
+            waitable = slots.waitable()
+            ready_fds = {
+                key.fd for key, _ in keys_events if key.fileobj is not waitable
+            }
+            only_sentinels = len(ready_fds) == len(keys_events)
+            if ready_fds and only_sentinels and ready_fds.issubset(stall_fds):
+                time.sleep(min(_RESOLUTION, deadline_to_timeout(deadline)))
+            stall_fds = ready_fds if only_sentinels else set()
 
     assert token is None or consume == 1, "Postcondition"
     return token

--- a/test/test_jobserver_concurrency.py
+++ b/test/test_jobserver_concurrency.py
@@ -21,7 +21,7 @@ from jobserver import (
     Jobserver,
 )
 
-from .helpers import helper_raise
+from .helpers import helper_noop, helper_raise
 
 
 class TestJobserverConcurrency(unittest.TestCase):
@@ -272,7 +272,7 @@ class TestJobserverConcurrency(unittest.TestCase):
         with Jobserver(slots=1) as js:
             # Finish a Future and let its child exit so the sentinel is
             # readable, but do not reclaim it: the lone slot stays consumed.
-            f = js.submit(fn=lambda: 42, timeout=5)
+            f = js.submit(fn=helper_noop, timeout=5)
             deadline = time.monotonic() + 5
             while f._process is not None and f._process.is_alive():
                 if time.monotonic() >= deadline:
@@ -310,7 +310,7 @@ class TestJobserverConcurrency(unittest.TestCase):
             window = 0.5
             start = time.monotonic()
             with self.assertRaises(Blocked):
-                js.submit(fn=lambda: 7, timeout=window)
+                js.submit(fn=helper_noop, timeout=window)
             elapsed = time.monotonic() - start
 
             release.set()
@@ -348,9 +348,9 @@ class TestJobserverConcurrency(unittest.TestCase):
                 # Serial submissions through a single slot: each waits for
                 # the prior child to exit, then reclaims and reuses the
                 # freed slot -- this must happen without a backoff sleep.
-                last: Future = js.submit(fn=lambda: 0, timeout=10)
+                last: Future = js.submit(fn=helper_noop, timeout=10)
                 for _ in range(19):
-                    last = js.submit(fn=lambda: 0, timeout=10)
+                    last = js.submit(fn=helper_noop, timeout=10)
                 last.result(timeout=10)
             finally:
                 time.sleep = real_sleep  # type: ignore[assignment]

--- a/test/test_jobserver_concurrency.py
+++ b/test/test_jobserver_concurrency.py
@@ -15,6 +15,7 @@ import time
 import unittest
 
 from jobserver import (
+    Blocked,
     CallbackRaised,
     Future,
     Jobserver,
@@ -258,3 +259,100 @@ class TestJobserverConcurrency(unittest.TestCase):
             # Now the future can complete normally
             f.wait(timeout=10)
             self.assertIsNone(f.result())
+
+    def test_submit_no_spin_on_contested_sentinel(self) -> None:
+        """submit() must not busy-spin on a ready-but-unclaimable sentinel.
+
+        With every slot consumed by a finished-but-unreclaimed Future whose
+        lock is held elsewhere, the obtain-token loop wakes immediately on
+        the ever-ready sentinel.  It must back off rather than re-select()
+        on the same fd, which would peg a CPU until the lock releases.  We
+        bound the number of select() calls made while blocked for ~timeout.
+        """
+        with Jobserver(slots=1) as js:
+            # Finish a Future and let its child exit so the sentinel is
+            # readable, but do not reclaim it: the lone slot stays consumed.
+            f = js.submit(fn=lambda: 42, timeout=5)
+            deadline = time.monotonic() + 5
+            while f._process is not None and f._process.is_alive():
+                if time.monotonic() >= deadline:
+                    self.fail("child did not exit")
+                time.sleep(0.01)
+
+            # Count select() calls the obtain-token loop performs.
+            selector = js._selector
+            original_select = selector.select
+            calls = 0
+
+            def counting_select(timeout=None):
+                nonlocal calls
+                calls += 1
+                return original_select(timeout)
+
+            selector.select = counting_select  # type: ignore[assignment]
+
+            # Hold the finished Future's lock so reclaim's done(timeout=0)
+            # cannot complete it nor unregister its still-ready sentinel.
+            acquired = threading.Event()
+            release = threading.Event()
+
+            def hold_lock() -> None:
+                with f._rlock:
+                    acquired.set()
+                    release.wait(timeout=10)
+
+            t = threading.Thread(target=hold_lock)
+            t.start()
+            acquired.wait(timeout=5)
+
+            # No slot can be obtained while the lock is held, so this blocks
+            # for the full timeout and then raises Blocked.
+            window = 0.5
+            start = time.monotonic()
+            with self.assertRaises(Blocked):
+                js.submit(fn=lambda: 7, timeout=window)
+            elapsed = time.monotonic() - start
+
+            release.set()
+            t.join(timeout=5)
+            selector.select = original_select  # type: ignore[assignment]
+
+            # A tight spin produced tens of thousands of calls; with a
+            # ~_RESOLUTION (0.01s) backoff the loop wakes only ~elapsed/0.01
+            # times.  Allow generous slack but stay far below a spin.
+            self.assertGreaterEqual(elapsed, window)
+            self.assertLess(calls, 1000)
+
+    def test_submit_no_backoff_without_contention(self) -> None:
+        """submit() must not back off when reclamation is unobstructed.
+
+        Sentinels live in the blocking wait precisely so the loop wakes to
+        reclaim a completed child and reuse its slot promptly.  With no
+        contended lock every reclaim succeeds on the first pass, so the
+        obtain-token loop must never fall into its busy-spin backoff sleep.
+        Doing so would add latency to every slot turnover and defeat the
+        selector -- the regression this guards against.
+        """
+        real_sleep = time.sleep
+        sleeps = 0
+
+        def counting_sleep(seconds: float) -> None:
+            nonlocal sleeps
+            sleeps += 1
+            real_sleep(seconds)
+
+        with Jobserver(slots=1) as js:
+            # Patch the shared time module that _maybe_obtain_token uses.
+            time.sleep = counting_sleep  # type: ignore[assignment]
+            try:
+                # Serial submissions through a single slot: each waits for
+                # the prior child to exit, then reclaims and reuses the
+                # freed slot -- this must happen without a backoff sleep.
+                last: Future = js.submit(fn=lambda: 0, timeout=10)
+                for _ in range(19):
+                    last = js.submit(fn=lambda: 0, timeout=10)
+                last.result(timeout=10)
+            finally:
+                time.sleep = real_sleep  # type: ignore[assignment]
+
+        self.assertEqual(sleeps, 0)


### PR DESCRIPTION
## Summary

Fixes #250. Under slot contention, `submit()` could peg a CPU at ~170k `select()` calls/sec until an unrelated lock released. This bounds that spin without slowing the normal path.

## The bug

When a finished Future's child has exited, its sentinel is readable and stays registered in the selector until `reclaim` completes the Future. If **another thread holds that Future's lock** (e.g. a concurrent `result(timeout=None)`), `reclaim`'s `done(timeout=0)` cannot complete it — so the sentinel stays ready. With every slot consumed, `_maybe_obtain_token`'s `select()` then returns that ever-ready sentinel **immediately on every iteration**, spinning until the lock releases.

```python
js = jobserver.Jobserver(slots=1)
f = js.submit(lambda: 42)            # finishes; child exits, sentinel ready
threading.Thread(target=lambda: f._rlock.acquire()).start()  # lock held elsewhere
js.submit(lambda: 7, timeout=0.5)    # spins: ~87,000 select() calls in 0.5s
```

## Why the obvious fixes don't work

- **Block on `slots.waitable()` only?** No. A freed token re-enters the queue *only* when `reclaim` completes a Future, and in the common single-threaded case the obtain-token loop is the **only** caller of `reclaim`. It must keep waking on sentinels to drive its own reclamation; a `slots.waitable()`-only wait never wakes to reclaim its own completed children.
- **Sleep on every sentinel-only wakeup?** No. A sentinel wakeup is the *normal* "child exited, reclaim its slot now" signal — at that instant the token isn't restored yet, so `slots.waitable()` is legitimately absent. Sleeping there delays the very reclaim that frees the slot (measured: serial submit **3.7 → 10.5 ms/job**).

## The fix

Distinguish *progress* from a *stall*. Track the ready fds a `reclaim` pass left unclaimed (`stall_fds`); back off by `_RESOLUTION` **only** when a sentinel-only wakeup repeats fds the previous pass already failed to reclaim:

```python
ready_fds = {key.fd for key, _ in keys_events if key.fileobj is not waitable}
only_sentinels = len(ready_fds) == len(keys_events)
if ready_fds and only_sentinels and ready_fds.issubset(stall_fds):
    time.sleep(min(_RESOLUTION, deadline_to_timeout(deadline)))
stall_fds = ready_fds if only_sentinels else set()
```

A genuine child exit still costs just **one extra non-sleeping pass** before its slot is restored — so prompt reclamation is preserved — while a truly stuck sentinel falls into the bounded backoff instead of spinning. The deadline contract is unchanged.

## Results

| Scenario | Before | After |
|---|---|---|
| Contested sentinel (0.5s window) | ~87,000 `select()` calls | ~99 |
| Uncontended serial submit | 3.7 ms/job | 3.7 ms/job |

## Tests

Two regression tests in `test/test_jobserver_concurrency.py`:
- `test_submit_no_spin_on_contested_sentinel` — caps `select()` calls under a contested sentinel (fails at ~88k without the fix).
- `test_submit_no_backoff_without_contention` — asserts **zero** backoff sleeps during uncontended serial submission (fails at 19 with the naive "sleep on every sentinel wakeup" approach).

Full `./ci` passes: 192 tests, mypy/ruff/black clean, sdist builds.

https://claude.ai/code/session_01K9b34ZJDz8oeUAS8q4hypg

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9b34ZJDz8oeUAS8q4hypg)_