### PR TITLE
Clarify SIGPIPE handler usage in ignore_sigpipe docstring

### DIFF
--- a/src/jobserver/_compat.py
+++ b/src/jobserver/_compat.py
@@ -12,7 +12,9 @@ import signal
 def ignore_sigpipe() -> None:
     """Ignore SIGPIPE so broken pipes raise BrokenPipeError.
 
-    CPython does this at startup; PyPy does not.
+    CPython does this at startup; PyPy does not. Called only in child
+    workers and the dispatcher, never the user's main process; a child's
+    preexec_fn may reinstall a different SIGPIPE handler if desired.
     """
     if hasattr(signal, "SIGPIPE"):
         signal.signal(signal.SIGPIPE, signal.SIG_IGN)


### PR DESCRIPTION
## Summary
Updated the docstring for `ignore_sigpipe()` to clarify when and where the SIGPIPE handler is applied, and to document that child processes can override it if needed.

## Changes
- Expanded the docstring to specify that `ignore_sigpipe()` is called only in child workers and the dispatcher, never in the user's main process
- Added documentation that child processes can reinstall a different SIGPIPE handler via `preexec_fn` if desired

## Details
This is a documentation-only change that improves clarity around the function's usage context and behavior. The change helps users understand the scope of the SIGPIPE handler installation and provides guidance on how to customize signal handling in child processes if needed.

https://claude.ai/code/session_01V4D4nuBQdKyGY98g6wW7FN