### PR TITLE
Document orphaned worker risk in Jobserver docstring

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -442,6 +442,10 @@ class Jobserver:
     Concurrent submit() / reclaim_resources() calls on a Jobserver are not
     thread-safe.  In contrast, returned Futures are thread-safe.
 
+    Workers are non-daemon so they can spawn children; consequently a hard
+    parent crash orphans running workers rather than terminating them.
+    OS features, like PR_SET_PDEATHSIG on Linux, can force termination.
+
     Under spawn/forkserver, everything sent to a child is pickled: fn,
     args/kwargs, env values, preexec_fn, and sleep_fn.  Lambdas and local
     closures are unpicklable and so work only under fork.


### PR DESCRIPTION
Documents that `Jobserver` workers are non-daemon (so they can spawn children) and that a hard parent crash therefore orphans running workers rather than terminating them. Added as a 2-line note in the `Jobserver` docstring, just above the spawn/forkserver content.

Closes #233

https://claude.ai/code/session_01UJ6MkPCN4CSPdDFpqPnuB9

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJ6MkPCN4CSPdDFpqPnuB9)_