### PR TITLE
Report a registration seqno on CallbackRaised

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -75,7 +75,23 @@ class CallbackRaised(Exception):
     MUST re-invoke the same method until no CallbackRaised occurs.
     These MAY/MUST semantics allow the caller to decide how much additional
     processing to perform after seeing the 1st, 2nd, or Nth error.
+
+    The seqno member is the value Future.when_done(...) returned for the
+    callback registration, tying this exception back to that call.  The
+    first user-registered callback has seqno 0, the second has 1, etc.
     """
+
+    def __init__(self, seqno: int) -> None:
+        if not isinstance(seqno, int):
+            raise TypeError(f"seqno: int, got {type(seqno).__name__}")
+        super().__init__()
+        self.seqno = seqno
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}(seqno={self.seqno})"
+
+    # Exceptions need an explicit __str__; BaseException.__str__ ignores it.
+    __str__ = __repr__
 
 
 class SubmissionDied(Exception):
@@ -199,8 +215,12 @@ _PRIORITY_USER = 1
 _PRIORITY_CLEANUP = 2
 
 
-def _callback_wrapper(fn, *args, **kwargs) -> None:
-    """Call fn(*args, **kwargs) wrapping any Exception in CallbackRaised."""
+def _callback_wrapper(seqno: int, fn, *args, **kwargs) -> None:
+    """Call fn(*args, **kwargs) wrapping any Exception in CallbackRaised.
+
+    The seqno is the when_done(...) sequence number from registering fn
+    and is stamped on any CallbackRaised raised here.
+    """
     try:
         fn(*args, **kwargs)
     except Exception as e:
@@ -208,9 +228,10 @@ def _callback_wrapper(fn, *args, **kwargs) -> None:
         # triggers a nested _issue_callbacks(); without this
         # guard the caller sees CallbackRaised wrapping another
         # CallbackRaised instead of one layer around the cause.
+        # The inner CallbackRaised already carries its own seqno.
         if isinstance(e, CallbackRaised):
             raise
-        raise CallbackRaised() from e
+        raise CallbackRaised(seqno) from e
 
 
 class Future(Generic[T]):
@@ -250,7 +271,10 @@ class Future(Generic[T]):
         # (priority, callback_seqno, ...) so token restoration fires before
         # user callbacks, which fire before sentinel cleanup.
         self._callbacks: list[tuple] = []
-        self._callback_seqno = 0  # Monotonic needed due to reentrancy
+        # Monotonic seqno needed due to reentrancy.  Starting at -3 lets the
+        # three internal registrations submit() makes (token restoration plus
+        # sentinel and connection cleanup) consume -3, -2, -1 so user 0-based.
+        self._callback_seqno = -3
 
     def __repr__(self) -> str:
         with self._rlock:
@@ -285,7 +309,7 @@ class Future(Generic[T]):
                 source=self,
             )
 
-    def when_done(self, fn: Callable, *args: Any, **kwargs: Any) -> None:
+    def when_done(self, fn: Callable, *args: Any, **kwargs: Any) -> int:
         """
         Register fn(*args, **kwargs) for execution after Future.done(...).
 
@@ -293,13 +317,21 @@ class Future(Generic[T]):
         The Future is not automatically passed; to receive it, bind it
         explicitly via args, e.g. future.when_done(cb, future).
         May raise CallbackRaised from at most this new callback.
+
+        Returns a seqno identifying this registration.  Should fn raise,
+        the resulting CallbackRaised reports it via CallbackRaised.seqno.
         """
-        self._when_done(
-            fn=functools.partial(_callback_wrapper, fn),
-            args=args,
-            kwargs=kwargs,
-            priority=_PRIORITY_USER,
-        )
+        # _when_done assigns and returns the seqno under the same lock.
+        # self._callback_seqno is an int, so the partial curries a copy.
+        with self._rlock:
+            return self._when_done(
+                fn=functools.partial(
+                    _callback_wrapper, self._callback_seqno, fn
+                ),
+                args=args,
+                kwargs=kwargs,
+                priority=_PRIORITY_USER,
+            )
 
     def _when_done(
         self,
@@ -307,14 +339,15 @@ class Future(Generic[T]):
         priority: int,
         args: tuple[Any, ...] = (),
         kwargs: Optional[Mapping[str, Any]] = None,
-    ) -> None:
-        """Internal method for registering a callback with some priority."""
+    ) -> int:
+        """Register a callback with some priority, returning its seqno."""
         with self._rlock:
+            seqno = self._callback_seqno
             heapq.heappush(
                 self._callbacks,
                 (
                     priority,
-                    self._callback_seqno,
+                    seqno,
                     fn,
                     args,
                     {} if kwargs is None else kwargs,
@@ -323,6 +356,7 @@ class Future(Generic[T]):
             self._callback_seqno += 1
             if self._connection is None:
                 self._issue_callbacks()
+            return seqno
 
     def done(self, timeout: Optional[float] = 0) -> bool:
         """

--- a/test/test_jobserver_callbacks.py
+++ b/test/test_jobserver_callbacks.py
@@ -107,6 +107,72 @@ class TestJobserverCallbacks(unittest.TestCase):
             self.assertTrue(f.done())
             self.assertEqual(f.result(), 1)
 
