### PR TITLE
Bound slots to prevent deadlock during Jobserver construction

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -535,6 +535,12 @@ def _unregister_connection(
     connection.close()
 
 
+# Upper bound on slots, rejected above.  A pipe's buffer is finite, so
+# put()ing one token per slot blocks forever once it fills.  2048 tokens
+# fill ~36 KiB, fitting comfortably within a 64 KiB pipe.
+_MAX_SLOTS = 2048
+
+
 class Jobserver:
     """A Jobserver exposing a Future interface built atop multiprocessing.
 
@@ -587,6 +593,8 @@ class Jobserver:
             raise TypeError(f"slots: int, got {type(slots).__name__}")
         if slots < 1:
             raise ValueError(f"slots must be >= 1, got {slots!r}")
+        if slots > _MAX_SLOTS:
+            raise ValueError(f"slots must be <= {_MAX_SLOTS}, got {slots!r}")
 
         # Obtain some multiprocessing Context and the slot-tracking queue
         self._context = resolve_context(context)

--- a/test/test_jobserver_slots.py
+++ b/test/test_jobserver_slots.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""slots is bounded so construction cannot hang (issue #302).
+
+Filling a token pipe is O(slots) and, worse, deadlocks once the pipe
+buffer fills: put() blocks forever waiting for space no reader frees.
+Construction therefore rejects slots beyond _MAX_SLOTS with an
+informative ValueError, and the largest allowed value still fits.
+"""
+
+import threading
+import time
+import unittest
+
+from jobserver import Jobserver
+from jobserver._jobserver import _MAX_SLOTS
+
+from .helpers import FAST, TIMEOUT
+
+
+class TestLargeSlots(unittest.TestCase):
+    """slots above _MAX_SLOTS is rejected; the boundary still works."""
+
+    def test_slots_above_max_raises_informative_valueerror(self) -> None:
+        """Jobserver(slots=10**9) fails fast rather than hanging."""
+        with self.assertRaises(ValueError) as cm:
+            Jobserver(context=FAST, slots=10**9)
+        message = str(cm.exception)
+        self.assertIn(str(_MAX_SLOTS), message)
+        self.assertIn(repr(10**9), message)
+
+    def test_max_slots_constructs_quickly_and_runs(self) -> None:
+        """The largest allowed slots fills the pipe without deadlocking."""
+        done = threading.Event()
+
+        def build() -> None:
+            # Construct and immediately tear down; both must be fast.
+            with Jobserver(context=FAST, slots=_MAX_SLOTS):
+                pass
+            done.set()
+
+        # A daemon thread so a regression (a blocked pipe put()) cannot
+        # wedge the whole suite; it is reaped at interpreter exit.
+        thread = threading.Thread(target=build, daemon=True)
+        start = time.monotonic()
+        thread.start()
+        thread.join(timeout=TIMEOUT)
+        self.assertTrue(
+            done.is_set(),
+            "construction hung: still running after"
+            f" {time.monotonic() - start:.1f}s",
+        )
+
+    def test_max_slots_still_runs_work(self) -> None:
+        """A max-slots Jobserver still accepts and completes work."""
+        with Jobserver(context=FAST, slots=_MAX_SLOTS) as js:
+            future = js.submit(fn=abs, args=(-7,))
+            self.assertEqual(future.result(timeout=TIMEOUT), 7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This change prevents potential deadlocks during Jobserver construction by introducing an upper bound on the `slots` parameter. When slots exceed the pipe buffer capacity, the token-filling process can block indefinitely, causing construction to hang.

## Changes
- **Added `_MAX_SLOTS` constant** (2048): An upper bound on slots that safely fits within a typical 64 KiB pipe buffer (~36 KiB for 2048 tokens)
- **Added validation in `Jobserver.__init__`**: Raises an informative `ValueError` if `slots > _MAX_SLOTS`
- **Added comprehensive test suite** (`test_jobserver_slots.py`):
  - Verifies that slots above the limit are rejected with a clear error message
  - Confirms that the maximum allowed slots value constructs without hanging
  - Ensures max-slots Jobserver instances still function correctly for work submission

## Implementation Details
The pipe buffer is finite, and attempting to put one token per slot will block forever once the buffer fills. By capping slots at 2048 (which requires ~36 KiB), we ensure the operation completes safely within standard 64 KiB pipe buffers. The validation happens early in construction, failing fast with a descriptive error rather than hanging indefinitely.

Fixes issue #302.

https://claude.ai/code/session_013TLpURZXTBqnQYZPfofRQM