### PR TITLE
Document Jobserver thread-safety contract (#212)

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -439,6 +439,9 @@ def _initialize_selector(slots: MinimalQueue) -> DefaultSelector:
 class Jobserver:
     """A Jobserver exposing a Future interface built atop multiprocessing.
 
+    Concurrent submit() / reclaim_resources() calls on a Jobserver are not
+    thread-safe.  In contrast, returned Futures are thread-safe.
+
     Under spawn/forkserver, everything sent to a child is pickled: fn,
     args/kwargs, env values, preexec_fn, and sleep_fn.  Lambdas and local
     closures are unpicklable and so work only under fork.


### PR DESCRIPTION
## Thread-safety contract (#212)

Document in the `Jobserver` class docstring that concurrent `submit()` / `reclaim_resources()` calls are **not** thread-safe (both mutate the shared selector unsynchronized — by design, for a single-threaded driver), while the returned `Future` **is** thread-safe. Documents the contract rather than taxing the hot path with a lock.

Closes #212

https://claude.ai/code/session_01Ff8t2eqJkLaMYxkwEMHm73