+    def test_when_done_returns_monotonic_seqno(self) -> None:
+        """when_done() returns 0, 1, 2, ... for successive user callbacks."""
+        with Jobserver(context=FAST, slots=1) as js:
+            f = js.submit(fn=len, args=((1,),), timeout=5)
+            seqnos = [
+                f.when_done(helper_callback, [0], 0, 1) for _ in range(5)
+            ]
+            # The first user callback sees 0, then 1, 2, ... regardless of
+            # the internal callbacks submit() registers beforehand.
+            self.assertEqual(seqnos, list(range(5)))
+            f.wait(timeout=5)
+
+    def test_callback_raised_carries_seqno(self) -> None:
+        """CallbackRaised.seqno identifies the offending registration."""
+        with Jobserver(context=FAST, slots=1) as js:
+            f = js.submit(fn=len, args=((1,),), timeout=5)
+            s0 = f.when_done(helper_raise, ArithmeticError, "0")
+            s1 = f.when_done(helper_raise, ZeroDivisionError, "1")
+            self.assertEqual([s0, s1], [0, 1])
+
+            with self.assertRaises(CallbackRaised) as c:
+                f.wait(timeout=5)
+            self.assertIsInstance(c.exception.__cause__, ArithmeticError)
+            self.assertEqual(c.exception.seqno, 0)
+            self.assertEqual(repr(c.exception), "CallbackRaised(seqno=0)")
+            self.assertEqual(str(c.exception), "CallbackRaised(seqno=0)")
+
+            with self.assertRaises(CallbackRaised) as c:
+                f.wait(timeout=5)
+            self.assertIsInstance(c.exception.__cause__, ZeroDivisionError)
+            self.assertEqual(c.exception.seqno, 1)
+            self.assertEqual(repr(c.exception), "CallbackRaised(seqno=1)")
+            self.assertEqual(str(c.exception), "CallbackRaised(seqno=1)")
+
+            self.assertTrue(f.wait(timeout=5))
+
+    def test_callback_raised_repr_str_and_seqno_type(self) -> None:
+        """CallbackRaised repr/str show the seqno; seqno must be an int."""
+        # repr and str are identical and expose the seqno.
+        e = CallbackRaised(7)
+        self.assertEqual(repr(e), "CallbackRaised(seqno=7)")
+        self.assertEqual(str(e), repr(e))
+        # seqno is required and must be an int.
+        with self.assertRaises(TypeError):
+            CallbackRaised()  # type: ignore[call-arg]
+        with self.assertRaises(TypeError):
+            CallbackRaised("7")  # type: ignore[arg-type]
+
+    def test_already_done_callback_raised_carries_seqno(self) -> None:
+        """A raising callback registered post-completion reports its seqno."""
+        with Jobserver(context=FAST, slots=1) as js:
+            f = js.submit(fn=len, args=((1,),), timeout=5)
+            f.wait(timeout=5)
+            # Registering on an already-done Future fires immediately and
+            # raises out of when_done() itself before it can return a seqno;
+            # the CallbackRaised still carries the registration's seqno.
+            # The first user callback always sees seqno 0.
+            with self.assertRaises(CallbackRaised) as c:
+                f.when_done(helper_raise, UnicodeError, "now")
+            self.assertIsInstance(c.exception.__cause__, UnicodeError)
+            self.assertEqual(c.exception.seqno, 0)
+            # The next registration sees seqno 1.
+            with self.assertRaises(CallbackRaised) as c:
+                f.when_done(helper_raise, UnicodeError, "later")
+            self.assertEqual(c.exception.seqno, 1)
+
     def test_reentrant_when_done_nests_issue_callbacks(self) -> None:
         """Callbacks calling when_done() nest _issue_callbacks correctly.
 


### PR DESCRIPTION
## Summary

Implements the "names on callbacks" idea from #12 using the cheap, `inspect`-free seqno approach settled on in the issue discussion.

- `Future.when_done(...)` now **returns a per-Future seqno** identifying the registration: the first user callback is `0`, the second `1`, and so on.
- That seqno is curried into the callback wrapper, so when a callback raises, the resulting **`CallbackRaised` carries it via `CallbackRaised.seqno`** — letting callers tie a specific exception back to the exact `when_done(...)` that registered the offending callback.
- `CallbackRaised` takes a **required `int` seqno**, validates it, and renders as `CallbackRaised(seqno=N)` from both `repr` and `str`.

## Mechanics

- `_when_done` assigns and returns the seqno under the lock, so `when_done` curries `self._callback_seqno` (an immutable int copy) directly into the partial without a local variable.
- `Future._callback_seqno` starts at **`-3`** so `submit()`'s three internal bookkeeping registrations (token restoration + sentinel/connection cleanup) consume `-3, -2, -1`, keeping user callbacks 0-based. Negative seqnos still order correctly in the `(priority, seqno, ...)` callback heap.
- The behavior is documented on the `CallbackRaised` docstring and referenced from `Future.when_done(...)`.

## Tests

Added coverage in `test/test_jobserver_callbacks.py` for:
- successive user callbacks returning `0, 1, 2, ...`,
- `CallbackRaised.seqno` matching the returned seqno (including the already-done registration path),
- `repr`/`str` both rendering `CallbackRaised(seqno=N)`, and a required-int seqno.

## Verification

`./ci` passes end-to-end: 224 tests OK, `ruff` clean, `mypy` clean, `black` clean, examples run, sdist builds.

Closes #12


---
_Generated by [Claude Code](https://claude.ai/code/session_01244EMgY3nYAVvz8L1UBtN8)_