### PR TITLE
Document pickling requirements for Jobserver spawn/forkserver

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -437,7 +437,12 @@ def _initialize_selector(slots: MinimalQueue) -> DefaultSelector:
 
 
 class Jobserver:
-    """A Jobserver exposing a Future interface built atop multiprocessing."""
+    """A Jobserver exposing a Future interface built atop multiprocessing.
+
+    Under spawn/forkserver, everything sent to a child is pickled: fn,
+    args/kwargs, env values, preexec_fn, and sleep_fn.  Lambdas and local
+    closures are unpicklable and so work only under fork.
+    """
 
     __slots__ = (
         "_context",


### PR DESCRIPTION
## Summary
Added documentation to the `Jobserver` class docstring clarifying pickling requirements and limitations when using spawn or forkserver start methods.

## Changes
- Expanded the `Jobserver` class docstring to document that under spawn/forkserver start methods, all objects sent to child processes (functions, arguments, keyword arguments, environment values, preexec functions, and sleep functions) must be picklable
- Added a note that lambdas and local closures are unpicklable and therefore only work under the fork start method

## Details
This documentation change helps users understand why certain code patterns may fail when using different multiprocessing start methods, particularly when attempting to use unpicklable objects like lambdas or closures with spawn or forkserver modes.

https://claude.ai/code/session_016FUBzPXNAwXyvjUSZMMUid