### PR TITLE
Report cause of death when a BaseException escapes a worker (#167)

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -161,9 +161,7 @@ class ExceptionWrapper(Wrapper[Any]):
         self._raised = raised
         if isinstance(cause, ExceptionWrapper):
             self._raised_tb = cause._raised_tb
-        elif raised.__traceback__ is None:
-            self._raised_tb = ""
-        else:
+        elif raised.__traceback__ is not None:
             self._raised_tb = "".join(
                 traceback.format_exception(
                     type(raised),
@@ -171,6 +169,8 @@ class ExceptionWrapper(Wrapper[Any]):
                     raised.__traceback__,
                 )
             )
+        else:
+            self._raised_tb = ""
 
     def __getstate__(self) -> tuple:
         return (self._raised, self._raised_tb)
@@ -1003,12 +1003,25 @@ def _worker_entrypoint(send, env, preexec_fn, fn, *args, **kwargs) -> None:
         result = ResultWrapper(raw)
     except Exception as exception:
         result = ExceptionWrapper(exception)
+    except BaseException as base_exception:
+        # When possible, send cause of death back to the parent to aid
+        # users in debugging.  Raising SubmissionDied() from the escaped
+        # BaseException gives it a live traceback whose chained __cause__
+        # names the SystemExit/KeyboardInterrupt for the parent to render.
+        # SubmissionDied() without __cause__ indicates this send failed,
+        # e.g. due to a SIGKILL.
+        try:
+            raise SubmissionDied() from base_exception
+        except SubmissionDied as died:
+            result = ExceptionWrapper(died)
+        raise  # Proceed with any BaseException-specific teardown
     finally:
         # Ignore broken pipes which naturally occur when the destination
         # terminates (or otherwise hangs up) before the result is ready
         try:
-            # None means a BaseException (not Exception) escaped fn; let
-            # the pipe close so the parent sees EOFError -> SubmissionDied.
+            # None means result assignment never ran (e.g. an interpreter
+            # teardown between except and finally); let the pipe close so
+            # the parent sees EOFError -> SubmissionDied.
             if result is not None:
                 try:
                     send.send(result)  # ValueError => object too large

--- a/test/test_jobserver_traceback.py
+++ b/test/test_jobserver_traceback.py
@@ -16,7 +16,11 @@ import unittest
 from multiprocessing import get_all_start_methods, get_context
 
 from jobserver import Jobserver, SubmissionDied
-from jobserver._jobserver import ExceptionWrapper, ResultWrapper
+from jobserver._jobserver import (
+    ExceptionWrapper,
+    RemoteTraceback,
+    ResultWrapper,
+)
 
 from .helpers import helper_raise
 
@@ -72,6 +76,20 @@ def _wrap_live_exception() -> ExceptionWrapper:
         helper_raise(ZeroDivisionError, "boom")
     except Exception as e:
         return ExceptionWrapper(e)
+    raise AssertionError("unreachable")
+
+
+def _wrap_live_base_exception(klass: type, *args) -> ExceptionWrapper:
+    """Mirror _worker_entrypoint's BaseException path: raise SubmissionDied
+    from a freshly-raised control-flow BaseException, then wrap it (#167).
+    """
+    try:
+        raise klass(*args)
+    except BaseException as e:
+        try:
+            raise SubmissionDied() from e
+        except SubmissionDied as died:
+            return ExceptionWrapper(died)
     raise AssertionError("unreachable")
 
 
@@ -272,3 +290,28 @@ class TestExceptionWrapperPickle(unittest.TestCase):
         w = ExceptionWrapper(RuntimeError("fallback"), cause=inner)
         self.assertEqual(w._raised_tb, inner._raised_tb)
         self._assert_idempotent(w)
+
+    def test_submission_died_chained_from_keyboard_interrupt(self) -> None:
+        """SubmissionDied raised-from KeyboardInterrupt captures both."""
+        w = _wrap_live_base_exception(KeyboardInterrupt)
+        self.assertIsInstance(w._raised, SubmissionDied)
+        self.assertIn("SubmissionDied", w._raised_tb)
+        self.assertIn("KeyboardInterrupt", w._raised_tb)
+        self.assertIn("_wrap_live_base_exception", w._raised_tb)
+        self._assert_idempotent(w)
+
+    def test_submission_died_chained_from_system_exit(self) -> None:
+        """The chained SystemExit type renders so the parent can debug."""
+        w = _wrap_live_base_exception(SystemExit, 2)
+        self.assertIsInstance(w._raised, SubmissionDied)
+        self.assertIn("SystemExit", w._raised_tb)
+        self._assert_idempotent(w)
+
+    def test_chained_base_exception_round_trips(self) -> None:
+        """unwrap() after pickle raises SubmissionDied whose RemoteTraceback
+        renders the chained control-flow cause."""
+        w = self._round_trip(_wrap_live_base_exception(KeyboardInterrupt))
+        with self.assertRaises(SubmissionDied) as ctx:
+            w.unwrap()
+        self.assertIsInstance(ctx.exception.__cause__, RemoteTraceback)
+        self.assertIn("KeyboardInterrupt", str(ctx.exception.__cause__))

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -86,34 +86,49 @@ class TestJobserverWorker(unittest.TestCase):
                         f.result()
 
     def test_base_exception_surfaces_as_submission_died(self) -> None:
-        """BaseException subclasses escaping fn must surface as SubmissionDied.
+        """BaseException subclasses escaping fn surface as SubmissionDied.
 
         sys.exit(1) raises SystemExit and helper_raise(KeyboardInterrupt)
         raises KeyboardInterrupt – both are BaseException subclasses that
-        fall outside the ``except Exception:`` guard in _worker_entrypoint(),
-        so the worker closes the result pipe without writing, which the
-        parent sees as SubmissionDied.
+        fall outside the ``except Exception:`` guard in _worker_entrypoint().
+        The worker catches them via ``except BaseException``, sends a
+        SubmissionDied carrying the cause's traceback, then re-raises for
+        normal teardown.  The parent sees SubmissionDied whose __cause__ is a
+        RemoteTraceback naming the originating type (see #167).
         """
+        # fn, args, substring expected in the propagated child traceback.
         base_exceptions: list[tuple] = [
-            (sys.exit, (1,)),
-            (helper_raise, (KeyboardInterrupt,)),
+            (sys.exit, (1,), "SystemExit"),
+            (helper_raise, (KeyboardInterrupt,), "KeyboardInterrupt"),
         ]
         for method in get_all_start_methods():
-            for fn, args in base_exceptions:
+            for fn, args, expected in base_exceptions:
                 with self.subTest(method=method, fn=fn.__name__):
                     with Jobserver(context=method, slots=1) as js:
                         f = js.submit(fn=fn, args=args, timeout=5)
-                        with self.assertRaises(SubmissionDied):
+                        with self.assertRaises(SubmissionDied) as ctx:
                             f.result(timeout=5)
+                    # The enriched path attaches the child's traceback as a
+                    # cause; a silent death would leave __cause__ as None.
+                    cause = ctx.exception.__cause__
+                    self.assertIsNotNone(cause)
+                    self.assertIn(expected, str(cause))
 
     def test_os_exit_becomes_submission_died(self) -> None:
-        """os._exit() in worker produces SubmissionDied."""
+        """os._exit() in worker produces a bare, causeless SubmissionDied.
+
+        Unlike SystemExit/KeyboardInterrupt, os._exit() raises nothing the
+        worker can catch, so no cause is sent and the parent falls back to
+        EOFError -> SubmissionDied with __cause__ None (the silent-death
+        path that distinguishes it from the enriched #167 case).
+        """
         for method in get_all_start_methods():
             with self.subTest(method=method):
                 with Jobserver(context=method, slots=1) as js:
                     f = js.submit(fn=os._exit, args=(1,), timeout=5)
-                    with self.assertRaises(SubmissionDied):
+                    with self.assertRaises(SubmissionDied) as ctx:
                         f.result(timeout=5)
+                self.assertIsNone(ctx.exception.__cause__)
 
     def test_done_signal_terminates(self) -> None:
         """Future.wait(..., signal=...) accepts Signals enum and int forms."""


### PR DESCRIPTION
Fixes #167.

## Problem

A `SystemExit` or `KeyboardInterrupt` raised by `fn` is a `BaseException`, not an `Exception`, so it slipped past the worker's `except Exception` guard in `_worker_entrypoint`. `result` stayed `None`, the result pipe closed unwritten, and the parent surfaced a bare `SubmissionDied` (via `EOFError`) with no clue as to the cause.

## Fix

`_worker_entrypoint` now also catches `BaseException` and does `raise SubmissionDied() from base_exception`. Raising it gives the `SubmissionDied` a live traceback whose chained `__cause__` names the originating `SystemExit`/`KeyboardInterrupt`; `traceback.format_exception` walks that chain, so the existing `ExceptionWrapper` machinery (#206) conveys both frames to the parent unchanged. The wrapped result is shipped in the `finally` block, then the original `BaseException` is re-raised so the worker still undergoes normal teardown — `SystemExit` exits with its code rather than 0.

A causeless `SubmissionDied` continues to signal a genuinely silent death (`SIGKILL`, `os._exit`, or a failed send), preserving the two-way diagnostic contract.

## Tests

- `test_jobserver_worker.py`: the existing `BaseException` test now asserts the propagated `__cause__` names the type; `test_os_exit_becomes_submission_died` asserts `__cause__` is `None` (the silent-death contrast).
- `test_jobserver_traceback.py`: added `ExceptionWrapper` cases exercising the chained `SubmissionDied` path (KeyboardInterrupt/SystemExit capture and pickle round-trip to a `RemoteTraceback`).

Full `ci` passes locally: 206 tests, ruff, mypy, black, examples, and sdist build all green.

https://claude.ai/code/session_012EXzRVqrWHZYp3ccGLrPGi

---
_Generated by [Claude Code](https://claude.ai/code/session_012EXzRVqrWHZYp3ccGLrPGi)_