### PR TITLE
Extract pickle error handling to shared constant

### DIFF
--- a/src/jobserver/_compat.py
+++ b/src/jobserver/_compat.py
@@ -9,12 +9,10 @@ import os
 import pickle
 import signal
 
-# Failures raised when ForkingPickler.dumps() (hence MinimalQueue.put())
-# cannot serialize a payload: pickle's own PicklingError, an AttributeError
-# when the payload names a locally-defined (unpicklable-by-name) class, and a
-# TypeError when an object is fundamentally unpicklable.  Both the worker's
-# _worker_entrypoint and the executor's _responses_put_failed classify dump
-# failures with this same tuple so their fallbacks stay aligned.
+# Failures from pickling a payload for a queue: PicklingError, an
+# AttributeError for a locally-defined (unpicklable-by-name) class, or a
+# TypeError for a fundamentally unpicklable object.  Shared so the worker
+# and executor fallbacks classify dump failures identically.
 PICKLE_DUMP_ERRORS = (pickle.PicklingError, AttributeError, TypeError)
 
 

--- a/src/jobserver/_compat.py
+++ b/src/jobserver/_compat.py
@@ -6,7 +6,16 @@
 """Portability across interpreters and platforms."""
 
 import os
+import pickle
 import signal
+
+# Failures raised when ForkingPickler.dumps() (hence MinimalQueue.put())
+# cannot serialize a payload: pickle's own PicklingError, an AttributeError
+# when the payload names a locally-defined (unpicklable-by-name) class, and a
+# TypeError when an object is fundamentally unpicklable.  Both the worker's
+# _worker_entrypoint and the executor's _responses_put_failed classify dump
+# failures with this same tuple so their fallbacks stay aligned.
+PICKLE_DUMP_ERRORS = (pickle.PicklingError, AttributeError, TypeError)
 
 
 def ignore_sigpipe() -> None:

