### PR TITLE
Shorten the slowest regression tests without adding flake

### DIFF
--- a/test/test_design_consume.py
+++ b/test/test_design_consume.py
@@ -70,8 +70,10 @@ class TestDesignConsume(unittest.TestCase):
         for method in get_all_start_methods():
             with self.subTest(method=method):
                 with Jobserver(context=method, slots=self.SLOTS) as js:
-                    f = js.submit(fn=_recurse, args=(js, 10, 0), timeout=5)
-                    self.assertEqual(f.result(timeout=30), 10)
+                    # Depth far exceeds the 2 slots, exercising the
+                    # implicit free token at every interior level.
+                    f = js.submit(fn=_recurse, args=(js, 6, 0), timeout=5)
+                    self.assertEqual(f.result(timeout=30), 6)
 
     def test_top_level_backpressure_preserved(self) -> None:
         """consume=0 is for interiors; the top level still obeys slots."""

--- a/test/test_design_fork_selector.py
+++ b/test/test_design_fork_selector.py
@@ -38,9 +38,10 @@ def _child_reclaims(js: Jobserver) -> int:
     Under fork the inherited selector still tracks _sibling's Future;
     by the time this sleep elapses that process has exited, so its
     sentinel fd is ready.  reclaim_resources() must rebuild a clean
-    selector rather than act on the ancestor-owned process.
+    selector rather than act on the ancestor-owned process.  The sleep
+    only needs to outlast the 0.1s sibling with a margin to spare.
     """
-    time.sleep(0.5)
+    time.sleep(0.3)
     js.reclaim_resources()
     return 0
 

--- a/test/test_design_jobserver.py
+++ b/test/test_design_jobserver.py
@@ -72,7 +72,7 @@ class TestDesignShortcoming(unittest.TestCase):
 
                     # Parent -> Child -> Grandchild
                     future = js.submit(
-                        fn=_child_work, args=(js, 0.5), timeout=5
+                        fn=_child_work, args=(js, 0.2), timeout=5
                     )
                     time.sleep(0.5)  # Let Child start and submit Grandchild
 
@@ -81,8 +81,11 @@ class TestDesignShortcoming(unittest.TestCase):
                     with self.assertRaises(SubmissionDied):
                         future.result()
 
-                    # Grandchild finishes but nobody reclaims its token
-                    time.sleep(1.0)
+                    # Grandchild finishes but nobody reclaims its token.
+                    # Its token was consumed before the kill, so the leak
+                    # is independent of when the brief Grandchild returns;
+                    # this wait only need exceed the Grandchild duration.
+                    time.sleep(0.5)
 
                     # One fewer slot is usable now: the last is leaked.
                     # Hold workers alive so their tokens stay consumed.


### PR DESCRIPTION
The three design tests were the longest poles in the suite, dominated by
fixed sleeps and recursion depths far larger than their synchronization
or demonstration actually requires.

- test_intermediate_death_leaks_one_token: the grandchild's token is
  consumed before the child is killed, so the leak is independent of
  when the grandchild returns.  Shrink the grandchild duration 0.5s->0.2s
  and the post-kill settle wait 1.0s->0.5s (still well above the
  grandchild duration).
- test_nested_fanout_rebuilds_inherited_selector: the reclaiming child
  only needs to outlast the 0.1s sibling so its sentinel fd is ready;
  0.5s->0.3s keeps a comfortable 0.2s margin.
- test_consume_0_permits_arbitrary_depth: recursion depth 10->6 still
  demonstrates depth far beyond the 2 slots while spawning fewer nested
  processes per start method.

Cuts the unittest suite from ~38.1s to ~35.0s; all timing-sensitive
tests verified stable across repeated runs and the full ci passes.