### PR TITLE
Extract AbstractQueue base and rename concrete queue to SPSCQueue

### DIFF
--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -26,7 +26,7 @@ from ._jobserver import (
     Future,
     Jobserver,
 )
-from ._queue import MinimalQueue
+from ._queue import SPSCQueue
 
 __all__ = ("JobserverExecutor",)
 
@@ -67,8 +67,8 @@ class JobserverExecutor(concurrent.futures.Executor):
         # dispatcher Process, which drops _args after start() in 3.11+.
         self._jobserver = jobserver
 
-        self._requests: MinimalQueue = MinimalQueue(jobserver.context)
-        self._responses: MinimalQueue = MinimalQueue(jobserver.context)
+        self._requests: SPSCQueue = SPSCQueue(jobserver.context)
+        self._responses: SPSCQueue = SPSCQueue(jobserver.context)
 
         self._dispatcher = jobserver.context.Process(  # type: ignore
             target=_dispatch_loop,
@@ -390,8 +390,8 @@ class _DispatchState:
 
 def _dispatch_loop(
     jobserver: Jobserver,
-    requests: MinimalQueue,
-    responses: MinimalQueue,
+    requests: SPSCQueue,
+    responses: SPSCQueue,
 ) -> None:
     """Main loop for the dispatcher process."""
     _LOG.debug("Dispatcher process started")
@@ -416,7 +416,7 @@ def _dispatch_loop(
 def _handle_request(
     msg: object,
     state: _DispatchState,
-    responses: MinimalQueue,
+    responses: SPSCQueue,
 ) -> None:
     """Handle a single request message, updating state in place."""
     if isinstance(msg, _request.Shutdown):
@@ -450,9 +450,9 @@ def _handle_request(
 
 
 def _drain_requests(
-    requests: MinimalQueue,
+    requests: SPSCQueue,
     state: _DispatchState,
-    responses: MinimalQueue,
+    responses: SPSCQueue,
 ) -> None:
     """Drain the request queue, setting state.shutdown on Shutdown or EOF."""
     while True:
@@ -473,7 +473,7 @@ def _drain_requests(
 def _dispatch_pending(
     jobserver: Jobserver,
     state: _DispatchState,
-    responses: MinimalQueue,
+    responses: SPSCQueue,
 ) -> None:
     """Dispatch pending work in insertion (FIFO) order.
 
@@ -509,7 +509,7 @@ def _dispatch_pending(
 
 def _poll_running(
     state: _DispatchState,
-    responses: MinimalQueue,
+    responses: SPSCQueue,
 ) -> None:
     """Poll running Futures and bridge completed results."""
     running = state.running
@@ -528,7 +528,7 @@ def _poll_running(
 
 
 def _responses_put_failed(
-    responses: MinimalQueue,
+    responses: SPSCQueue,
     work_id: int,
     exc: Exception,
 ) -> None:
@@ -551,7 +551,7 @@ def _responses_put_failed(
 def _bridge_result(
     f: Future,
     work_id: int,
-    responses: MinimalQueue,
+    responses: SPSCQueue,
 ) -> None:
     """Transfer a completed jobserver Future's outcome to response queue."""
     try:
@@ -563,7 +563,7 @@ def _bridge_result(
 
 def _handle_shutdown(
     state: _DispatchState,
-    responses: MinimalQueue,
+    responses: SPSCQueue,
 ) -> None:
     """Cancel pending work, drain running futures, signal completion."""
     for item in state.pending.values():
@@ -580,9 +580,9 @@ def _handle_shutdown(
 
 
 def _poll_requests_briefly(
-    requests: MinimalQueue,
+    requests: SPSCQueue,
     state: _DispatchState,
-    responses: MinimalQueue,
+    responses: SPSCQueue,
 ) -> None:
     """Brief blocking poll to pick up new work without busy-spinning.
 

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -37,7 +37,7 @@ from ._compat import (
     sched_getaffinity0,
 )
 from ._queue import (
-    MinimalQueue,
+    SPSCQueue,
     deadline_to_timeout,
     resolve_context,
     timeout_to_deadline,
@@ -513,7 +513,7 @@ class SlotsSentinel:
         return None
 
 
-def _restore_token(slots: MinimalQueue, token: Optional[int]) -> None:
+def _restore_token(slots: SPSCQueue, token: Optional[int]) -> None:
     """Restore token to slots, tolerating a closed queue."""
     if token is not None:
         try:
@@ -618,7 +618,7 @@ class Jobserver:
 
         # Obtain some multiprocessing Context and the slot-tracking queue
         self._context = resolve_context(context)
-        self._slots: MinimalQueue[int] = MinimalQueue(self._context)
+        self._slots: SPSCQueue[int] = SPSCQueue(self._context)
 
         # Issue one token for each requested slot
         for token in range(slots):
@@ -1165,7 +1165,7 @@ def _maybe_obtain_token(
     reclaim_tokens_fn: Callable[[], Any],
     selector: DefaultSelector,
     sleep_fn: SleepFn,
-    slots: MinimalQueue[int],
+    slots: SPSCQueue[int],
 ) -> Optional[int]:
     """
     Either retrieve a requested token or raise Blocked while trying.

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -18,7 +18,6 @@ from multiprocessing.reduction import ForkingPickler
 from typing import Any, Generic, Optional, TypeVar, Union
 
 __all__ = (
-    "AbstractQueue",
     "MinimalQueue",
     "timeout_to_deadline",
     "deadline_to_timeout",

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -26,6 +26,10 @@ __all__ = (
 
 T = TypeVar("T")
 
+# Bound TypeVar emulating the Python 3.11+ Self type so that methods
+# returning self report the concrete subclass type under mypy.
+Self = TypeVar("Self", bound="AbstractQueue")
+
 # Maximum seconds safely passable to poll() without overflow.  poll(2) on
 # Linux takes timeout in milliseconds as a signed 32-bit int, so the ceiling
 # is INT_MAX ms = 2**31-1 ms = 2_147_483_647 ms = 2_147_483.647 s (~24.85 d).
@@ -114,7 +118,7 @@ class AbstractQueue(Generic[T], abc.ABC):
         self._read_lock = threading.Lock()
         self._write_lock = threading.Lock()
 
-    def __enter__(self) -> "AbstractQueue":
+    def __enter__(self: Self) -> Self:
         return self
 
     def __exit__(self, *exc: Any) -> None:
@@ -131,12 +135,12 @@ class AbstractQueue(Generic[T], abc.ABC):
         except AttributeError:
             pass
 
-    def __copy__(self) -> "AbstractQueue":
+    def __copy__(self: Self) -> Self:
         """Shallow copies return the original MinimalQueue unchanged."""
         # Because any "copy" should and can only mutate same pipe/locks
         return self
 
-    def __deepcopy__(self, _: Any) -> "AbstractQueue":
+    def __deepcopy__(self: Self, _: Any) -> Self:
         """Deep copies return the original MinimalQueue unchanged."""
         # Because any "copy" should and can only mutate same pipe/locks
         return self

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""MinimalQueue and related utility functions."""
+"""SPSCQueue and related utility functions."""
 
 import abc
 import queue
@@ -18,7 +18,7 @@ from multiprocessing.reduction import ForkingPickler
 from typing import Any, Generic, Optional, TypeVar, Union
 
 __all__ = (
-    "MinimalQueue",
+    "SPSCQueue",
     "timeout_to_deadline",
     "deadline_to_timeout",
     "resolve_context",
@@ -68,7 +68,7 @@ def resolve_context(context: Union[None, str, BaseContext]) -> BaseContext:
 
 
 def _conn_repr(conn: Optional[Connection]) -> str:
-    """Describe a pipe end for MinimalQueue.__repr__, tolerating closed fds."""
+    """Describe a pipe end for SPSCQueue.__repr__, tolerating closed fds."""
     if conn is None:
         return "closed"
     # fileno() raises ValueError/OSError on a closed fd.
@@ -97,11 +97,7 @@ class AbstractQueue(Generic[T], abc.ABC):
 
     @abc.abstractmethod
     def _getstate_locks(self) -> Any:
-        """Return a picklable representation of this queue's locks.
-
-        Return None to discard locks across pickling; return the lock
-        objects themselves (if picklable) to preserve them.
-        """
+        """Return a picklable representation of this queue's locks."""
         ...
 
     @abc.abstractmethod
@@ -118,7 +114,7 @@ class AbstractQueue(Generic[T], abc.ABC):
 
     def __repr__(self) -> str:
         return (
-            f"MinimalQueue(reader={_conn_repr(self._reader)},"
+            f"SPSCQueue(reader={_conn_repr(self._reader)},"
             f" writer={_conn_repr(self._writer)})"
         )
 
@@ -152,12 +148,12 @@ class AbstractQueue(Generic[T], abc.ABC):
             pass
 
     def __copy__(self: Self) -> Self:
-        """Shallow copies return the original MinimalQueue unchanged."""
+        """Shallow copies return the original SPSCQueue unchanged."""
         # Because any "copy" should and can only mutate same pipe/locks
         return self
 
     def __deepcopy__(self: Self, _: Any) -> Self:
-        """Deep copies return the original MinimalQueue unchanged."""
+        """Deep copies return the original SPSCQueue unchanged."""
         # Because any "copy" should and can only mutate same pipe/locks
         return self
 
@@ -203,7 +199,7 @@ class AbstractQueue(Generic[T], abc.ABC):
             # ValueError here rather than a None-dereference at recv time.
             reader = self._reader
             if reader is None:
-                raise ValueError("MinimalQueue.get() after close_get()")
+                raise ValueError("SPSCQueue.get() after close_get()")
             if not reader.poll(deadline_to_timeout(deadline)):
                 raise queue.Empty
             # Reading under the lock preserves frame integrity if multiple
@@ -228,12 +224,18 @@ class AbstractQueue(Generic[T], abc.ABC):
             # ValueError here rather than a None-dereference at send time.
             writer = self._writer
             if writer is None:
-                raise ValueError("MinimalQueue.put() after close_put()")
+                raise ValueError("SPSCQueue.put() after close_put()")
             writer.send_bytes(bytez)
 
 
-class MinimalQueue(AbstractQueue[T]):
-    """A trivial concrete AbstractQueue; see AbstractQueue for behavior."""
+class SPSCQueue(AbstractQueue[T]):
+    """A single-producer, single-consumer AbstractQueue.
+
+    Here "single" means single process: the threading.Lock guards only
+    serialize concurrent producers or consumers within one process and
+    are recreated fresh on unpickle, so they provide no mutual exclusion
+    across processes.  See AbstractQueue for the remaining behavior.
+    """
 
     __slots__ = ()
 

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -90,14 +90,21 @@ class AbstractQueue(Generic[T], abc.ABC):
 
     __slots__ = ("_reader", "_writer", "_read_lock", "_write_lock")
 
+    @abc.abstractmethod
+    def _new_lock(self) -> "threading.Lock":
+        """Return a fresh lock guarding one pipe end.
+
+        Called once per end by __setstate__, both at construction and on
+        every unpickle into a new process.
+        """
+        ...
+
     def __init__(self, context: Union[None, str, BaseContext] = None) -> None:
         """Use given context with default of multiprocessing.get_context()."""
         context = resolve_context(context)
         reader, writer = context.Pipe(duplex=False)
-        self._reader: Optional[Connection] = reader
-        self._writer: Optional[Connection] = writer
-        self._read_lock = threading.Lock()
-        self._write_lock = threading.Lock()
+        # Delegate reader/writer/lock wiring to the single __setstate__ path.
+        self.__setstate__((reader, writer))
 
     def __repr__(self) -> str:
         return (
@@ -115,8 +122,8 @@ class AbstractQueue(Generic[T], abc.ABC):
         state: tuple[Optional[Connection], Optional[Connection]],
     ) -> None:
         self._reader, self._writer = state
-        self._read_lock = threading.Lock()
-        self._write_lock = threading.Lock()
+        self._read_lock = self._new_lock()
+        self._write_lock = self._new_lock()
 
     def __enter__(self: Self) -> Self:
         return self
@@ -220,3 +227,6 @@ class MinimalQueue(AbstractQueue[T]):
     """A trivial concrete AbstractQueue; see AbstractQueue for behavior."""
 
     __slots__ = ()
+
+    def _new_lock(self) -> "threading.Lock":
+        return threading.Lock()

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """MinimalQueue and related utility functions."""
 
+import abc
 import queue
 import threading
 import time
@@ -17,6 +18,7 @@ from multiprocessing.reduction import ForkingPickler
 from typing import Any, Generic, Optional, TypeVar, Union
 
 __all__ = (
+    "AbstractQueue",
     "MinimalQueue",
     "timeout_to_deadline",
     "deadline_to_timeout",
@@ -73,7 +75,7 @@ def _conn_repr(conn: Optional[Connection]) -> str:
         return "open(fd=closed)"
 
 
-class MinimalQueue(Generic[T]):
+class AbstractQueue(Generic[T], abc.ABC):
     """
     An unbounded SimpleQueue-variant with minimal functionality.
 
@@ -113,7 +115,7 @@ class MinimalQueue(Generic[T]):
         self._read_lock = threading.Lock()
         self._write_lock = threading.Lock()
 
-    def __enter__(self) -> "MinimalQueue":
+    def __enter__(self) -> "AbstractQueue":
         return self
 
     def __exit__(self, *exc: Any) -> None:
@@ -130,12 +132,12 @@ class MinimalQueue(Generic[T]):
         except AttributeError:
             pass
 
-    def __copy__(self) -> "MinimalQueue":
+    def __copy__(self) -> "AbstractQueue":
         """Shallow copies return the original MinimalQueue unchanged."""
         # Because any "copy" should and can only mutate same pipe/locks
         return self
 
-    def __deepcopy__(self, _: Any) -> "MinimalQueue":
+    def __deepcopy__(self, _: Any) -> "AbstractQueue":
         """Deep copies return the original MinimalQueue unchanged."""
         # Because any "copy" should and can only mutate same pipe/locks
         return self
@@ -209,3 +211,9 @@ class MinimalQueue(Generic[T]):
             if writer is None:
                 raise ValueError("MinimalQueue.put() after close_put()")
             writer.send_bytes(bytez)
+
+
+class MinimalQueue(AbstractQueue[T]):
+    """A trivial concrete AbstractQueue; see AbstractQueue for behavior."""
+
+    __slots__ = ()

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -90,13 +90,23 @@ class AbstractQueue(Generic[T], abc.ABC):
 
     __slots__ = ("_reader", "_writer", "_read_lock", "_write_lock")
 
-    @abc.abstractmethod
-    def _new_lock(self) -> "threading.Lock":
-        """Return a fresh lock guarding one pipe end.
+    # Lock attributes are populated by _setstate_locks in concrete
+    # subclasses; their concrete type is left to the subclass.
+    _read_lock: Any
+    _write_lock: Any
 
-        Called once per end by __setstate__, both at construction and on
-        every unpickle into a new process.
+    @abc.abstractmethod
+    def _getstate_locks(self) -> Any:
+        """Return a picklable representation of this queue's locks.
+
+        Return None to discard locks across pickling; return the lock
+        objects themselves (if picklable) to preserve them.
         """
+        ...
+
+    @abc.abstractmethod
+    def _setstate_locks(self, state: Any) -> None:
+        """Restore this queue's locks from _getstate_locks() output."""
         ...
 
     def __init__(self, context: Union[None, str, BaseContext] = None) -> None:
@@ -104,7 +114,7 @@ class AbstractQueue(Generic[T], abc.ABC):
         context = resolve_context(context)
         reader, writer = context.Pipe(duplex=False)
         # Delegate reader/writer/lock wiring to the single __setstate__ path.
-        self.__setstate__((reader, writer))
+        self.__setstate__((reader, writer, None))
 
     def __repr__(self) -> str:
         return (
@@ -114,16 +124,15 @@ class AbstractQueue(Generic[T], abc.ABC):
 
     def __getstate__(
         self,
-    ) -> tuple[Optional[Connection], Optional[Connection]]:
-        return (self._reader, self._writer)
+    ) -> tuple[Optional[Connection], Optional[Connection], Any]:
+        return (self._reader, self._writer, self._getstate_locks())
 
     def __setstate__(
         self,
-        state: tuple[Optional[Connection], Optional[Connection]],
+        state: tuple[Optional[Connection], Optional[Connection], Any],
     ) -> None:
-        self._reader, self._writer = state
-        self._read_lock = self._new_lock()
-        self._write_lock = self._new_lock()
+        self._reader, self._writer, lockstate = state
+        self._setstate_locks(lockstate)
 
     def __enter__(self: Self) -> Self:
         return self
@@ -228,5 +237,9 @@ class MinimalQueue(AbstractQueue[T]):
 
     __slots__ = ()
 
-    def _new_lock(self) -> "threading.Lock":
-        return threading.Lock()
+    def _getstate_locks(self) -> None:
+        return None  # locks are intra-process; never pickled
+
+    def _setstate_locks(self, _: Any) -> None:
+        self._read_lock = threading.Lock()
+        self._write_lock = threading.Lock()

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -18,7 +18,7 @@ import time
 import typing
 
 from jobserver import Jobserver, JobserverExecutor
-from jobserver._queue import MinimalQueue
+from jobserver._queue import SPSCQueue
 
 T = typing.TypeVar("T")
 
@@ -101,8 +101,8 @@ def executor_in_child_via_queue(
     q.put(executor_in_child(method))
 
 
-def helper_nonblocking(mq: MinimalQueue[str]) -> str:
-    """Receive and return a handshake from a MinimalQueue."""
+def helper_nonblocking(mq: SPSCQueue[str]) -> str:
+    """Receive and return a handshake from a SPSCQueue."""
     # Timeout allows heavy OS load while also detecting complete breakage
     return mq.get(timeout=60.0)
 

--- a/test/test_executor_basic.py
+++ b/test/test_executor_basic.py
@@ -29,7 +29,7 @@ from jobserver import (
     _response,
 )
 from jobserver._executor import _responses_put_failed
-from jobserver._queue import MinimalQueue
+from jobserver._queue import SPSCQueue
 
 from .helpers import (
     FAST,
@@ -470,7 +470,7 @@ class TestResponsesPutFailedFallback(unittest.TestCase):
         class LocalError(Exception):
             pass
 
-        with MinimalQueue(context=FAST) as q:
+        with SPSCQueue(context=FAST) as q:
             _responses_put_failed(q, 7, LocalError("boom"))
             resp = q.get(timeout=TIMEOUT)
         self.assertIsInstance(resp, _response.Failed)
@@ -480,7 +480,7 @@ class TestResponsesPutFailedFallback(unittest.TestCase):
 
     def test_picklable_exc_passes_through(self) -> None:
         """A picklable exception reaches the consumer unchanged."""
-        with MinimalQueue(context=FAST) as q:
+        with SPSCQueue(context=FAST) as q:
             _responses_put_failed(q, 3, ValueError("kept"))
             resp = q.get(timeout=TIMEOUT)
         self.assertIsInstance(resp, _response.Failed)

--- a/test/test_executor_concurrency.py
+++ b/test/test_executor_concurrency.py
@@ -26,7 +26,7 @@ from multiprocessing import get_all_start_methods
 
 from jobserver import Jobserver, JobserverExecutor, _request, _response
 from jobserver._executor import _DispatchState, _handle_request
-from jobserver._queue import MinimalQueue
+from jobserver._queue import SPSCQueue
 from jobserver._request import Submit
 
 from .helpers import (
@@ -342,20 +342,20 @@ class TestInternalInvariants(unittest.TestCase):
 
         Verify the lock is released before each put() by spying on the call.
 
-        MinimalQueue uses __slots__ so instance-level patching is impossible;
+        SPSCQueue uses __slots__ so instance-level patching is impossible;
         patch the class method and filter by queue object identity instead.
         """
         with Jobserver(context=FAST, slots=2) as js:
             exe = JobserverExecutor(js)
             lock_held: list[bool] = []
-            original_put = MinimalQueue.put
+            original_put = SPSCQueue.put
 
-            def spy_put(self_q: MinimalQueue, *args: typing.Any) -> None:
+            def spy_put(self_q: SPSCQueue, *args: typing.Any) -> None:
                 if self_q is exe._requests:
                     lock_held.append(exe._lock.locked())
                 return original_put(self_q, *args)
 
-            with unittest.mock.patch.object(MinimalQueue, "put", spy_put):
+            with unittest.mock.patch.object(SPSCQueue, "put", spy_put):
                 exe.submit(len, (1, 2, 3)).result(timeout=TIMEOUT)
                 exe.shutdown(wait=True)
 
@@ -370,7 +370,7 @@ class TestInternalInvariants(unittest.TestCase):
         After shutdown(cancel_futures=True) sends Cancel(), a Submit racing
         the impending Shutdown must be cancelled on arrival, never dispatched.
         """
-        responses: MinimalQueue = MinimalQueue(FAST)
+        responses: SPSCQueue = SPSCQueue(FAST)
         state = _DispatchState()
         try:
             # Blanket Cancel() latches cancelling True.
@@ -401,15 +401,15 @@ class TestInternalInvariants(unittest.TestCase):
         Without rollback the future would sit in _futures forever,
         preventing clean shutdown and leaking state.
 
-        MinimalQueue uses __slots__ so instance-level patching is impossible;
+        SPSCQueue uses __slots__ so instance-level patching is impossible;
         patch the class method and filter by queue object identity instead.
         """
         with Jobserver(context=FAST, slots=2) as js:
             exe = JobserverExecutor(js)
-            original_put = MinimalQueue.put
+            original_put = SPSCQueue.put
             fail_once = [True]
 
-            def failing_put(self_q: MinimalQueue, *args: typing.Any) -> None:
+            def failing_put(self_q: SPSCQueue, *args: typing.Any) -> None:
                 if (
                     fail_once[0]
                     and self_q is exe._requests
@@ -420,7 +420,7 @@ class TestInternalInvariants(unittest.TestCase):
                     raise OSError("simulated put failure")
                 return original_put(self_q, *args)
 
-            with unittest.mock.patch.object(MinimalQueue, "put", failing_put):
+            with unittest.mock.patch.object(SPSCQueue, "put", failing_put):
                 with self.assertRaises(OSError):
                     exe.submit(len, (1,))
 

--- a/test/test_executor_lifecycle.py
+++ b/test/test_executor_lifecycle.py
@@ -32,7 +32,7 @@ from jobserver import (
     _response,
 )
 from jobserver._executor import _DispatchState, _handle_request
-from jobserver._queue import MinimalQueue
+from jobserver._queue import SPSCQueue
 
 from .helpers import (
     FAST,
@@ -164,7 +164,7 @@ class TestSelectiveCancel(unittest.TestCase):
 
     def test_selective_cancel_removes_only_target(self) -> None:
         """Cancel(work_id=X) removes only X from pending."""
-        with MinimalQueue() as responses:
+        with SPSCQueue() as responses:
             state = _DispatchState(
                 pending={
                     n: _request.Submit(n, len, ((),), {}) for n in (1, 2, 3)
@@ -182,7 +182,7 @@ class TestSelectiveCancel(unittest.TestCase):
 
     def test_bulk_cancel_removes_all(self) -> None:
         """Cancel(work_id=None) removes everything."""
-        with MinimalQueue() as responses:
+        with SPSCQueue() as responses:
             state = _DispatchState(
                 pending={n: _request.Submit(n, len, ((),), {}) for n in (1, 2)}
             )
@@ -671,7 +671,7 @@ class TestOwnedJobserver(unittest.TestCase):
         f.result(timeout=TIMEOUT)
         exe.shutdown(wait=True)
         # The owned jobserver's slots queue should be closed; putting
-        # to it should raise (ValueError from MinimalQueue.put on a
+        # to it should raise (ValueError from SPSCQueue.put on a
         # closed queue).
         self.assertFalse(exe._own_jobserver)
 

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -27,7 +27,7 @@ from jobserver import (
     Blocked,
     Jobserver,
 )
-from jobserver._queue import MinimalQueue
+from jobserver._queue import SPSCQueue
 
 from .helpers import (
     barrier_wait,
@@ -261,7 +261,7 @@ class TestJobserverBasic(unittest.TestCase):
             with self.subTest(method=method, check_done=check_done):
                 context = get_context(method)
                 with (
-                    MinimalQueue(context=context) as mq,
+                    SPSCQueue(context=context) as mq,
                     Jobserver(context=context, slots=1) as js,
                 ):
                     delay = 0.02  # Impacts test runtime on success path

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -31,7 +31,7 @@ from jobserver._jobserver import (
     ResultWrapper,
     _worker_entrypoint,
 )
-from jobserver._queue import MinimalQueue
+from jobserver._queue import SPSCQueue
 
 from .helpers import (
     helper_callback,
@@ -155,7 +155,7 @@ class TestJobserverWorker(unittest.TestCase):
         for method in get_all_start_methods():
             with self.subTest(method=method):
                 context = get_context(method)
-                with MinimalQueue(context=context) as mq:
+                with SPSCQueue(context=context) as mq:
                     with Jobserver(context=context, slots=1) as js:
                         f = js.submit(fn=helper_nonblocking, args=(mq,))
                         try:

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -3,9 +3,9 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""MinimalQueue and low-level utility tests.
+"""SPSCQueue and low-level utility tests.
 
-MinimalQueue receives heavy indirect coverage through the Jobserver and
+SPSCQueue receives heavy indirect coverage through the Jobserver and
 JobserverExecutor suites, so this file only covers its own API surface
 and the resolve_context / timeout_to_deadline helpers.
 """
@@ -16,17 +16,17 @@ import unittest
 from multiprocessing import get_all_start_methods, get_context
 from multiprocessing.context import BaseContext
 
-from jobserver._queue import MinimalQueue, resolve_context, timeout_to_deadline
+from jobserver._queue import SPSCQueue, resolve_context, timeout_to_deadline
 
 
-class MinimalQueueTest(unittest.TestCase):
-    """Unit tests for MinimalQueue."""
+class SPSCQueueTest(unittest.TestCase):
+    """Unit tests for SPSCQueue."""
 
     def test_duplication_minimalqueue(self) -> None:
-        """Copying of MinimalQueue is explicitly allowed."""
+        """Copying of SPSCQueue is explicitly allowed."""
         for method in get_all_start_methods():
             with self.subTest(method=method):
-                with MinimalQueue(context=method) as mq1:
+                with SPSCQueue(context=method) as mq1:
                     mq2 = copy.copy(mq1)
                     mq3 = copy.deepcopy(mq1)
                     mq1.put(1)
@@ -42,7 +42,7 @@ class MinimalQueueTest(unittest.TestCase):
 
     def test_close_get_and_close_put_are_idempotent(self) -> None:
         """close_get() and close_put() are safe to call more than once."""
-        with MinimalQueue() as mq:
+        with SPSCQueue() as mq:
             pass
         # Both ends already closed by __exit__; repeat must not raise
         mq.close_get()
@@ -50,7 +50,7 @@ class MinimalQueueTest(unittest.TestCase):
 
     def test_context_manager(self) -> None:
         """Context manager closes both ends; put/get raise after exit."""
-        with MinimalQueue() as mq:
+        with SPSCQueue() as mq:
             mq.put(42)
             self.assertEqual(42, mq.get(timeout=1))
         with self.assertRaises(ValueError):

--- a/test/test_str_repr.py
+++ b/test/test_str_repr.py
@@ -11,7 +11,7 @@ from jobserver import (
     Jobserver,
     JobserverExecutor,
 )
-from jobserver._queue import MinimalQueue
+from jobserver._queue import SPSCQueue
 
 from .helpers import helper_return
 
@@ -76,24 +76,24 @@ class TestJobserverExecutorRepr(unittest.TestCase):
             self.assertIn("jobserver=", r)
 
 
-class TestMinimalQueueRepr(unittest.TestCase):
-    """MinimalQueue __repr__ reports pipe state."""
+class TestSPSCQueueRepr(unittest.TestCase):
+    """SPSCQueue __repr__ reports pipe state."""
 
     def test_open(self) -> None:
-        with MinimalQueue() as mq:
+        with SPSCQueue() as mq:
             r = repr(mq)
             self.assertIn("reader=open", r)
             self.assertIn("writer=open", r)
             self.assertIn("fd=", r)
 
     def test_closed_reader(self) -> None:
-        with MinimalQueue() as mq:
+        with SPSCQueue() as mq:
             mq.close_get()
             self.assertIn("reader=closed", repr(mq))
             self.assertIn("writer=open", repr(mq))
 
     def test_closed_writer(self) -> None:
-        with MinimalQueue() as mq:
+        with SPSCQueue() as mq:
             mq.close_put()
             self.assertIn("reader=open", repr(mq))
             self.assertIn("writer=closed", repr(mq))


### PR DESCRIPTION
Refactor `_queue.py` into an abstract base plus a concrete single-process
queue, establishing a seam where the lock-pickling policy is a subclass
concern. This is groundwork toward a cross-process-safe queue for the
nested-submit corruption/deadlock in #310; behavior of the existing queue
is unchanged.

## Changes

- **Extract `AbstractQueue`.** Every method of the former `MinimalQueue`
  moves into a new `abc.ABC` base, leaving the concrete class trivial.
- **`Self`-style return typing.** A bound `TypeVar` emulates the 3.11+
  `Self` type so `__enter__`/`__copy__`/`__deepcopy__` report the concrete
  subclass under mypy.
- **Pluggable lock-pickling policy.** `AbstractQueue` carries an opaque
  lock blob in its `(reader, writer, locks)` state tuple and delegates
  lock construction/restoration to abstract `_getstate_locks`/
  `_setstate_locks` hooks. The base knows neither the lock type nor
  whether locks survive pickling — both are subclass decisions.
- **Rename `MinimalQueue` -> `SPSCQueue`** (single-producer,
  single-consumer) across source and tests. Its docstring documents that
  "single" means single *process*: the `threading.Lock` guards only
  serialize within one process and are rebuilt fresh on unpickle, so they
  provide no cross-process mutual exclusion. `SPSCQueue` keeps the prior
  discard-and-recreate lock behavior.

The `_getstate_locks`/`_setstate_locks` seam is where a future
cross-process subclass would emit a picklable lock that survives
unpickling, giving the interprocess mutual exclusion #310 needs.

Merged current `master`.

https://claude.ai/code/session_017LP1XvK7PKZFgvoTDhqpfh