### PR TITLE
Rebuild selector after fork to avoid inherited sibling Futures

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -525,17 +525,6 @@ def _unregister_connection(
     connection.close()
 
 
-def _initialize_selector(slots: MinimalQueue) -> DefaultSelector:
-    """Create a selector with slots pre-registered."""
-    selector = DefaultSelector()
-    selector.register(
-        slots.waitable(),
-        EVENT_READ,
-        data=types.SimpleNamespace(done=noop),
-    )
-    return selector
-
-
 class Jobserver:
     """A Jobserver exposing a Future interface built atop multiprocessing.
 
@@ -555,6 +544,7 @@ class Jobserver:
         "_context",
         "_slots",
         "_selector",
+        "_selector_pid",
         "_env",
         "_preexec_fn",
         "_sleep_fn",
@@ -599,8 +589,11 @@ class Jobserver:
         for token in range(slots):
             self._slots.put(token)
 
-        # Tracks outstanding Futures via their process sentinels.
-        self._selector = _initialize_selector(self._slots)
+        # Tracks outstanding Futures via their process sentinels.  Built
+        # lazily by _lazy_selector(); None means "not yet built" and
+        # _selector_pid stamps the building process so forks rebuild it.
+        self._selector: Optional[DefaultSelector] = None
+        self._selector_pid: Optional[int] = None
 
         # Instance-level defaults for submit(...)
         # Defensive copy: consume any one-shot iterable and guard against
@@ -652,9 +645,11 @@ class Jobserver:
         if hasattr(self, "_slots"):
             self._slots.close_put()
             self._slots.close_get()
-        # Matches the cleanup in __exit__.
-        if hasattr(self, "_selector"):
-            self._selector.close()
+        # Matches the cleanup in __exit__.  Tolerates a missing slot
+        # (partial construction) and None (never built lazily).
+        selector = getattr(self, "_selector", None)
+        if selector is not None:
+            selector.close()
 
     def __enter__(self) -> "Jobserver":
         return self
@@ -683,7 +678,10 @@ class Jobserver:
         self._slots.close_put()
         self._slots.close_get()
         # Release the selector's underlying fd and all registrations.
-        self._selector.close()
+        # reclaim_resources() above built it via _lazy_selector(); guard
+        # None for symmetry with __del__ should that ever not hold.
+        if self._selector is not None:
+            self._selector.close()
 
     def __getstate__(self) -> tuple:
         """Get instance state without exposing in-flight Futures.
@@ -711,7 +709,10 @@ class Jobserver:
             self._preexec_fn,
             self._sleep_fn,
         ) = state
-        self._selector = _initialize_selector(self._slots)
+        # Defer selector construction to first use, exactly like __init__.
+        # A pickled child thus takes the same lazy path as a forked child.
+        self._selector = None
+        self._selector_pid = None
 
     # Use typing.Self once Python 3.11 is the minimum version
     def __copy__(self) -> "Jobserver":
@@ -737,6 +738,26 @@ class Jobserver:
         """Return the multiprocessing context used by this Jobserver."""
         return self._context
 
