### PR TITLE
Make MinimalQueue.put single-item to close put atomicity race (#174)

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -596,7 +596,8 @@ class Jobserver:
         self._slots: MinimalQueue[int] = MinimalQueue(self._context)
 
         # Issue one token for each requested slot
-        self._slots.put(*range(slots))
+        for token in range(slots):
+            self._slots.put(token)
 
         # Tracks outstanding Futures via their process sentinels.
         self._selector = _initialize_selector(self._slots)

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -178,8 +178,8 @@ class MinimalQueue(Generic[T]):
         ):
             raise queue.Empty
         try:
-            # Check under the lock so a concurrent close_get() cannot null
-            # self._reader between the check and use; bind a local thereafter.
+            # Snapshot self._reader so a concurrent close_get() yields a clean
+            # ValueError here rather than a None-dereference at recv time.
             reader = self._reader
             if reader is None:
                 raise ValueError("MinimalQueue.get() after close_get()")
@@ -194,19 +194,18 @@ class MinimalQueue(Generic[T]):
         # Deserialize outside the critical section
         return ForkingPickler.loads(recv)
 
-    def put(self, *args: T) -> None:
+    def put(self, obj: T) -> None:
         """
-        Put zero or more objects into the queue, contiguously.
+        Put one object into the queue.
 
         Raises BrokenPipeError if the receiving half has hung up.
         """
         # Serialize outside the critical section
-        send = [ForkingPickler.dumps(arg) for arg in args]
+        bytez = ForkingPickler.dumps(obj)
         with self._write_lock:
-            # Check under the lock so a concurrent close_put() cannot null
-            # self._writer between the check and use; bind a local thereafter.
+            # Snapshot self._writer so a concurrent close_put() yields a clean
+            # ValueError here rather than a None-dereference at send time.
             writer = self._writer
             if writer is None:
                 raise ValueError("MinimalQueue.put() after close_put()")
-            for item in send:
-                writer.send_bytes(item)
+            writer.send_bytes(bytez)


### PR DESCRIPTION
Closes #174.

## Problem

`MinimalQueue.put(*args)` serialized all args and then sent them in a loop of `send_bytes` calls under the write lock. Each completed `send_bytes` is an independently-receivable frame, so a mid-loop `BrokenPipeError` could deliver some items and drop others — a partial-sequence hazard. For slot tokens this would mean token leakage. The only multi-arg caller was the single-threaded startup token seed, so the hazard was latent, but the `*args` interface invited multi-item use.

## Change

Narrow `put()` to a single object, removing the loop and the `*args` interface that invited the hazard. The partial-sequence race is now structurally impossible: one `put` is exactly one frame. Pickling still happens outside the lock.

- `MinimalQueue.put(*args)` → `MinimalQueue.put(obj)`; single `send_bytes(bytez)` under the lock.
- `Jobserver.__init__` now issues startup slot tokens one at a time via a `for` loop instead of `self._slots.put(*range(slots))`.

All other call sites already pass exactly one argument.

## Testing

`./ci` passes: unit tests OK, examples run, ruff/mypy/black clean, sdist builds.

https://claude.ai/code/session_011g1PjcgKuX6uGi6GqxWtjG

---
_Generated by [Claude Code](https://claude.ai/code/session_011g1PjcgKuX6uGi6GqxWtjG)_