--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -526,9 +526,6 @@ def _responses_put_failed(
     tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
     try:
         responses.put(failed)
-    # A locally-defined exception class raises AttributeError and an
-    # unpicklable payload TypeError, so both join PicklingError here; aligns
-    # with _jobserver.py's _worker_entrypoint pickle-failure classification.
     except PICKLE_DUMP_ERRORS:
         responses.put(
             _response.Failed(

--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -20,14 +20,14 @@ from multiprocessing.connection import Connection, wait
 from typing import Any, Optional, TypeVar, Union
 
 from . import _request, _response
-from ._compat import ignore_sigpipe
+from ._compat import PICKLE_DUMP_ERRORS, ignore_sigpipe
 from ._jobserver import (
     Blocked,
     CallbackRaised,
     Future,
     Jobserver,
 )
-from ._queue import PICKLE_DUMP_ERRORS, MinimalQueue
+from ._queue import MinimalQueue
 
 __all__ = ("JobserverExecutor",)
 
@@ -526,10 +526,9 @@ def _responses_put_failed(
     tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
     try:
         responses.put(failed)
-    # Shared classification: a locally-defined exception class raises
-    # AttributeError, an unpicklable payload TypeError, and pickle itself
-    # PicklingError; see PICKLE_DUMP_ERRORS.  Keeps this fallback aligned
-    # with _jobserver.py's _worker_entrypoint.
+    # A locally-defined exception class raises AttributeError and an
+    # unpicklable payload TypeError, so both join PicklingError here; aligns
+    # with _jobserver.py's _worker_entrypoint pickle-failure classification.
     except PICKLE_DUMP_ERRORS:
         responses.put(
             _response.Failed(

--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -9,7 +9,6 @@ import concurrent.futures
 import functools
 import itertools
 import logging
-import pickle
 import queue
 import threading
 import traceback
@@ -28,7 +27,7 @@ from ._jobserver import (
     Future,
     Jobserver,
 )
-from ._queue import MinimalQueue
+from ._queue import PICKLE_DUMP_ERRORS, MinimalQueue
 
 __all__ = ("JobserverExecutor",)
 
@@ -527,10 +526,11 @@ def _responses_put_failed(
     tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
     try:
         responses.put(failed)
-    # A locally-defined exception class raises AttributeError and an
-    # unpicklable payload TypeError, so both join PicklingError here; aligns
-    # with _jobserver.py's _worker_entrypoint pickle-failure classification.
-    except (pickle.PicklingError, AttributeError, TypeError):
+    # Shared classification: a locally-defined exception class raises
+    # AttributeError, an unpicklable payload TypeError, and pickle itself
+    # PicklingError; see PICKLE_DUMP_ERRORS.  Keeps this fallback aligned
+    # with _jobserver.py's _worker_entrypoint.
+    except PICKLE_DUMP_ERRORS:
         responses.put(
             _response.Failed(
                 work_id=work_id,

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -10,7 +10,6 @@ import concurrent.futures
 import functools
 import heapq
 import os
-import pickle
 import queue
 import signal
 import threading
@@ -33,6 +32,7 @@ from typing import Any, Generic, NoReturn, Optional, TypeVar, Union, cast
 
 from ._compat import ignore_sigpipe, sched_getaffinity0
 from ._queue import (
+    PICKLE_DUMP_ERRORS,
     MinimalQueue,
     deadline_to_timeout,
     resolve_context,
@@ -1062,7 +1062,7 @@ def _worker_entrypoint(send, env, preexec_fn, fn, *args, **kwargs) -> None:
             if result is not None:
                 try:
                     payload = ForkingPickler.dumps(result)
-                except (pickle.PicklingError, AttributeError, TypeError) as pe:
+                except PICKLE_DUMP_ERRORS as pe:
                     payload = ForkingPickler.dumps(
                         ExceptionWrapper(
                             RuntimeError(

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -30,9 +30,12 @@ from multiprocessing.reduction import ForkingPickler
 from selectors import EVENT_READ, DefaultSelector
 from typing import Any, Generic, NoReturn, Optional, TypeVar, Union, cast
 
-from ._compat import ignore_sigpipe, sched_getaffinity0
-from ._queue import (
+from ._compat import (
     PICKLE_DUMP_ERRORS,
+    ignore_sigpipe,
+    sched_getaffinity0,
+)
+from ._queue import (
     MinimalQueue,
     deadline_to_timeout,
     resolve_context,

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -55,6 +55,13 @@ PreexecFn = Callable[[], Union[None, AbstractContextManager]]
 # sleep_fn returns None when work is acceptable or a non-negative
 # number of seconds for which the process should sleep before retrying.
 SleepFn = Callable[[], Optional[float]]
+# env may be a Mapping of names to values (None unsets the name) or an
+# iterable of such pairs.  Where a submission overrides an instance default,
+# Optional[EnvItems] additionally permits None to mean "use the default".
+EnvItems = Union[
+    Mapping[str, Optional[str]],
+    Iterable[tuple[str, Optional[str]]],
+]
 
 
 class Blocked(Exception):
@@ -565,10 +572,7 @@ class Jobserver:
         context: Union[None, str, BaseContext] = None,
         slots: Optional[int] = None,
         *,
-        env: Union[
-            Mapping[str, Optional[str]],
-            Iterable[tuple[str, Optional[str]]],
-        ] = (),
+        env: EnvItems = (),
         preexec_fn: Optional[PreexecFn] = None,
         sleep_fn: Optional[SleepFn] = None,
     ) -> None:
@@ -764,11 +768,7 @@ class Jobserver:
         args: Iterable = (),
         kwargs: Mapping[str, Any] = types.MappingProxyType({}),
         consume: int = 1,
-        env: Union[
-            None,
-            Mapping[str, Optional[str]],
-            Iterable[tuple[str, Optional[str]]],
-        ] = None,
+        env: Optional[EnvItems] = None,
         preexec_fn: Optional[PreexecFn] = None,  # None: use default
         sleep_fn: Optional[SleepFn] = None,  # None: use default
         timeout: Optional[float] = None,
@@ -936,11 +936,7 @@ class Jobserver:
         argses: Optional[Iterable[Iterable]] = None,
         kwargses: Optional[Iterable[Mapping[str, Any]]] = None,
         *,
-        env: Union[
-            None,
-            Mapping[str, Optional[str]],
-            Iterable[tuple[str, Optional[str]]],
-        ] = None,
+        env: Optional[EnvItems] = None,
         preexec_fn: Optional[PreexecFn] = None,  # None: use default
         sleep_fn: Optional[SleepFn] = None,  # None: use default
         timeout: Optional[float] = None,
@@ -1085,10 +1081,7 @@ def _worker_entrypoint(send, env, preexec_fn, fn, *args, **kwargs) -> None:
 
 
 def _env_coerce(
-    env: Union[
-        Mapping[str, Optional[str]],
-        Iterable[tuple[str, Optional[str]]],
-    ],
+    env: EnvItems,
 ) -> dict[str, Optional[str]]:
     """Convert env to a dict, validating key/value types."""
     result = dict(env.items() if isinstance(env, Mapping) else env)
@@ -1246,11 +1239,7 @@ def _map_generate(
     chunksize: int,
     buffersize: int,
     deadline: float,
-    env: Union[
-        None,
-        Mapping[str, Optional[str]],
-        Iterable[tuple[str, Optional[str]]],
-    ] = None,
+    env: Optional[EnvItems] = None,
     preexec_fn: Optional[PreexecFn] = None,
     sleep_fn: Optional[SleepFn] = None,
 ) -> Iterator[T]:

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -5,7 +5,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """MinimalQueue and related utility functions."""
 
-import pickle
 import queue
 import threading
 import time
@@ -22,18 +21,9 @@ __all__ = (
     "timeout_to_deadline",
     "deadline_to_timeout",
     "resolve_context",
-    "PICKLE_DUMP_ERRORS",
 )
 
 T = TypeVar("T")
-
-# Failures raised when ForkingPickler.dumps() (hence MinimalQueue.put())
-# cannot serialize a payload: pickle's own PicklingError, an AttributeError
-# when the payload names a locally-defined (unpicklable-by-name) class, and a
-# TypeError when an object is fundamentally unpicklable.  Both the worker's
-# _worker_entrypoint and the executor's _responses_put_failed classify dump
-# failures with this same tuple so their fallbacks stay aligned.
-PICKLE_DUMP_ERRORS = (pickle.PicklingError, AttributeError, TypeError)
 
 # Maximum seconds safely passable to poll() without overflow.  poll(2) on
 # Linux takes timeout in milliseconds as a signed 32-bit int, so the ceiling

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """MinimalQueue and related utility functions."""
 
+import pickle
 import queue
 import threading
 import time
@@ -21,9 +22,18 @@ __all__ = (
     "timeout_to_deadline",
     "deadline_to_timeout",
     "resolve_context",
+    "PICKLE_DUMP_ERRORS",
 )
 
 T = TypeVar("T")
+
+# Failures raised when ForkingPickler.dumps() (hence MinimalQueue.put())
+# cannot serialize a payload: pickle's own PicklingError, an AttributeError
+# when the payload names a locally-defined (unpicklable-by-name) class, and a
+# TypeError when an object is fundamentally unpicklable.  Both the worker's
+# _worker_entrypoint and the executor's _responses_put_failed classify dump
+# failures with this same tuple so their fallbacks stay aligned.
+PICKLE_DUMP_ERRORS = (pickle.PicklingError, AttributeError, TypeError)
 
 # Maximum seconds safely passable to poll() without overflow.  poll(2) on
 # Linux takes timeout in milliseconds as a signed 32-bit int, so the ceiling


### PR DESCRIPTION
## Summary
Refactored pickle error handling to use a shared constant across modules, improving code maintainability and consistency.

## Key Changes
- Created `PICKLE_DUMP_ERRORS` constant in `_compat.py` to centralize the tuple of exceptions that can be raised during pickle serialization: `(pickle.PicklingError, AttributeError, TypeError)`
- Updated `_jobserver.py` and `_executor.py` to import and use this constant instead of duplicating the exception tuple
- Introduced `EnvItems` type alias in `_jobserver.py` to reduce repetition of the environment variable type annotation across multiple function signatures
- Removed redundant `import pickle` statements from `_jobserver.py` and `_executor.py` (now only imported in `_compat.py`)

## Implementation Details
- The `PICKLE_DUMP_ERRORS` constant captures three distinct failure modes:
  - `pickle.PicklingError`: Standard pickling failures
  - `AttributeError`: Raised when attempting to pickle locally-defined (unpicklable-by-name) classes
  - `TypeError`: Raised for fundamentally unpicklable objects
- The `EnvItems` type alias simplifies function signatures in `__init__`, `submit`, `map`, and `_map_generate` methods
- This change ensures consistent error classification between worker and executor fallback paths

https://claude.ai/code/session_01WNNttsDF53WnC6zaqgmqba