### PR TITLE
Wrap parent-side result reconstruction failures (#303)

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -444,9 +444,17 @@ class Future(Generic[T]):
             # EOFError is an unexpected hang up from the other end
             try:
                 self._wrapper = self._connection.recv()
-                assert isinstance(self._wrapper, Wrapper), type(self._wrapper)
             except EOFError:
                 self._wrapper = ExceptionWrapper(SubmissionDied())
+            except Exception as e:
+                # A value can pickle in the child yet fail to reconstitute
+                # in the parent (e.g. a returned Connection raises
+                # FileNotFoundError deep in recv()).
+                self._wrapper = ExceptionWrapper(
+                    RuntimeError(f"Result not reconstructable: {e!r}")
+                )
+            else:
+                assert isinstance(self._wrapper, Wrapper), type(self._wrapper)
 
             # Now join() and set to None reclaiming OS/Python resources
             assert self._process is not None

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -128,6 +128,12 @@ def helper_marker_return(directory: str, arg: T) -> T:
     return arg
 
 
+def helper_return_connection(context):
+    """Return a live Connection that pickles but cannot rebuild remotely."""
+    recv, _send = context.Pipe(duplex=False)
+    return recv
+
+
 def helper_raise(klass: type, *args) -> typing.NoReturn:
     """Helper raising the requested Exception class."""
     raise klass(*args)

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -43,6 +43,7 @@ from .helpers import (
     helper_preexec_suppressing_cm,
     helper_raise,
     helper_return,
+    helper_return_connection,
 )
 
 
@@ -584,3 +585,22 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
             wrapper.unwrap()
         self.assertIn("not picklable", str(ctx.exception))
         self.assertTrue(send.closed)
+
+
+class TestResultNotReconstructable(unittest.TestCase):
+    """A value that pickles in the child but cannot be rebuilt in the
+    parent must surface a clean library error, not a raw OS error (#303)."""
+
+    @unittest.skipUnless(
+        "fork" in get_all_start_methods(), "requires fork start method"
+    )
+    def test_returned_connection_does_not_leak_filenotfounderror(self) -> None:
+        """Returning a live Connection pickles in the child but fails to
+        rebuild in the parent; report it via RuntimeError rather than
+        leaking FileNotFoundError from recv()."""
+        context = get_context("fork")
+        with Jobserver(context=context, slots=2) as js:
+            future = js.submit(fn=helper_return_connection, args=(context,))
+            with self.assertRaises(RuntimeError) as ctx:
+                future.result(timeout=10)
+        self.assertIn("not reconstructable", str(ctx.exception))


### PR DESCRIPTION
Fixes #303.

A value can pickle in the child yet fail to rebuild in the parent (e.g. a returned `Jobserver` carrying a live `Connection` raises `FileNotFoundError` from `connection.recv()`). This leaked a bare OS error straight out of `Future.result()`/`wait()`.

`Future.wait()` now catches such reconstruction failures and reports them as a `RuntimeError` through the library's normal result-marshaling channel, matching the existing "not picklable" path.

A fork-based regression test (`TestResultNotReconstructable`) reproduces the issue; it leaks `FileNotFoundError` without the fix and raises a clean `RuntimeError` with it. `./ci` passes.

https://claude.ai/code/session_01MgnuJBVwk2EDSui5XADUbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgnuJBVwk2EDSui5XADUbC)_