### PR TITLE
Raise defined error on use-after-close (#311)

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -581,6 +581,7 @@ class Jobserver:
         "_slots",
         "_selector",
         "_selector_pid",
+        "_selector_closed",
         "_env",
         "_preexec_fn",
         "_sleep_fn",
@@ -629,6 +630,7 @@ class Jobserver:
         # _selector_pid stamps the building process so forks rebuild it.
         self._selector: Optional[DefaultSelector] = None
         self._selector_pid: Optional[int] = None
+        self._selector_closed = False
 
         # Instance-level defaults for submit(...)
         # Defensive copy: consume any one-shot iterable and guard against
@@ -680,13 +682,24 @@ class Jobserver:
         if hasattr(self, "_slots"):
             self._slots.close_put()
             self._slots.close_get()
-        # Matches the cleanup in __exit__.  Tolerates a missing slot
-        # (partial construction) and None (never built lazily).
+        # Matches the cleanup in __exit__, tolerating partial construction.
+        self._selector_close()
+
+    def _selector_close(self) -> None:
+        # Record closure on _selector_closed because a closed selector
+        # cannot be detected after the fact: its get_map() can spuriously
+        # report open in a forked child under garbage collection.  Forks
+        # inherit the flag, so _lazy_selector checks it before its fork
+        # rebuild and a closed fork raises a clean RuntimeError rather than
+        # tripping self._slots.waitable().
         selector = getattr(self, "_selector", None)
         if selector is not None:
             selector.close()
+            self._selector_closed = True
 
     def __enter__(self) -> "Jobserver":
+        # Preparing the selector confirms the instance is not closed.
+        self._lazy_selector()
         return self
 
     def __exit__(self, *exc: Any) -> None:
@@ -712,11 +725,7 @@ class Jobserver:
         # Finally, stop any further manipulation of slots
         self._slots.close_put()
         self._slots.close_get()
-        # Release the selector's underlying fd and all registrations.
-        # reclaim_resources() above built it via _lazy_selector(); guard
-        # None for symmetry with __del__ should that ever not hold.
-        if self._selector is not None:
-            self._selector.close()
+        self._selector_close()
 
     def __getstate__(self) -> tuple:
         """Get instance state without exposing in-flight Futures.
@@ -748,6 +757,7 @@ class Jobserver:
         # A pickled child thus takes the same lazy path as a forked child.
         self._selector = None
         self._selector_pid = None
+        self._selector_closed = False
 
     # Use typing.Self once Python 3.11 is the minimum version
     def __copy__(self) -> "Jobserver":
@@ -780,6 +790,12 @@ class Jobserver:
         child reusing an ancestor's selector would join()/is_alive() the
         ancestor's Futures and share its epoll set, so it is discarded.
         """
+        # Closed via __exit__/__del__ here or in an ancestor before this fork.
+        if self._selector_closed:
+            raise RuntimeError("Jobserver is closed")
+        # Build on first use, or rebuild after a fork (pid change) to discard
+        # an ancestor's selector: reusing it would join()/is_alive() the
+        # ancestor's Futures and share its epoll set.
         if self._selector is None or self._selector_pid != os.getpid():
             # Pre-register the slots waitable so the obtain-token loop and
             # reclaim share one persistent interest set (a noop done() keeps
@@ -1340,8 +1356,8 @@ def _map_generate(
     finally:
         # On teardown explicitly clear still-held Futures, then reclaim
         # finished workers' slots.  Loop since reclaim aborts on the first
-        # CallbackRaised; a closed Jobserver, causing ValueError or
-        # OSError, ends the loop.
+        # CallbackRaised; a closed Jobserver (RuntimeError) or a closed
+        # selector/queue (ValueError or OSError) ends the loop.
         futures.clear()
         chunk = ()
         while True:
@@ -1350,5 +1366,5 @@ def _map_generate(
                 break
             except CallbackRaised:
                 continue
-            except (ValueError, OSError):
+            except (RuntimeError, ValueError, OSError):
                 break

--- a/test/test_design_fork_selector.py
+++ b/test/test_design_fork_selector.py
@@ -19,6 +19,7 @@ worker would join()/is_alive() a process it never created, raising
 clean selector when it first observes a pid change.
 """
 
+import os
 import time
 import unittest
 from multiprocessing import get_all_start_methods
@@ -65,3 +66,34 @@ class TestDesignForkSelector(unittest.TestCase):
                 with Jobserver(context=method, slots=8) as js:
                     f = js.submit(fn=_parent_fanout, args=(js,), consume=0)
                     self.assertEqual(f.result(timeout=60), 0)
+
+    @unittest.skipUnless(hasattr(os, "fork"), "requires os.fork")
+    def test_fork_of_closed_parent_raises_closed(self) -> None:
+        """A child forked from a closed Jobserver reports it as closed.
+
+        The child inherits the parent's _selector_closed flag, so its
+        _lazy_selector raises a clean RuntimeError before the fork rebuild
+        reaches self._slots.waitable() on the inherited closed slots queue.
+        Selector closure cannot be probed after the fact: a closed selector's
+        get_map() can spuriously report open in a forked child under GC.
+        """
+        js = Jobserver(context="fork", slots=2)
+        with js:
+            js.submit(fn=len, args=("warm",)).result(timeout=30)
+        # js is now closed; fork a child that tries to reuse it.
+        reader, writer = os.pipe()
+        pid = os.fork()
+        if pid == 0:  # pragma: no cover - exercised in the forked child
+            os.close(reader)
+            try:
+                js.submit(fn=len, args=("child",))
+                name = "NoError"
+            except BaseException as exc:  # noqa: BLE001
+                name = type(exc).__name__
+            os.write(writer, name.encode())
+            os.close(writer)
+            os._exit(0)
+        os.close(writer)
+        self.assertEqual(os.waitpid(pid, 0)[1], 0)
+        self.assertEqual(os.read(reader, 64).decode(), "RuntimeError")
+        os.close(reader)

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -485,8 +485,12 @@ class TestJobserverBasic(unittest.TestCase):
         with Jobserver(slots=2) as js:
             f = js.submit(fn=helper_return, args=(42,))
             self.assertEqual(42, f.result())
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(RuntimeError, "Jobserver is closed"):
             js.submit(fn=helper_return, args=(1,))
+        # Re-entering a closed Jobserver raises the same defined error
+        with self.assertRaisesRegex(RuntimeError, "Jobserver is closed"):
+            with js:
+                pass
 
     def test_context_manager_lingering_future(self) -> None:
         """Lingering Future completes and fires callbacks after exit."""


### PR DESCRIPTION
## Summary

Submitting to or re-entering a closed `Jobserver` leaked a low-level
`ValueError: I/O operation on closed epoll object` from the closed
`DefaultSelector`. This guards the submit, reclaim, and `__enter__` paths
in `_lazy_selector()` so they raise a defined
`RuntimeError("Jobserver is closed")` instead.

## Approach

- Closure is tracked on an explicit `_selector_closed` flag, set wherever
  the selector is torn down (factored into a new `_selector_close()` used
  by both `__exit__` and `__del__`).
- A plain `bool` is used rather than probing the live selector. A closed
  selector's `get_map()` can spuriously report *open* in a forked child
  under garbage collection, so a child forked from a closed parent would
  otherwise miss the closed state, fall through to the per-process
  selector rebuild, and trip `self._slots.waitable()` with an
  `AssertionError` instead of a clean error. Forks inherit the flag
  faithfully, and `_lazy_selector()` checks it before the rebuild.
- `_map_generate()`'s teardown loop also breaks on the new `RuntimeError`.

## Behavior preserved

Existing Futures still resolve after close; only new submissions and
re-entry are rejected.

## Testing

- New regression test `test_fork_of_closed_parent_raises_closed` covering
  the fork-of-closed-parent case (the original flake).
- Updated `test_context_manager_*` to assert the `RuntimeError` on both
  submit-after-close and re-entry.
- Full `./ci` passes (unit tests, examples, ruff, mypy, black, sdist
  build), including after rebasing onto current `master`.

Fixes #311.

https://claude.ai/code/session_01HzchSYTpSwGXGxyYgeCGdJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzchSYTpSwGXGxyYgeCGdJ)_