+    def _lazy_selector(self) -> DefaultSelector:
+        """Create-or-return the selector for the current process.
+
+        Built on first use (None), rebuilt after a fork (pid change): a
+        child reusing an ancestor's selector would join()/is_alive() the
+        ancestor's Futures and share its epoll set, so it is discarded.
+        """
+        if self._selector is None or self._selector_pid != os.getpid():
+            # Pre-register the slots waitable so the obtain-token loop and
+            # reclaim share one persistent interest set (a noop done() keeps
+            # it indistinguishable from a Future entry during select()).
+            self._selector = DefaultSelector()
+            self._selector.register(
+                self._slots.waitable(),
+                EVENT_READ,
+                data=types.SimpleNamespace(done=noop),
+            )
+            self._selector_pid = os.getpid()
+        return self._selector
+
     def reclaim_resources(self) -> None:
         """
         Reclaim resources for any completed submissions and issue callbacks.
@@ -753,7 +774,7 @@ class Jobserver:
         # O(N) rebuild occurs on each call.  select(timeout=0) is
         # a non-blocking poll returning only the k ready entries.
         # done() triggers callbacks mutating the selector.
-        for key, _ in self._selector.select(timeout=0):
+        for key, _ in self._lazy_selector().select(timeout=0):
             assert hasattr(key.data, "done"), type(key.data)
             key.data.done()
 
@@ -849,11 +870,12 @@ class Jobserver:
         # ASIDE: If another design is desired, instead of reclaim_resources
         # any other method could be injected below.  Notice that the
         # callback priority mechanism does permit issuing callback subsets.
+        selector = self._lazy_selector()
         token = _maybe_obtain_token(
             consume=consume,
             deadline=timeout_to_deadline(timeout),
             reclaim_tokens_fn=self.reclaim_resources,
-            selector=self._selector,
+            selector=selector,
             sleep_fn=sleep_fn,
             slots=self._slots,
         )
@@ -879,16 +901,16 @@ class Jobserver:
             # Register both the connection and the sentinel for O(k) polling.
             # Observing the connection reclaims a Future whose result is ready
             # while its child stays blocked mid-send() and thus unexited.
-            self._selector.register(recv, EVENT_READ, data=future)
-            self._selector.register(process.sentinel, EVENT_READ, data=future)
+            selector.register(recv, EVENT_READ, data=future)
+            selector.register(process.sentinel, EVENT_READ, data=future)
         except Exception:
             # Undo any registration that succeeded before the failure.
             # The connection registers first, so cleanup it first too.
             try:
                 if recv is not None:
-                    self._selector.unregister(recv)
+                    selector.unregister(recv)
                 if process is not None:
-                    self._selector.unregister(process.sentinel)
+                    selector.unregister(process.sentinel)
             except (KeyError, ValueError):
                 pass  # Never registered or never started
             # Close pipe fds to avoid leaking until garbage collection
@@ -914,7 +936,7 @@ class Jobserver:
         # holding a reference until this last-priority callback fires.
         future._when_done(
             fn=_unregister_sentinel,
-            args=(self._selector, process.sentinel, process),
+            args=(selector, process.sentinel, process),
             priority=_PRIORITY_CLEANUP,
         )
 
@@ -923,7 +945,7 @@ class Jobserver:
         # reused by a concurrent submit() before removal from the selector.
         future._when_done(
             fn=_unregister_connection,
-            args=(self._selector, recv),
+            args=(selector, recv),
             priority=_PRIORITY_CLEANUP,
         )
 
@@ -1160,10 +1182,9 @@ def _maybe_obtain_token(
                 raise Blocked() from None
 
             # (6) ...then block until some interesting event.
-            # O(k) via the persistent selector:
-            # _initialize_selector() places slots.waitable() once
-            # so only one epoll_wait
-            # is needed here.  No rebuilding of the interest set.
+            # O(k) via the persistent selector: _lazy_selector() places
+            # slots.waitable() once so only one epoll_wait is needed here.
+            # No rebuilding of the interest set.
             keys_events = selector.select(timeout=deadline - monotonic)
 
             # (7) A sentinel wakeup normally means a child exited and the next

--- a/test/test_design_fork_selector.py
+++ b/test/test_design_fork_selector.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Forked children must not inherit the parent's selector (issue #296).
+
+Under spawn/forkserver a Jobserver is pickled into each child, so
+__setstate__ rebuilds a fresh per-process selector.  Under fork no
+pickling occurs: a worker inherits the parent's Jobserver as a memory
+copy, so without intervention it keeps the parent's selector, including
+sibling Futures whose Process objects belong to an ancestor.
+
+A worker performing nested fan-out (submitting a second child while a
+first sibling is still registered) then calls reclaim_resources() on
+entry to submit().  If an inherited sibling's sentinel fd is ready, the
+worker would join()/is_alive() a process it never created, raising
+"can only join a child process".  The Jobserver instead rebuilds a
+clean selector when it first observes a pid change.
+"""
+
+import time
+import unittest
+from multiprocessing import get_all_start_methods
+
+from jobserver import Jobserver
+
+
+def _sibling() -> int:
+    """Still running when the nested child forks, then exits."""
+    time.sleep(0.1)
+    return 0
+
+
+def _child_reclaims(js: Jobserver) -> int:
+    """Reclaim after the inherited sibling has exited (fd ready).
+
+    Under fork the inherited selector still tracks _sibling's Future;
+    by the time this sleep elapses that process has exited, so its
+    sentinel fd is ready.  reclaim_resources() must rebuild a clean
+    selector rather than act on the ancestor-owned process.
+    """
+    time.sleep(0.5)
+    js.reclaim_resources()
+    return 0
+
+
+def _parent_fanout(js: Jobserver) -> int:
+    """Submit a sibling, then a nested child that reclaims while it runs."""
+    sibling = js.submit(fn=_sibling)
+    nested = js.submit(fn=_child_reclaims, args=(js,), consume=0)
+    value = nested.result(timeout=30)
+    sibling.result(timeout=30)
+    return value
+
+
+class TestDesignForkSelector(unittest.TestCase):
+    """Nested fan-out under fork must not reclaim an ancestor's Future."""
+
+    def test_nested_fanout_rebuilds_inherited_selector(self) -> None:
+        """A forked worker reclaims cleanly despite inherited siblings."""
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=method, slots=8) as js:
+                    f = js.submit(fn=_parent_fanout, args=(js,), consume=0)
+                    self.assertEqual(f.result(timeout=60), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Fixes issue #296 where forked children would inherit the parent's selector containing references to sibling Futures from ancestor processes, causing errors when reclaiming resources.

## Key Changes
- **Lazy selector initialization**: Replaced eager `_initialize_selector()` call in `__init__` with lazy construction via new `_lazy_selector()` method that builds the selector on first use
- **Fork detection**: Added `_selector_pid` field to track which process built the selector; rebuilds automatically when a pid change is detected (indicating a fork)
- **Pickle support**: Modified `__setstate__` to defer selector construction (matching `__init__` behavior), ensuring pickled children also take the lazy path
- **Updated references**: Changed all direct `self._selector` accesses to use `self._lazy_selector()` in `reclaim_resources()` and `submit()`
- **Defensive cleanup**: Updated `__del__` and `__exit__` to safely handle `None` selectors

## Implementation Details
The `_lazy_selector()` method:
- Returns the existing selector if already built in the current process
- Rebuilds a fresh selector if the process id has changed (fork detected)
- Pre-registers the slots waitable with a noop done() callback to maintain consistent selector state
- Ensures forked children don't inherit ancestor process references that would cause "can only join a child process" errors during nested fan-out scenarios

## Testing
Added `test_design_fork_selector.py` with a test case that verifies nested fan-out (parent submits sibling, then nested child that reclaims) works correctly under fork without attempting to join ancestor processes.

https://claude.ai/code/session_01QXmmSAUorEiaLYWA5X5RE8