### PR TITLE
Clean up partial JobserverExecutor init on startup failure

### DIFF
--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -65,6 +65,10 @@ class JobserverExecutor(concurrent.futures.Executor):
         if jobserver is None:
             jobserver = Jobserver()
 
+        # Bind early so _abort_startup can release it; also outlives the
+        # dispatcher Process, which drops _args after start() in 3.11+.
+        self._jobserver = jobserver
+
         self._requests: MinimalQueue = MinimalQueue(jobserver.context)
         self._responses: MinimalQueue = MinimalQueue(jobserver.context)
 
@@ -74,22 +78,36 @@ class JobserverExecutor(concurrent.futures.Executor):
             daemon=False,
             name="JobserverExecutor-dispatcher",
         )
-        self._dispatcher.start()
-
-        # Close before receiver so EOF propagates if receiver fails to start.
-        self._requests.close_get()
-        self._responses.close_put()
-
         self._receiver = threading.Thread(
             target=self._receive_loop,
             daemon=True,
             name="JobserverExecutor-receiver",
         )
-        self._receiver.start()
 
-        # Keep a reference so the Jobserver (and its slot semaphores) outlives
-        # the dispatcher Process, which drops _args after start() in 3.11+.
-        self._jobserver = jobserver
+        try:
+            self._dispatcher.start()
+
+            # Close before receiver so EOF propagates if receiver fails to
+            # start.
+            self._requests.close_get()
+            self._responses.close_put()
+
+            self._receiver.start()
+        except BaseException:
+            # A failed dispatcher or receiver start tears down whatever
+            # started so __init__ never orphans a dispatcher nor leaks an
+            # owned Jobserver.  No work is in flight and the receiver never
+            # started, so terminate() suffices and each step tolerates the
+            # thing it cleans up not having run.
+            if self._dispatcher.pid is not None:
+                self._dispatcher.terminate()
+                self._dispatcher.join()
+            self._requests.close_put()
+            self._responses.close_get()
+            if self._own_jobserver:
+                self._own_jobserver = False
+                self._jobserver.__exit__(None, None, None)
+            raise
 
         _LOG.debug(
             "Executor started (dispatcher pid=%d)",

--- a/test/test_executor_lifecycle.py
+++ b/test/test_executor_lifecycle.py
@@ -23,6 +23,7 @@ import time
 import unittest
 import weakref
 from collections import deque
+from unittest import mock
 
 from jobserver import (
     Jobserver,
@@ -583,6 +584,60 @@ class TestReceiverGuard(unittest.TestCase):
         exe = _StubExecutor(_RaisingResponses(RuntimeError()))
         exe._broken = RuntimeError("x")
         self.assertIn("broken", repr(exe))
+
+
+def _fail_receiver_start(boom: BaseException):
+    """Patch threading.Thread.start to raise only for the receiver thread."""
+    original = threading.Thread.start
+
+    def start(self: threading.Thread) -> None:
+        if self.name == "JobserverExecutor-receiver":
+            raise boom
+        original(self)
+
+    return start
+
+
+class TestStartupFailure(unittest.TestCase):
+    """Partial __init__ failure must not orphan the dispatcher (#220)."""
+
+    def _wait_for_baseline(self, baseline: int) -> None:
+        deadline = time.monotonic() + TIMEOUT
+        while (
+            len(multiprocessing.active_children()) > baseline
+            and time.monotonic() < deadline
+        ):
+            time.sleep(0.02)
+        self.assertEqual(baseline, len(multiprocessing.active_children()))
+
+    def test_receiver_start_failure_tears_down_owned(self) -> None:
+        """A failed receiver start stops the dispatcher; nothing leaks."""
+        baseline = len(multiprocessing.active_children())
+        boom = RuntimeError("can't start new thread")
+        with mock.patch.object(
+            threading.Thread, "start", _fail_receiver_start(boom)
+        ):
+            with self.assertRaises(RuntimeError) as cm:
+                JobserverExecutor()
+        # The original failure propagates, not a cleanup error.
+        self.assertIs(cm.exception, boom)
+        # The dispatcher that did start must have been reaped.
+        self._wait_for_baseline(baseline)
+
+    def test_receiver_start_failure_keeps_external_jobserver(self) -> None:
+        """Cleanup of a partial init leaves a caller-owned Jobserver open."""
+        boom = RuntimeError("can't start new thread")
+        with Jobserver(context=FAST, slots=2) as js:
+            baseline = len(multiprocessing.active_children())
+            with mock.patch.object(
+                threading.Thread, "start", _fail_receiver_start(boom)
+            ):
+                with self.assertRaises(RuntimeError):
+                    JobserverExecutor(js)
+            self._wait_for_baseline(baseline)
+            # The external Jobserver was not closed by cleanup: still usable.
+            f = js.submit(fn=len, args=((1, 2, 3),))
+            self.assertEqual(3, f.result(timeout=TIMEOUT))
 
 
 class TestOwnedJobserver(unittest.TestCase):


### PR DESCRIPTION
If the dispatcher process started but the receiver thread failed to
start (e.g. OS thread exhaustion), `__init__` left the dispatcher running
with no one to drive it, orphaning it (and any owned Jobserver's slot
semaphores) until interpreter exit.

Wrap the start sequence in a `try/except` that, on any partial failure,
calls `_abort_startup`: terminate a started dispatcher, close the queues,
and release an owned Jobserver. A caller-supplied Jobserver is left open.

Since no work is in flight at init time and the half-built executor is
never handed to the caller, cleanup needs neither a graceful drain nor
lock-guarded state — `terminate()` is sufficient.

Tests patch `Thread.start` to fail only the receiver and assert the
dispatcher returns to baseline for both owned and caller-supplied
Jobservers (the latter staying usable).

Fixes #220.