### PR TITLE
Reclaim finished workers' slots when map() generator is abandoned

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -929,6 +929,9 @@ class Jobserver:
         concurrent.futures, all chunksize results are materialized
         in memory at once.
 
+        Stopping iteration early neither cancels nor waits for running work.
+        Slots are retained until next reclaim_resources() or __exit__.
+
         When env provided, child updates os.environ unsetting None-valued keys.
         See submit() for preexec_fn semantics.
 
@@ -964,6 +967,7 @@ class Jobserver:
             collected = None
         return _map_generate(
             submit=self.submit,
+            reclaim=self.reclaim_resources,
             fn=fn,
             pairs=pairs if collected is None else iter(collected),
             chunksize=chunksize,
@@ -1201,6 +1205,7 @@ def _map_chunk(fn: Callable, chunk: tuple) -> list:
 
 def _map_generate(
     submit: Callable[..., Future[T]],
+    reclaim: Callable[[], None],
     fn: Callable[..., T],
     pairs: Iterator,
     chunksize: int,
@@ -1247,3 +1252,18 @@ def _map_generate(
         # concurrent.futures.TimeoutError (not builtin TimeoutError) so that
         # callers catching either type see it on Python < 3.11.
         raise concurrent.futures.TimeoutError() from None
+    finally:
+        # On teardown explicitly clear still-held Futures, then reclaim
+        # finished workers' slots.  Loop since reclaim aborts on the first
+        # CallbackRaised; a closed Jobserver, causing ValueError or
+        # OSError, ends the loop.
+        futures.clear()
+        chunk = ()
+        while True:
+            try:
+                reclaim()
+                break
+            except CallbackRaised:
+                continue
+            except (ValueError, OSError):
+                break

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -117,6 +117,17 @@ def helper_return(arg: T) -> T:
     return arg
 
 
+def helper_marker_return(directory: str, arg: T) -> T:
+    """Create a marker file named for arg under directory then return arg.
+
+    Lets a test observe, without itself reclaiming slots, that a worker has
+    actually finished: the marker exists once fn has run to completion.
+    """
+    with open(os.path.join(directory, str(arg)), "w") as handle:
+        handle.write("ran")
+    return arg
+
+
 def helper_raise(klass: type, *args) -> typing.NoReturn:
     """Helper raising the requested Exception class."""
     raise klass(*args)

--- a/test/test_jobserver_map.py
+++ b/test/test_jobserver_map.py
@@ -10,6 +10,9 @@ timeout semantics, and error propagation.
 """
 
 import concurrent.futures
+import gc
+import os
+import tempfile
 import time
 import unittest
 from multiprocessing import get_all_start_methods
@@ -19,6 +22,7 @@ from jobserver import Jobserver
 from .helpers import (
     FAST,
     TIMEOUT,
+    helper_marker_return,
     helper_return,
     raising_at_position,
     silence_forkserver,
@@ -362,3 +366,84 @@ class TestJobserverMap(unittest.TestCase):
                         )
                     )
                     self.assertEqual(results, list(range(30)))
+
+
+class TestJobserverMapAbandonment(unittest.TestCase):
+    """map() reclaims slots when its generator is abandoned (issue #176).
+
+    A map() generator that is abandoned mid-iteration -- the caller stops
+    iterating (GeneratorExit via close()/del) or a deadline expires
+    (Blocked) -- must not leave the slots of already-finished workers
+    held until some unrelated reclaim_resources()/__exit__ runs.  The
+    generator's teardown drops its outstanding Future references and runs
+    the existing non-blocking reclaim so finished workers return their
+    slots promptly.  Still-running workers cannot be cancelled mid-flight
+    and are not awaited, so they keep their slot until later reclamation.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        silence_forkserver()
+
+    def _wait_until_finished(self, directory: str, count: int) -> None:
+        """Block until count workers have finished, observed via markers.
+
+        Polls the filesystem rather than the Jobserver so the test never
+        itself reclaims the slots whose reclamation is under test.  Each
+        worker writes its marker as the last thing fn does; a brief settle
+        then covers the tiny window before the worker sends its result and
+        exits, so a single non-blocking reclaim can subsequently reap it.
+        """
+        deadline = time.monotonic() + TIMEOUT
+        while len(os.listdir(directory)) < count:
+            if time.monotonic() > deadline:
+                self.fail("workers never finished")
+            time.sleep(0.01)
+        time.sleep(0.1)
+
+    def test_close_reclaims_finished_slots(self) -> None:
+        """Closing the generator returns finished workers' slots."""
+        slots = 4
+        with tempfile.TemporaryDirectory() as directory:
+            with Jobserver(context=FAST, slots=slots) as js:
+                argses = [(directory, i) for i in range(slots)]
+                # buffersize=None submits all work up front; with one slot
+                # per item no submit() ever blocks, so submit()'s internal
+                # reclaim never runs and the finished-but-undrained Futures
+                # all retain their slots.
+                gen = js.map(
+                    fn=helper_marker_return,
+                    argses=argses,
+                    buffersize=None,
+                    timeout=TIMEOUT,
+                )
+                self.assertEqual(next(gen), 0)
+
+                # All workers finish, yet only the first (drained by the
+                # next() above) has returned its slot: the rest leak.
+                self._wait_until_finished(directory, slots)
+                self.assertGreater(js._tracked(), 0)
+
+                # Abandoning the generator must reclaim those slots.
+                gen.close()
+                self.assertEqual(js._tracked(), 0)
+
+    def test_del_reclaims_finished_slots(self) -> None:
+        """Dropping the only reference (GC) returns finished workers' slots."""
+        slots = 4
+        with tempfile.TemporaryDirectory() as directory:
+            with Jobserver(context=FAST, slots=slots) as js:
+                argses = [(directory, i) for i in range(slots)]
+                gen = js.map(
+                    fn=helper_marker_return,
+                    argses=argses,
+                    buffersize=None,
+                    timeout=TIMEOUT,
+                )
+                self.assertEqual(next(gen), 0)
+                self._wait_until_finished(directory, slots)
+                self.assertGreater(js._tracked(), 0)
+
+                del gen
+                gc.collect()
+                self.assertEqual(js._tracked(), 0)


### PR DESCRIPTION
Closes #176.

`Jobserver.map()` returns a generator whose internal deque holds `Future`s with running children. When iteration stopped early — the caller dropped the iterator (`GeneratorExit` via `close()`/`del`/GC) or a deadline expired (`TimeoutError`) — slots of already-finished workers stayed held until some unrelated `reclaim_resources()`/`__exit__` ran, causing transient slot starvation.

**Fix:** a `try/finally` in the generator clears its outstanding references and reclaims finished workers' slots via the existing non-blocking reclaim path. It loops as `__exit__` does so a `CallbackRaised` from an unrelated `Future` can't strand them, and stops on a closed `Jobserver` (`ValueError`/`OSError`). Still-running children are neither cancelled nor waited for, preserving the non-blocking teardown contract.

**Contract:** `map()`'s docstring now states that stopping iteration early neither cancels nor waits for running work, and that those slots are retained until the next `reclaim_resources()`/`__exit__`.

**Tests:** `TestJobserverMapAbandonment` covers the `close()` and `del`/GC paths, observing worker completion via marker files so the test never itself reclaims the slots under test.