### PR TITLE
Preserve child traceback across Future.result() (#206)

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -10,10 +10,12 @@ import concurrent.futures
 import functools
 import heapq
 import os
+import pickle
 import queue
 import signal
 import threading
 import time
+import traceback
 import types
 import warnings
 from collections import deque
@@ -94,6 +96,11 @@ class Wrapper(abc.ABC, Generic[T]):
         """Raise any wrapped Exception otherwise return some result."""
         ...
 
+    @abc.abstractmethod
+    def describe(self) -> str:
+        """Short label naming what is wrapped, for diagnostics."""
+        ...
+
 
 # Down the road, ResultWrapper might be extended with "big object"
 # support that chooses to place data in shared memory or on disk
@@ -110,19 +117,76 @@ class ResultWrapper(Wrapper[T]):
     def unwrap(self) -> T:
         return self._result
 
+    def describe(self) -> str:
+        return f"Result of type {type(self._result).__name__}"
+
+
+# TODO: revisit once Python 3.11 is the minimum version (Exception.add_note).
+# TODO: align _executor.py's _responses_put_failed pickle-fallback so both
+# paths catch the same exception tuple and share traceback re-attach logic.
+class RemoteTraceback(Exception):
+    """Carries a child process's formatted traceback string."""
+
+    def __init__(self, traceback: str) -> None:
+        self._traceback = traceback
+
+    def __str__(self) -> str:
+        return self._traceback
+
 
 class ExceptionWrapper(Wrapper[Any]):
-    """Specialization of Wrapper for when an Exception has been raised."""
+    """Specialization of Wrapper for when an Exception has been raised.
 
-    __slots__ = ("_raised",)
+    Captures the raised exception's traceback as a string at construction
+    so that the child stack survives pickle (which drops __traceback__).
+    On unpickling, the captured string is re-attached as a RemoteTraceback
+    via __cause__ so the parent sees the originating frames on unwrap().
+    Any pre-existing __cause__ chain renders inside that string but is
+    collapsed into the single RemoteTraceback programmatically.
+    """
 
-    def __init__(self, raised: Exception) -> None:
-        """Wrap the provided Exception for use during unwrap()."""
+    __slots__ = ("_raised", "_raised_tb")
+
+    _raised: Exception
+    _raised_tb: str
+
+    def __init__(
+        self,
+        raised: Exception,
+        cause: Optional["Wrapper"] = None,
+    ) -> None:
+        """Wrap raised; inherit cause's captured tb when cause is an
+        ExceptionWrapper, else format from raised.__traceback__."""
         assert isinstance(raised, Exception), type(raised)
         self._raised = raised
+        if isinstance(cause, ExceptionWrapper):
+            self._raised_tb = cause._raised_tb
+        elif raised.__traceback__ is None:
+            self._raised_tb = ""
+        else:
+            self._raised_tb = "".join(
+                traceback.format_exception(
+                    type(raised),
+                    raised,
+                    raised.__traceback__,
+                )
+            )
+
+    def __getstate__(self) -> tuple:
+        return (self._raised, self._raised_tb)
+
+    def __setstate__(self, state: tuple) -> None:
+        # Pickle dropped __traceback__ in transit; re-attach the captured
+        # string via __cause__ so the child's stack renders in the parent.
+        self._raised, self._raised_tb = state
+        if self._raised_tb:
+            self._raised.__cause__ = RemoteTraceback(self._raised_tb)
 
     def unwrap(self) -> NoReturn:
         raise self._raised
+
+    def describe(self) -> str:
+        return f"Exception of type {type(self._raised).__name__}"
 
 
 # Callback priorities for the Future heapq-based callback queue.
@@ -946,7 +1010,17 @@ def _worker_entrypoint(send, env, preexec_fn, fn, *args, **kwargs) -> None:
             # None means a BaseException (not Exception) escaped fn; let
             # the pipe close so the parent sees EOFError -> SubmissionDied.
             if result is not None:
-                send.send(result)  # ValueError => object too large
+                try:
+                    send.send(result)  # ValueError => object too large
+                except (pickle.PicklingError, AttributeError, TypeError) as pe:
+                    send.send(
+                        ExceptionWrapper(
+                            RuntimeError(
+                                f"{result.describe()} not picklable: {pe!r}"
+                            ),
+                            cause=result,
+                        )
+                    )
         except BrokenPipeError:
             pass
         try:

--- a/test/test_jobserver_traceback.py
+++ b/test/test_jobserver_traceback.py
@@ -1,0 +1,274 @@
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Child-process traceback propagation across Jobserver Future.result().
+
+Pickle does not carry __traceback__ across the pipe, so the parent's
+result() must surface the child's traceback some other way (see #206).
+"""
+
+import pickle
+import traceback
+import typing
+import unittest
+from multiprocessing import get_all_start_methods, get_context
+
+from jobserver import Jobserver, SubmissionDied
+from jobserver._jobserver import ExceptionWrapper, ResultWrapper
+
+from .helpers import helper_raise
+
+
+class CustomChildError(Exception):
+    """Module-level (hence picklable) custom exception subclass."""
+
+
+def helper_raise_local() -> typing.NoReturn:
+    """Raise an exception whose type is defined locally and is unpicklable."""
+
+    class LocallyDefinedError(Exception):
+        pass
+
+    raise LocallyDefinedError("local boom")
+
+
+def helper_raise_picklable_chain() -> typing.NoReturn:
+    """Raise RuntimeError chained from a picklable ValueError cause."""
+    try:
+        helper_raise(ValueError, "inner-picklable")
+    except ValueError as e:
+        raise RuntimeError("outer-picklable") from e
+
+
+def helper_raise_unpicklable_cause() -> typing.NoReturn:
+    """Raise picklable RuntimeError chained from a locally-defined cause."""
+
+    class LocalCause(Exception):
+        pass
+
+    try:
+        raise LocalCause("inner-local")
+    except LocalCause as e:
+        raise RuntimeError("outer-picklable") from e
+
+
+def helper_raise_unpicklable_outer() -> typing.NoReturn:
+    """Raise a locally-defined exception chained from a picklable cause."""
+
+    class LocalOuter(Exception):
+        pass
+
+    try:
+        helper_raise(ValueError, "inner-picklable")
+    except ValueError as e:
+        raise LocalOuter("outer-local") from e
+
+
+def _wrap_live_exception() -> ExceptionWrapper:
+    """Return an ExceptionWrapper around an exception with a live tb."""
+    try:
+        helper_raise(ZeroDivisionError, "boom")
+    except Exception as e:
+        return ExceptionWrapper(e)
+    raise AssertionError("unreachable")
+
+
+class TestJobserverTraceback(unittest.TestCase):
+    """Future.result() preserves the child's traceback (see #206)."""
+
+    def test_traceback_includes_child_frames(self) -> None:
+        """Rendered traceback names the child's failing frame."""
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=get_context(method), slots=1) as js:
+                    f = js.submit(
+                        fn=helper_raise,
+                        args=(ZeroDivisionError, "division by zero"),
+                        timeout=None,
+                    )
+                    with self.assertRaises(ZeroDivisionError) as ctx:
+                        f.result()
+                    rendered = "".join(
+                        traceback.format_exception(
+                            type(ctx.exception),
+                            ctx.exception,
+                            ctx.exception.__traceback__,
+                        )
+                    )
+                    self.assertIn("helper_raise", rendered)
+                    self.assertIn("helpers.py", rendered)
+                    self.assertIn("division by zero", rendered)
+
+    def test_traceback_custom_picklable_type(self) -> None:
+        """A module-level custom exception type round-trips with its trace."""
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=get_context(method), slots=1) as js:
+                    f = js.submit(
+                        fn=helper_raise,
+                        args=(CustomChildError, "custom boom"),
+                        timeout=None,
+                    )
+                    with self.assertRaises(CustomChildError) as ctx:
+                        f.result()
+                    rendered = "".join(
+                        traceback.format_exception(
+                            type(ctx.exception),
+                            ctx.exception,
+                            ctx.exception.__traceback__,
+                        )
+                    )
+                    self.assertIn("helper_raise", rendered)
+                    self.assertIn("custom boom", rendered)
+
+    def test_traceback_unpicklable_exception_type(self) -> None:
+        """An unpicklable child exception still surfaces a useful traceback."""
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=get_context(method), slots=1) as js:
+                    f = js.submit(fn=helper_raise_local, timeout=None)
+                    with self.assertRaises(Exception) as ctx:
+                        f.result()
+                    rendered = "".join(
+                        traceback.format_exception(
+                            type(ctx.exception),
+                            ctx.exception,
+                            ctx.exception.__traceback__,
+                        )
+                    )
+                    self.assertIn("LocallyDefinedError", rendered)
+                    self.assertIn("local boom", rendered)
+                    self.assertIn("helper_raise_local", rendered)
+
+    def test_traceback_picklable_chain(self) -> None:
+        """Both layers of a picklable cause chain render in the parent."""
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=get_context(method), slots=1) as js:
+                    f = js.submit(
+                        fn=helper_raise_picklable_chain, timeout=None
+                    )
+                    with self.assertRaises(RuntimeError) as ctx:
+                        f.result()
+                    rendered = "".join(
+                        traceback.format_exception(
+                            type(ctx.exception),
+                            ctx.exception,
+                            ctx.exception.__traceback__,
+                        )
+                    )
+                    self.assertIn("ValueError", rendered)
+                    self.assertIn("inner-picklable", rendered)
+                    self.assertIn("outer-picklable", rendered)
+                    self.assertIn("direct cause", rendered)
+
+    def test_traceback_unpicklable_cause(self) -> None:
+        """A locally-defined cause still renders despite being unpicklable."""
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=get_context(method), slots=1) as js:
+                    f = js.submit(
+                        fn=helper_raise_unpicklable_cause, timeout=None
+                    )
+                    with self.assertRaises(RuntimeError) as ctx:
+                        f.result()
+                    rendered = "".join(
+                        traceback.format_exception(
+                            type(ctx.exception),
+                            ctx.exception,
+                            ctx.exception.__traceback__,
+                        )
+                    )
+                    self.assertIn("LocalCause", rendered)
+                    self.assertIn("inner-local", rendered)
+                    self.assertIn("outer-picklable", rendered)
+                    self.assertIn("direct cause", rendered)
+
+    def test_traceback_unpicklable_outer_picklable_cause(self) -> None:
+        """A locally-defined outer's chain renders through the fallback."""
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=get_context(method), slots=1) as js:
+                    f = js.submit(
+                        fn=helper_raise_unpicklable_outer, timeout=None
+                    )
+                    with self.assertRaises(RuntimeError) as ctx:
+                        f.result()
+                    rendered = "".join(
+                        traceback.format_exception(
+                            type(ctx.exception),
+                            ctx.exception,
+                            ctx.exception.__traceback__,
+                        )
+                    )
+                    self.assertIn("ValueError", rendered)
+                    self.assertIn("inner-picklable", rendered)
+                    self.assertIn("LocalOuter", rendered)
+                    self.assertIn("outer-local", rendered)
+                    self.assertIn("direct cause", rendered)
+                    # Fallback wraps the unpicklable outer as RuntimeError.
+                    self.assertIn("not picklable", rendered)
+
+
+class TestExceptionWrapperPickle(unittest.TestCase):
+    """ExceptionWrapper pickle round-trips are idempotent (see #206)."""
+
+    def _round_trip(self, w: ExceptionWrapper) -> ExceptionWrapper:
+        return pickle.loads(pickle.dumps(w))
+
+    def _assert_idempotent(self, w: ExceptionWrapper) -> None:
+        """Two consecutive round-trips preserve _raised_tb and unwrap()."""
+        once = self._round_trip(w)
+        twice = self._round_trip(once)
+        self.assertEqual(w._raised_tb, once._raised_tb)
+        self.assertEqual(once._raised_tb, twice._raised_tb)
+        self.assertEqual(type(w._raised), type(twice._raised))
+        self.assertEqual(w._raised.args, twice._raised.args)
+        with self.assertRaises(type(w._raised)) as ctx_once:
+            once.unwrap()
+        with self.assertRaises(type(w._raised)) as ctx_twice:
+            twice.unwrap()
+        if w._raised_tb:
+            self.assertIsNotNone(ctx_once.exception.__cause__)
+            self.assertEqual(
+                str(ctx_once.exception.__cause__),
+                str(ctx_twice.exception.__cause__),
+            )
+            self.assertEqual(str(ctx_once.exception.__cause__), w._raised_tb)
+        else:
+            self.assertIsNone(ctx_twice.exception.__cause__)
+
+    def test_round_trip_with_live_traceback(self) -> None:
+        """Wrapping a freshly-raised exception captures and survives."""
+        w = _wrap_live_exception()
+        self.assertIn("helper_raise", w._raised_tb)
+        self._assert_idempotent(w)
+
+    def test_round_trip_without_traceback(self) -> None:
+        """Parent-built wrappers have no tb; round-trips stay empty."""
+        w = ExceptionWrapper(SubmissionDied())
+        self.assertEqual(w._raised_tb, "")
+        self._assert_idempotent(w)
+
+    def test_round_trip_cause_result_wrapper(self) -> None:
+        """A ResultWrapper cause contributes no tb; round-trips stay empty."""
+        w = ExceptionWrapper(RuntimeError("fallback"), cause=ResultWrapper(42))
+        self.assertEqual(w._raised_tb, "")
+        self._assert_idempotent(w)
+
+    def test_round_trip_cause_exception_wrapper(self) -> None:
+        """An ExceptionWrapper cause donates its tb; round-trips preserve."""
+        inner = _wrap_live_exception()
+        w = ExceptionWrapper(RuntimeError("fallback"), cause=inner)
+        self.assertEqual(w._raised_tb, inner._raised_tb)
+        self.assertIn("helper_raise", w._raised_tb)
+        self._assert_idempotent(w)
+
+    def test_round_trip_cause_exception_wrapper_after_pickle(self) -> None:
+        """Cause donation works after the cause has already round-tripped."""
+        inner = self._round_trip(_wrap_live_exception())
+        w = ExceptionWrapper(RuntimeError("fallback"), cause=inner)
+        self.assertEqual(w._raised_tb, inner._raised_tb)
+        self._assert_idempotent(w)


