### PR TITLE
Guard _receive_loop so a dead receiver fails loudly (#193)

### DIFF
--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -50,11 +50,14 @@ class JobserverExecutor(concurrent.futures.Executor):
         When jobserver is None, a default-constructed Jobserver is
         created and owned by this executor.
         """
-        # One lock guards _shutdown, _work_ids, and _futures together.
+        # One lock guards _shutdown, _work_ids, _futures, and _broken together.
         self._lock = threading.Lock()
         self._shutdown = False
         self._work_ids: Iterator[int] = itertools.count()
         self._futures: dict[int, concurrent.futures.Future] = {}
+        # The receiver thread's fatal exception, once it dies; submit() then
+        # refuses work.
+        self._broken: Optional[BaseException] = None
 
         # Own the jobserver when none is supplied; caller owns it otherwise.
         self._own_jobserver = jobserver is None
@@ -94,7 +97,12 @@ class JobserverExecutor(concurrent.futures.Executor):
 
     def __repr__(self) -> str:
         with self._lock:
-            state = "shutdown" if self._shutdown else "active"
+            if self._broken is not None:
+                state = "broken"
+            elif self._shutdown:
+                state = "shutdown"
+            else:
+                state = "active"
             pending = len(self._futures)
         return (
             f"JobserverExecutor({state}, pending={pending}"
@@ -110,6 +118,10 @@ class JobserverExecutor(concurrent.futures.Executor):
     ) -> concurrent.futures.Future[T]:
         """Submit a callable for execution and return a Future."""
         with self._lock:
+            if self._broken is not None:
+                raise concurrent.futures.BrokenExecutor(
+                    "Cannot submit: executor is broken"
+                ) from self._broken
             if self._shutdown:
                 raise RuntimeError("Cannot submit: executor is shut down")
             future: concurrent.futures.Future[T] = concurrent.futures.Future()
@@ -222,15 +234,31 @@ class JobserverExecutor(concurrent.futures.Executor):
     # ---- Receiver thread (bridges responses to c.f.Futures) ----
 
     def _receive_loop(self) -> None:
+        """Drain responses; never let the receiver die silently.
+
+        An unhandled exception here would otherwise kill this daemon thread
+        and hang every outstanding future.  Fail them with the cause attached,
+        then re-raise so the thread still dies loudly via threading.excepthook.
+        """
+        try:
+            self._receive_messages()
+        except BaseException as exc:
+            self._fail_all(cause=exc)
+            raise
+        else:
+            # Clean exit (Shutdown or EOF): fail any work the dispatcher left.
+            self._fail_all(cause=None)
+
+    def _receive_messages(self) -> None:
         """Drain response queue, completing c.f.Futures as results arrive."""
         while True:
             try:
                 msg = self._responses.get(timeout=None)
             except EOFError:
-                break
+                return
 
             if isinstance(msg, _response.Shutdown):
-                break
+                return
             elif isinstance(msg, _response.Started):
                 with self._lock:
                     future = self._futures.get(msg.work_id)
@@ -264,31 +292,39 @@ class JobserverExecutor(concurrent.futures.Executor):
             else:
                 raise RuntimeError(f"Unexpected response type: {type(msg)!r}")
 
-        # Fail any futures still outstanding because the dispatcher
-        # exited without sending results for them (crash or unexpected exit).
+    def _fail_all(self, cause: Optional[BaseException]) -> None:
+        """Fail every outstanding future; no more results will arrive.
+
+        cause is None when the dispatcher exited; otherwise the receiver died
+        and cause is recorded as _broken and chained onto each failed future.
+        """
         with self._lock:
+            if cause is not None:
+                self._broken = cause
             remaining = list(self._futures.values())
             self._futures.clear()
         _LOG.debug(
-            "Dispatcher exited with %d outstanding futures",
+            "Failing %d outstanding futures (broken=%s)",
             len(remaining),
+            cause is not None,
         )
+        message = (
+            "Receiver thread died before delivering this future's result"
+            if cause is not None
+            else "Dispatcher process exited before"
+            " delivering this future's result"
+        )
+        err = concurrent.futures.BrokenExecutor(message)
+        if cause is not None:
+            err.__cause__ = cause
         for future in remaining:
             if future.done():
                 continue
             try:
-                future.set_running_or_notify_cancel()
+                # set_exception accepts a PENDING or RUNNING future directly.
+                future.set_exception(err)
             except concurrent.futures.InvalidStateError:
-                pass
-            try:
-                future.set_exception(
-                    RuntimeError(
-                        "Dispatcher process exited before"
-                        " delivering this future's result"
-                    )
-                )
-            except concurrent.futures.InvalidStateError:
-                pass
+                pass  # cancelled concurrently after the done() check
 
 
 def _cancel_observer(

--- a/test/test_executor_lifecycle.py
+++ b/test/test_executor_lifecycle.py
@@ -496,6 +496,87 @@ class TestResourceLeaks(unittest.TestCase):
             exe.shutdown(wait=True)
 
 
+class _RaisingResponses:
+    """A _responses stand-in whose get() crashes the receiver loop."""
+
+    def __init__(self, error: BaseException) -> None:
+        self._error = error
+
+    def get(self, timeout: object = None) -> object:
+        raise self._error
+
+
+class _StubExecutor(JobserverExecutor):
+    """JobserverExecutor sans __init__: just the receiver-guard attributes."""
+
+    def __init__(self, responses: object) -> None:
+        self._lock = threading.Lock()
+        self._shutdown = False
+        self._futures = {}
+        self._broken = None
+        self._responses = responses
+        self._jobserver = None
+
+
+class TestReceiverGuard(unittest.TestCase):
+    """The receiver thread fails loudly instead of dying silently (#193)."""
+
+    def test_crash_breaks_executor_and_fails_futures(self) -> None:
+        """A receiver crash marks the executor broken and fails futures."""
+        sentinel = ValueError("boom in receiver")
+        exe = _StubExecutor(_RaisingResponses(sentinel))
+        future: concurrent.futures.Future = concurrent.futures.Future()
+        exe._futures[0] = future
+
+        # Capture the loud death so the re-raise stays out of test output.
+        captured: list[BaseException] = []
+        old_hook = threading.excepthook
+        threading.excepthook = lambda args: captured.append(args.exc_value)
+        try:
+            t = threading.Thread(target=exe._receive_loop, daemon=True)
+            t.start()
+            t.join(timeout=TIMEOUT)
+        finally:
+            threading.excepthook = old_hook
+
+        self.assertFalse(t.is_alive())  # died loudly, did not hang
+        self.assertIn(sentinel, captured)
+        self.assertIs(exe._broken, sentinel)
+        # The outstanding future fails carrying the real cause.
+        exc = future.exception(timeout=TIMEOUT)
+        self.assertIsInstance(exc, concurrent.futures.BrokenExecutor)
+        self.assertIs(exc.__cause__, sentinel)
+
+    def test_fails_running_future_without_reraising(self) -> None:
+        """A RUNNING outstanding future is failed, not left for a crash."""
+        sentinel = ValueError("receiver died")
+        exe = _StubExecutor(_RaisingResponses(sentinel))
+        future: concurrent.futures.Future = concurrent.futures.Future()
+        future.set_running_or_notify_cancel()  # Started arrived, no Completed
+        exe._futures[0] = future
+
+        exe._fail_all(cause=sentinel)  # must not raise
+
+        exc = future.exception(timeout=TIMEOUT)
+        self.assertIsInstance(exc, concurrent.futures.BrokenExecutor)
+        self.assertIs(exc.__cause__, sentinel)
+
+    def test_submit_after_broken_raises_with_cause(self) -> None:
+        """submit() refuses work once broken, chaining the real cause."""
+        sentinel = RuntimeError("receiver died")
+        exe = _StubExecutor(_RaisingResponses(sentinel))
+        exe._broken = sentinel
+        with self.assertRaises(concurrent.futures.BrokenExecutor) as cm:
+            exe.submit(len, (1,))
+        self.assertIs(cm.exception.__cause__, sentinel)
+
+    def test_repr_reports_broken(self) -> None:
+        """__repr__ surfaces the broken state."""
+        exe = _StubExecutor(_RaisingResponses(RuntimeError()))
+        exe._broken = RuntimeError("x")
+        self.assertIn("broken", repr(exe))
+
+
 class TestOwnedJobserver(unittest.TestCase):
     """Owned Jobserver (constructed with jobserver=None)."""
 


### PR DESCRIPTION
The receiver thread had no top-level exception handler, so any unexpected
error in the loop body (corrupt pickle, isinstance-dispatch bug,
InvalidStateError, ...) killed the daemon thread silently. Outstanding
futures then hung forever with no diagnostic.

Wrap the loop in a top-level guard following the ProcessPoolExecutor
BrokenExecutor pattern:

- Split the loop body into _receive_messages(); _receive_loop() now wraps
  it. On an unexpected exception it marks the executor broken, fails every
  outstanding future, then re-raises so the thread still dies loudly via
  threading.excepthook.
- Add _fail_all(cause): unifies the existing clean-exit tail with the new
  crash path. Failed futures carry a concurrent.futures.BrokenExecutor
  (a RuntimeError subclass, so existing expectations hold); when the
  receiver itself died, the live in-process exception is chained as
  __cause__ so future.result() shows why.
- submit() raises BrokenExecutor (chaining the cause) once _broken is set,
  and __repr__ reports the broken state.

The Failed branch still forwards msg.exc unchanged, preserving the child
traceback work from #206.