### PR TITLE
Replace AssertionError with ValueError for invalid sleep_fn returns

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -1161,7 +1161,11 @@ def _maybe_obtain_token(
         # sleep_fn() duration is properly accounted for.
         sleep = sleep_fn()
         if sleep is not None:
-            assert sleep >= 0.0
+            if not sleep >= 0.0:
+                raise ValueError(
+                    "sleep_fn must return None or non-negative "
+                    f"seconds, got {sleep!r}"
+                )
             remaining = deadline_to_timeout(deadline)
             time.sleep(max(_RESOLUTION, min(sleep, remaining)))
             if time.monotonic() >= deadline:

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -271,9 +271,12 @@ class TestJobserverWorker(unittest.TestCase):
         for method in get_all_start_methods():
             with self.subTest(method=method):
                 with Jobserver(context=method, slots=1) as js:
-                    # Confirm negative sleep is detectable with fn never called
-                    with self.assertRaises(AssertionError):
+                    # Confirm negative/nan sleep raises ValueError, fn uncalled
+                    with self.assertRaises(ValueError) as c:
                         js.submit(fn=len, sleep_fn=lambda: -1.0)
+                    self.assertIn("-1.0", str(c.exception))
+                    with self.assertRaises(ValueError):
+                        js.submit(fn=len, sleep_fn=lambda: float("nan"))
 
                     # Confirm sleep_fn(...) returning zero can proceed
                     zs = iter(itertools.cycle((0, None)))


### PR DESCRIPTION
## Summary
Changed the validation of `sleep_fn` return values from using `assert` statements to raising `ValueError` with descriptive error messages. This improves error handling by using appropriate exception types and providing better debugging information.

## Key Changes
- Replaced `assert sleep >= 0.0` with explicit `ValueError` raising in `_maybe_obtain_token()` method
- Error message now clearly indicates that `sleep_fn` must return `None` or non-negative seconds, and includes the actual invalid value received
- Updated test expectations from `AssertionError` to `ValueError`
- Added test coverage for NaN (not-a-number) return values, which also raise `ValueError`
- Added assertion to verify the error message contains the problematic value

## Implementation Details
- The validation now explicitly checks `if not sleep >= 0.0` and raises `ValueError` with a formatted message including the invalid value using `repr()`
- This catches both negative values and NaN values (since `NaN >= 0.0` evaluates to `False`)
- The error message format is: `"sleep_fn must return None or non-negative seconds, got {value}"`

https://claude.ai/code/session_014ztvhkiWV5qU9WjnunNd3V