### PR TITLE
Document RemoteTraceback as an internal marker

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -125,7 +125,10 @@ class ResultWrapper(Wrapper[T]):
 # TODO: align _executor.py's _responses_put_failed pickle-fallback so both
 # paths catch the same exception tuple and share traceback re-attach logic.
 class RemoteTraceback(Exception):
-    """Carries a child process's formatted traceback string."""
+    """Carries a child's formatted traceback string.
+
+    Surfaced only via __cause__ on exceptions Future.result() re-raises.
+    """
 
     def __init__(self, traceback: str) -> None:
         self._traceback = traceback


### PR DESCRIPTION
`RemoteTraceback` lives in the private `_jobserver` module and is deliberately absent from `__all__`, yet its unprefixed name reads as "public-ish." It only ever reaches users hanging off `__cause__` on an exception re-raised by `Future.result()` — there's no symbol to import and no API surface beyond `__str__`.

This adds a one-line note to its docstring making the boundary explicit, so the unexported status reads as intentional rather than an oversight. Mirrors the stdlib precedent (`concurrent.futures.process._RemoteTraceback`), without renaming — the unprefixed name keeps printed tracebacks readable.

Docs-only; no behavior change. ruff, black, mypy, and the traceback tests pass.

https://claude.ai/code/session_012EXzRVqrWHZYp3ccGLrPGi

---
_Generated by [Claude Code](https://claude.ai/code/session_012EXzRVqrWHZYp3ccGLrPGi)_