### PR DESCRIPTION
## Problem

Pickle drops `__traceback__`, so a child-process exception arriving in the parent showed only the `unwrap()` frame. The originating stack was lost, mirroring the long-standing gap that `concurrent.futures.ProcessPoolExecutor` works around with `_RemoteTraceback`.

## Approach

Format the child's traceback to a string in the child (where `__traceback__` is still live) and re-attach it in the parent via `__cause__`. All transit-time work lives in `ExceptionWrapper.__getstate__` / `__setstate__`, so `unwrap()` stays a pure `raise self._raised`.

- `ExceptionWrapper(raised, cause: Optional[Wrapper] = None)` — formats from `raised.__traceback__`, or inherits the captured string from an `ExceptionWrapper` cause without re-formatting.
- `RemoteTraceback(Exception)` — single-field carrier whose `__str__` is the formatted child stack. Attached as `__cause__` during `__setstate__`.
- `Wrapper.describe()` — abstract; `ResultWrapper` and `ExceptionWrapper` each return `"Kind of type Name"` for the worker's diagnostic message, keeping `_worker_entrypoint` free of wrapper internals.
- `_worker_entrypoint` — on `(PicklingError, AttributeError, TypeError)` from `send.send(result)`, sends `ExceptionWrapper(RuntimeError(...), cause=result)` so the captured child traceback survives the fallback. Locally-defined exception types no longer degrade silently into `SubmissionDied`.

## Trade-offs

- Eager formatting in `__init__` costs one `format_exception` call per wrap, even for in-process wrappers that are never pickled. Negligible.
- `__cause__` chains render in full but collapse into a single `RemoteTraceback` programmatically — the same compromise `concurrent.futures` makes. Documented on `ExceptionWrapper`.

## Tests (`test/test_jobserver_traceback.py`)

End-to-end through `Jobserver` across all start methods:

- child frames appear in the rendered traceback
- module-level custom exception types round-trip with their stack
- locally-defined (unpicklable) exception types surface via the fallback
- picklable cause chains render both layers
- unpicklable causes still render the chain
- unpicklable outer with picklable cause renders the chain through the fallback

`ExceptionWrapper` pickle idempotency across two consecutive round-trips:

- live traceback / no traceback / `cause=ResultWrapper` / `cause=ExceptionWrapper` / `cause=ExceptionWrapper` after it has itself round-tripped

Closes #206

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPopHwtLBCvDKNKwGevWTp)_