### PR TITLE
Fix submit/shutdown race in JobserverExecutor (#191)

### DIFF
--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -16,6 +16,7 @@ import traceback
 import weakref
 from collections import deque
 from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
 from multiprocessing.connection import Connection, wait
 from typing import Any, Optional, TypeVar, Union
 
@@ -117,6 +118,9 @@ class JobserverExecutor(concurrent.futures.Executor):
         **kwargs: Any,
     ) -> concurrent.futures.Future[T]:
         """Submit a callable for execution and return a Future."""
+        # Built outside the lock; no external referrer yet, so the critical
+        # section need only cover the gate and work_id registration.
+        future: concurrent.futures.Future[T] = concurrent.futures.Future()
         with self._lock:
             if self._broken is not None:
                 raise concurrent.futures.BrokenExecutor(
@@ -124,17 +128,14 @@ class JobserverExecutor(concurrent.futures.Executor):
                 ) from self._broken
             if self._shutdown:
                 raise RuntimeError("Cannot submit: executor is shut down")
-            future: concurrent.futures.Future[T] = concurrent.futures.Future()
             work_id = next(self._work_ids)
             self._futures[work_id] = future
-            # Observe cancellation so a PENDING future calling .cancel() tells
-            # the dispatcher to prune it before dispatch, reclaiming the slot
-            # that would otherwise run work whose result is discarded.  A weak
-            # reference keeps a retained future from pinning the executor (and
-            # its dispatcher process, threads, and pipes) alive.
-            future.add_done_callback(
-                functools.partial(_cancel_observer, weakref.ref(self), work_id)
-            )
+        # Let a cancelled PENDING future tell the dispatcher to prune it before
+        # dispatch; the weak ref avoids pinning the executor alive.  Registered
+        # before the future escapes to the caller, so no .cancel() can race it.
+        future.add_done_callback(
+            functools.partial(_cancel_observer, weakref.ref(self), work_id)
+        )
         success = False
         try:
             self._requests.put(
@@ -149,9 +150,9 @@ class JobserverExecutor(concurrent.futures.Executor):
                 "Cannot submit: executor is shut down"
             ) from None
         finally:
-            # Lock was released before put() to avoid blocking on IPC.
-            # On any failure, remove the orphaned future so the
-            # dispatcher never sees a work_id without a request.
+            # Lock released before put() to avoid blocking on IPC.  On any
+            # failure, remove the orphaned future so the dispatcher never
+            # sees a work_id without a request.
             if not success:
                 with self._lock:
                     self._futures.pop(work_id, None)
@@ -211,6 +212,8 @@ class JobserverExecutor(concurrent.futures.Executor):
                 wait,
                 cancel_futures,
             )
+            # Puts are lock-free; a Submit racing this Cancel() is caught by
+            # the dispatcher's latch (see _handle_request).
             try:
                 if cancel_futures:
                     self._requests.put(_request.Cancel())
