### PR TITLE
Reject non-int types in consume parameter (#304)

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -1141,7 +1141,7 @@ def _maybe_obtain_token(
     May raise CallbackRaised via reclaim_tokens_fn so raising.
     """
     # Defensively check arguments
-    if consume != 0 and consume != 1:
+    if type(consume) is not int or consume not in (0, 1):
         raise ValueError(f"consume must be 0 or 1, got {consume!r}")
     # Acquire the requested token or raise Blocked when impossible
     token: Optional[int] = None

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -466,6 +466,20 @@ class TestJobserverBasic(unittest.TestCase):
                         "available slots",
                     )
 
+    def test_consume_rejects_non_int(self) -> None:
+        """consume accepts only the ints 0/1, not bools/floats (#304)."""
+        with Jobserver(slots=2) as js:
+            for good in (0, 1):
+                self.assertEqual(
+                    1,
+                    js.submit(
+                        fn=helper_return, args=(1,), consume=good
+                    ).result(timeout=5),
+                )
+            for bad in (2, -1, 99, True, False, 1.0, 0.0):
+                with self.assertRaises(ValueError):
+                    js.submit(fn=helper_return, args=(1,), consume=bad)
+
     def test_context_manager(self) -> None:
         """Context manager closes slots; submit raises after exit."""
         with Jobserver(slots=2) as js:

--- a/test/test_jobserver_callbacks.py
+++ b/test/test_jobserver_callbacks.py
@@ -29,6 +29,20 @@ from .helpers import (
 class TestJobserverCallbacks(unittest.TestCase):
     """Jobserver Future callback machinery."""
 
+    def await_exit(self, *futures: Future) -> None:
+        """Block until each child exits so results are ready to reclaim.
+
+        A fixed sleep is unreliable under forkserver (the Python 3.14
+        default), whose slower startup can leave a child unfinished.
+        Polling is_alive() waits without firing callbacks early.
+        """
+        deadline = time.monotonic() + 5
+        for f in futures:
+            while f._process is not None and f._process.is_alive():
+                if time.monotonic() >= deadline:
+                    self.fail("child did not exit")
+                time.sleep(0.01)
+
     def helper_check_semantics(self, f: Future[None]) -> None:
         """Helper checking Future semantics *inside* a callback as expected."""
         # Prepare how callbacks will be observed
@@ -237,7 +251,7 @@ class TestJobserverCallbacks(unittest.TestCase):
             c.when_done(helper_raise, LookupError, "c")
             order: list[str] = []
             d.when_done(order.append, "ok")
-            time.sleep(0.5)  # ensure all children finish
+            self.await_exit(a, b, c, d)
 
             # Collect all CallbackRaised causes; ordering across
             # futures is kernel-determined and not guaranteed.
@@ -297,6 +311,6 @@ class TestJobserverCallbacks(unittest.TestCase):
             b.when_done(helper_raise, ArithmeticError, "b")
             c.when_done(helper_raise, LookupError, "c")
             d.when_done(order.append, "ok")
-            time.sleep(0.5)  # ensure all children finish
+            self.await_exit(a, b, c, d)
         # __exit__ ran without raising; all callbacks were drained
         self.assertEqual(order, ["ok"])


### PR DESCRIPTION
## Summary
Strengthen validation of the `consume` parameter in `Jobserver.submit()` to explicitly reject non-integer types (booleans, floats, etc.) while only accepting the integer values 0 and 1.

## Changes
- **Validation logic**: Updated the type check in `_maybe_obtain_token()` to use `type(consume) is not int` instead of relying on value comparison alone. This ensures that boolean values (which are technically int subclasses in Python) and other numeric types like floats are rejected.
- **Test coverage**: Added `test_consume_rejects_non_int()` to verify that:
  - Integer values 0 and 1 are accepted
  - Non-integer types (booleans, floats) are rejected
  - Out-of-range integers (2, -1, 99) are rejected

## Implementation Details
The fix uses an explicit type check (`type(consume) is not int`) combined with value validation (`consume not in (0, 1)`) to prevent implicit type coercion. This is important because in Python, `bool` is a subclass of `int`, so `isinstance()` would incorrectly accept `True` and `False`.

https://claude.ai/code/session_01XUSCue4gwqw3VTT7EZ6ggh