@@ -350,6 +353,22 @@ def _cancel_observer(
 # ---- Dispatcher process (runs in a child process) ----
 
 
+@dataclass
+class _DispatchState:
+    """Mutable state owned by the dispatcher loop and its handlers.
+
+    Passed by reference and updated in place, so handlers need no return
+    values to thread `shutdown` and `cancelling` back to the loop.
+    """
+
+    pending: deque[_request.Submit] = field(default_factory=deque)
+    running: dict[Future, int] = field(default_factory=dict)
+    # Latched by a blanket Cancel(); then racing Submits are cancelled.
+    cancelling: bool = False
+    # Set by a Shutdown() message or parent EOF; ends the loop.
+    shutdown: bool = False
+
+
 def _dispatch_loop(
     jobserver: Jobserver,
     requests: MinimalQueue,
@@ -363,71 +382,70 @@ def _dispatch_loop(
     requests.close_put()
     responses.close_get()
 
-    pending: deque[_request.Submit] = deque()
-    running: dict[Future, int] = {}
+    state = _DispatchState()
+    while not state.shutdown:
+        _drain_requests(requests, state, responses)
+        _dispatch_pending(jobserver, state, responses)
+        _poll_running(state, responses)
+        if not state.shutdown:
+            _poll_requests_briefly(requests, state, responses)
 
-    shutdown = False
-    while not shutdown:
-        shutdown = _drain_requests(requests, pending, running, responses)
-        _dispatch_pending(jobserver, pending, running, responses)
-        _poll_running(running, responses)
-        if not shutdown:
-            shutdown = _poll_requests_briefly(
-                requests, pending, running, responses
-            )
-
-    _handle_shutdown(pending, running, responses)
+    _handle_shutdown(state, responses)
     _LOG.debug("Dispatcher process exiting")
 
 
 def _handle_request(
     msg: object,
-    pending: deque[_request.Submit],
+    state: _DispatchState,
     responses: MinimalQueue,
-) -> bool:
-    """Handle a single request message.  Return True on Shutdown."""
+) -> None:
+    """Handle a single request message, updating state in place."""
     if isinstance(msg, _request.Shutdown):
-        return True
-    if isinstance(msg, _request.Cancel):
+        state.shutdown = True
+    elif isinstance(msg, _request.Cancel):
         keep: list[_request.Submit] = []
-        for item in pending:
+        for item in state.pending:
             if msg.work_id is None or item.work_id == msg.work_id:
                 responses.put(_response.Cancelled(work_id=item.work_id))
             else:
                 keep.append(item)
-        pending.clear()
-        pending.extend(keep)
+        state.pending.clear()
+        state.pending.extend(keep)
+        # A blanket Cancel() precedes Shutdown(); latch to cancel late Submits.
+        state.cancelling = state.cancelling or msg.work_id is None
     elif isinstance(msg, _request.Submit):
-        pending.append(msg)
+        if state.cancelling:
+            responses.put(_response.Cancelled(work_id=msg.work_id))
+        else:
+            state.pending.append(msg)
     else:
         raise RuntimeError(f"Unexpected request type: {type(msg)!r}")
-    return False
 
 
 def _drain_requests(
     requests: MinimalQueue,
-    pending: deque[_request.Submit],
-    running: dict[Future, int],
+    state: _DispatchState,
     responses: MinimalQueue,
-) -> bool:
-    """Drain the request queue.  Return True when shutdown requested."""
+) -> None:
+    """Drain the request queue, setting state.shutdown on Shutdown or EOF."""
     while True:
         # Block only when there is nothing else to do
-        block = (not pending) and (not running)
+        block = (not state.pending) and (not state.running)
         try:
             msg = requests.get(timeout=None if block else 0)
         except queue.Empty:
-            return False
+            return
         except EOFError:
-            return True  # Parent died, treat as shutdown
-        if _handle_request(msg, pending, responses):
-            return True
+            state.shutdown = True  # Parent died, treat as shutdown
+            return
+        _handle_request(msg, state, responses)
+        if state.shutdown:
+            return
 
 
 def _dispatch_pending(
     jobserver: Jobserver,
-    pending: deque[_request.Submit],
-    running: dict[Future, int],
+    state: _DispatchState,
     responses: MinimalQueue,
 ) -> None:
     """Dispatch pending work in place via popleft().
@@ -435,6 +453,7 @@ def _dispatch_pending(
     Keeps c.f.Future in PENDING (cancellable) until a process is
     spawned.  Stops on first Blocked since remaining will be too.
     """
+    pending = state.pending
     while pending:
         item = pending[0]
         try:
@@ -457,14 +476,15 @@ def _dispatch_pending(
         # Dispatch succeeded -- inform receiver and track
         pending.popleft()
         responses.put(_response.Started(work_id=item.work_id))
-        running[f] = item.work_id
+        state.running[f] = item.work_id
 
 
 def _poll_running(
-    running: dict[Future, int],
+    state: _DispatchState,
     responses: MinimalQueue,
 ) -> None:
     """Poll running Futures and bridge completed results."""
+    running = state.running
     completed: list[Future] = []
     for f in running:
         try:
@@ -517,14 +537,13 @@ def _bridge_result(
 
 
 def _handle_shutdown(
-    pending: deque[_request.Submit],
-    running: dict[Future, int],
+    state: _DispatchState,
     responses: MinimalQueue,
 ) -> None:
     """Cancel pending work, drain running futures, signal completion."""
-    for item in pending:
+    for item in state.pending:
         responses.put(_response.Cancelled(work_id=item.work_id))
-    for f, work_id in running.items():
+    for f, work_id in state.running.items():
         while True:
             try:
                 f.wait(timeout=None)
@@ -537,21 +556,20 @@ def _handle_shutdown(
 
 def _poll_requests_briefly(
     requests: MinimalQueue,
-    pending: deque[_request.Submit],
-    running: dict[Future, int],
+    state: _DispatchState,
     responses: MinimalQueue,
-) -> bool:
+) -> None:
     """Brief blocking poll to pick up new work without busy-spinning.
 
-    Returns True when shutdown was requested.
+    Sets state.shutdown when a Shutdown()/EOF is observed.
     """
-    if not running and not pending:
-        return False
+    if not state.running and not state.pending:
+        return
 
     waitable = requests.waitable()
     augmented: list[Union[Connection, int]] = [waitable]
     augmented.extend(
-        f._process.sentinel for f in running if f._process is not None
+        f._process.sentinel for f in state.running if f._process is not None
     )
 
     # 1s timeout is a robustness fallback; normally a sentinel fires first
@@ -559,7 +577,5 @@ def _poll_requests_briefly(
         try:
             msg = requests.get(timeout=0)
         except (queue.Empty, EOFError):
-            return False
-        return _handle_request(msg, pending, responses)
-
-    return False
+            return
+        _handle_request(msg, state, responses)

--- a/test/test_executor_concurrency.py
+++ b/test/test_executor_concurrency.py
@@ -24,7 +24,8 @@ import unittest.mock
 import weakref
 from multiprocessing import get_all_start_methods
 
-from jobserver import Jobserver, JobserverExecutor
+from jobserver import Jobserver, JobserverExecutor, _request, _response
+from jobserver._executor import _DispatchState, _handle_request
 from jobserver._queue import MinimalQueue
 from jobserver._request import Submit
 
@@ -362,6 +363,37 @@ class TestInternalInvariants(unittest.TestCase):
             # it must have been issued with the lock already released.
             self.assertGreater(len(lock_held), 0)
             self.assertFalse(lock_held[0])
+
+    def test_blanket_cancel_latches_cancelling(self) -> None:
+        """A blanket Cancel() makes the dispatcher cancel later Submits.
+
+        After shutdown(cancel_futures=True) sends Cancel(), a Submit racing
+        the impending Shutdown must be cancelled on arrival, never dispatched.
+        """
+        responses: MinimalQueue = MinimalQueue(FAST)
+        state = _DispatchState()
+        try:
+            # Blanket Cancel() latches cancelling True.
+            _handle_request(_request.Cancel(), state, responses)
+            self.assertFalse(state.shutdown)
+            self.assertTrue(state.cancelling)
+
+            # A Submit arriving while cancelling is cancelled, not queued.
+            _handle_request(
+                _request.Submit(work_id=7, fn=len, args=((1,),), kwargs={}),
+                state,
+                responses,
+            )
+            self.assertFalse(state.shutdown)
+            self.assertTrue(state.cancelling)
+            self.assertEqual(0, len(state.pending))
+
+            msg = responses.get(timeout=TIMEOUT)
+            self.assertIsInstance(msg, _response.Cancelled)
+            self.assertEqual(7, msg.work_id)
+        finally:
+            responses.close_put()
+            responses.close_get()
 
     def test_submit_removes_future_on_put_failure(self) -> None:
         """A future registered in _futures is removed if put() fails.

--- a/test/test_executor_lifecycle.py
+++ b/test/test_executor_lifecycle.py
@@ -31,7 +31,7 @@ from jobserver import (
     _request,
     _response,
 )
-from jobserver._executor import _handle_request
+from jobserver._executor import _DispatchState, _handle_request
 from jobserver._queue import MinimalQueue
 
 from .helpers import (
@@ -165,15 +165,19 @@ class TestSelectiveCancel(unittest.TestCase):
     def test_selective_cancel_removes_only_target(self) -> None:
         """Cancel(work_id=X) removes only X from pending."""
         with MinimalQueue() as responses:
-            pending = deque(
-                [
-                    _request.Submit(1, len, ((),), {}),
-                    _request.Submit(2, len, ((),), {}),
-                    _request.Submit(3, len, ((),), {}),
-                ]
+            state = _DispatchState(
+                pending=deque(
+                    [
+                        _request.Submit(1, len, ((),), {}),
+                        _request.Submit(2, len, ((),), {}),
+                        _request.Submit(3, len, ((),), {}),
+                    ]
+                )
             )
-            _handle_request(_request.Cancel(work_id=2), pending, responses)
-            self.assertEqual([1, 3], [s.work_id for s in pending])
+            _handle_request(_request.Cancel(work_id=2), state, responses)
+            # A targeted Cancel(work_id=X) does not latch the cancelling state.
+            self.assertFalse(state.cancelling)
+            self.assertEqual([1, 3], [s.work_id for s in state.pending])
             msg = responses.get(timeout=1)
             self.assertIsInstance(msg, _response.Cancelled)
             self.assertEqual(2, msg.work_id)
@@ -181,14 +185,18 @@ class TestSelectiveCancel(unittest.TestCase):
     def test_bulk_cancel_removes_all(self) -> None:
         """Cancel(work_id=None) removes everything."""
         with MinimalQueue() as responses:
-            pending = deque(
-                [
-                    _request.Submit(1, len, ((),), {}),
-                    _request.Submit(2, len, ((),), {}),
-                ]
+            state = _DispatchState(
+                pending=deque(
+                    [
+                        _request.Submit(1, len, ((),), {}),
+                        _request.Submit(2, len, ((),), {}),
+                    ]
+                )
             )
-            _handle_request(_request.Cancel(), pending, responses)
-            self.assertEqual(0, len(pending))
+            _handle_request(_request.Cancel(), state, responses)
+            # A blanket Cancel() latches cancelling for later Submits.
+            self.assertTrue(state.cancelling)
+            self.assertEqual(0, len(state.pending))
             ids = {
                 responses.get(timeout=1).work_id,
                 responses.get(timeout=1).work_id,


### PR DESCRIPTION
## Summary

Fixes #191: a `submit()` running concurrently with `shutdown(cancel_futures=True)` could land its `Submit` on the request pipe after the blanket `Cancel()`, so the work survived cancellation and was dispatched — violating the caller's `cancel_futures=True` expectation.

The fix lives in the **dispatcher**, not by holding a lock across IPC. When the dispatcher sees the blanket `Cancel()` that only `shutdown(cancel_futures=True)` ever sends, it latches a `cancelling` flag; while latched, any `Submit` that arrives is **cancelled on arrival** instead of being queued and dispatched. So a racing submit's future is cancelled, never run. `submit()`/`shutdown()` keep their lock-free puts, so no lock is ever held across a blocking `put()`.

## Why this approach

The obvious alternative — hold the lock across `submit()`'s and `shutdown()`'s puts to order them — couples the lock to `put()` latency and, under a burst of submits, **deadlocks**: a `put()` blocked on a full request pipe holds the lock the receiver needs to drain responses, so the dispatcher stalls and the pipe never drains. Fixing the race dispatcher-side avoids that entirely.

## Also included (tidying)

- **`_DispatchState` dataclass** — the dispatcher loop's `pending`/`running`/`cancelling`/`shutdown` are now one object passed by reference and mutated in place, replacing the `(shutdown, cancelling)` tuple returns threaded through the request handlers.
- **Smaller `submit()` critical section** — the `Future` is constructed and its cancel observer registered outside `_lock`; only the broken/shutdown gate and `work_id` registration remain under the lock.

## Testing

- New unit tests for the latch (`Submit` after a blanket `Cancel()` is cancelled on arrival), updated for the `_DispatchState` signatures.
- Full `./ci` passes: 218 unit tests, all examples, ruff, mypy, black, and sdist build.
- Separately verified that a 3,000-task burst-submit workload — which deadlocks the lock-coupled alternative — completes cleanly here.

https://claude.ai/code/session_018357HLzvJ7RZgrj9JHWVmf

---
_Generated by [Claude Code](https://claude.ai/code/session_018357HLzvJ7RZgrj9JHWVmf)_