### PR TITLE
Add cross-process MPMCQueue with multiprocessing IPC locks

### DIFF
--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""SPSCQueue and related utility functions."""
+"""AbstractQueue and related utility functions."""
 
 import abc
 import queue
@@ -15,7 +15,7 @@ from multiprocessing import get_context
 from multiprocessing.connection import Connection
 from multiprocessing.context import BaseContext
 from multiprocessing.reduction import ForkingPickler
-from typing import Any, Generic, Optional, TypeVar, Union
+from typing import Any, Generic, Optional, TypeVar, Union, final
 
 __all__ = (
     "SPSCQueue",
@@ -68,7 +68,7 @@ def resolve_context(context: Union[None, str, BaseContext]) -> BaseContext:
 
 
 def _conn_repr(conn: Optional[Connection]) -> str:
-    """Describe a pipe end for SPSCQueue.__repr__, tolerating closed fds."""
+    """Describe a pipe end for __repr__, tolerating closed fds."""
     if conn is None:
         return "closed"
     # fileno() raises ValueError/OSError on a closed fd.
@@ -114,7 +114,7 @@ class AbstractQueue(Generic[T], abc.ABC):
 
     def __repr__(self) -> str:
         return (
-            f"SPSCQueue(reader={_conn_repr(self._reader)},"
+            f"{type(self).__name__}(reader={_conn_repr(self._reader)},"
             f" writer={_conn_repr(self._writer)})"
         )
 
@@ -148,12 +148,12 @@ class AbstractQueue(Generic[T], abc.ABC):
             pass
 
     def __copy__(self: Self) -> Self:
-        """Shallow copies return the original SPSCQueue unchanged."""
+        """Shallow copies return the original queue unchanged."""
         # Because any "copy" should and can only mutate same pipe/locks
         return self
 
     def __deepcopy__(self: Self, _: Any) -> Self:
-        """Deep copies return the original SPSCQueue unchanged."""
+        """Deep copies return the original queue unchanged."""
         # Because any "copy" should and can only mutate same pipe/locks
         return self
 
@@ -199,7 +199,9 @@ class AbstractQueue(Generic[T], abc.ABC):
             # ValueError here rather than a None-dereference at recv time.
             reader = self._reader
             if reader is None:
-                raise ValueError("SPSCQueue.get() after close_get()")
+                raise ValueError(
+                    f"{type(self).__name__}.get() after close_get()"
+                )
             if not reader.poll(deadline_to_timeout(deadline)):
                 raise queue.Empty
             # Reading under the lock preserves frame integrity if multiple
@@ -224,10 +226,13 @@ class AbstractQueue(Generic[T], abc.ABC):
             # ValueError here rather than a None-dereference at send time.
             writer = self._writer
             if writer is None:
-                raise ValueError("SPSCQueue.put() after close_put()")
+                raise ValueError(
+                    f"{type(self).__name__}.put() after close_put()"
+                )
             writer.send_bytes(bytez)
 
 
+@final
 class SPSCQueue(AbstractQueue[T]):
     """A single-producer, single-consumer AbstractQueue.
 

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -18,6 +18,7 @@ from multiprocessing.reduction import ForkingPickler
 from typing import Any, Generic, Optional, TypeVar, Union, final
 
 __all__ = (
+    "MPMCQueue",
     "SPSCQueue",
     "timeout_to_deadline",
     "deadline_to_timeout",
@@ -190,9 +191,10 @@ class AbstractQueue(Generic[T], abc.ABC):
         # and conditionals repeatedly checking for negative situations
         # Otherwise, this turns into an unpleasantly messy stretch of code
         deadline = timeout_to_deadline(timeout)
-        if not self._read_lock.acquire(
-            blocking=True, timeout=deadline_to_timeout(deadline)
-        ):
+        # Call acquire() positionally: threading locks name the first
+        # argument "blocking" while multiprocessing locks name it "block",
+        # so a keyword would not work across both lock implementations.
+        if not self._read_lock.acquire(True, deadline_to_timeout(deadline)):
             raise queue.Empty
         try:
             # Snapshot self._reader so a concurrent close_get() yields a clean
@@ -250,3 +252,39 @@ class SPSCQueue(AbstractQueue[T]):
     def _setstate_locks(self, _: Any) -> None:
         self._read_lock = threading.Lock()
         self._write_lock = threading.Lock()
+
+
+@final
+class MPMCQueue(AbstractQueue[T]):
+    """A multiple-producer, multiple-consumer AbstractQueue.
+
+    Safe for concurrent producers and consumers spread across processes:
+    the read/write guards are multiprocessing IPC locks minted from the
+    queue's multiprocessing context, so (unlike SPSCQueue) they are
+    preserved across pickling into other processes and provide genuine
+    cross-process mutual exclusion.  See AbstractQueue for the remaining
+    behavior.
+    """
+
+    __slots__ = ("_context",)
+
+    def __init__(self, context: Union[None, str, BaseContext] = None) -> None:
+        """Use given context with default of multiprocessing.get_context()."""
+        # Retain the resolved context so _setstate_locks can mint IPC locks
+        # from it at construction, before any locks have been inherited.
+        self._context = resolve_context(context)
+        super().__init__(self._context)
+
+    def _getstate_locks(self) -> Any:
+        # Preserve the IPC locks so cross-process mutual exclusion survives
+        # pickling into child processes (via multiprocessing inheritance).
+        return (self._read_lock, self._write_lock)
+
+    def _setstate_locks(self, state: Any) -> None:
+        if state is None:
+            # Fresh construction: mint new IPC locks from the context.
+            self._read_lock = self._context.Lock()
+            self._write_lock = self._context.Lock()
+        else:
+            # Unpickled into another process: reuse the inherited locks.
+            self._read_lock, self._write_lock = state

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""AbstractQueue and related utility functions."""
+"""MPMCQueue, SPSCQueue, and related utility functions."""
 
 import abc
 import queue
@@ -15,6 +15,7 @@ from multiprocessing import get_context
 from multiprocessing.connection import Connection
 from multiprocessing.context import BaseContext
 from multiprocessing.reduction import ForkingPickler
+from multiprocessing.synchronize import Lock
 from typing import Any, Generic, Optional, TypeVar, Union, final
 
 __all__ = (
@@ -102,7 +103,7 @@ class AbstractQueue(Generic[T], abc.ABC):
         ...
 
     @abc.abstractmethod
-    def _setstate_locks(self, state: Any) -> None:
+    def _setstate_locks(self, state_locks: Any) -> None:
         """Restore this queue's locks from _getstate_locks() output."""
         ...
 
@@ -128,8 +129,8 @@ class AbstractQueue(Generic[T], abc.ABC):
         self,
         state: tuple[Optional[Connection], Optional[Connection], Any],
     ) -> None:
-        self._reader, self._writer, lockstate = state
-        self._setstate_locks(lockstate)
+        self._reader, self._writer, state_locks = state
+        self._setstate_locks(state_locks)
 
     def __enter__(self: Self) -> Self:
         return self
@@ -238,10 +239,9 @@ class AbstractQueue(Generic[T], abc.ABC):
 class SPSCQueue(AbstractQueue[T]):
     """A single-producer, single-consumer AbstractQueue.
 
-    Here "single" means single process: the threading.Lock guards only
-    serialize concurrent producers or consumers within one process and
-    are recreated fresh on unpickle, so they provide no mutual exclusion
-    across processes.  See AbstractQueue for the remaining behavior.
+    Here "single" means single process: the threading.Lock guards
+    serialize producers and consumers within one process only and are
+    recreated fresh on unpickle, giving no cross-process exclusion.
     """
 
     __slots__ = ()
@@ -249,7 +249,7 @@ class SPSCQueue(AbstractQueue[T]):
     def _getstate_locks(self) -> None:
         return None  # locks are intra-process; never pickled
 
-    def _setstate_locks(self, _: Any) -> None:
+    def _setstate_locks(self, state_locks: Any) -> None:
         self._read_lock = threading.Lock()
         self._write_lock = threading.Lock()
 
@@ -258,12 +258,9 @@ class SPSCQueue(AbstractQueue[T]):
 class MPMCQueue(AbstractQueue[T]):
     """A multiple-producer, multiple-consumer AbstractQueue.
 
-    Safe for concurrent producers and consumers spread across processes:
-    the read/write guards are multiprocessing IPC locks minted from the
-    queue's multiprocessing context, so (unlike SPSCQueue) they are
-    preserved across pickling into other processes and provide genuine
-    cross-process mutual exclusion.  See AbstractQueue for the remaining
-    behavior.
+    Safe for concurrent producers and consumers across processes: the
+    read/write guards are multiprocessing IPC locks that are preserved
+    across pickling, providing genuine cross-process mutual exclusion.
     """
 
     __slots__ = ("_context",)
@@ -275,16 +272,16 @@ class MPMCQueue(AbstractQueue[T]):
         self._context = resolve_context(context)
         super().__init__(self._context)
 
-    def _getstate_locks(self) -> Any:
+    def _getstate_locks(self) -> tuple[Lock, Lock]:
         # Preserve the IPC locks so cross-process mutual exclusion survives
         # pickling into child processes (via multiprocessing inheritance).
         return (self._read_lock, self._write_lock)
 
-    def _setstate_locks(self, state: Any) -> None:
-        if state is None:
+    def _setstate_locks(self, state_locks: Any) -> None:
+        if state_locks is None:
             # Fresh construction: mint new IPC locks from the context.
             self._read_lock = self._context.Lock()
             self._write_lock = self._context.Lock()
         else:
             # Unpickled into another process: reuse the inherited locks.
-            self._read_lock, self._write_lock = state
+            self._read_lock, self._write_lock = state_locks

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""SPSCQueue and low-level utility tests.
+"""SPSCQueue, MPMCQueue, and low-level utility tests.
 
 SPSCQueue receives heavy indirect coverage through the Jobserver and
 JobserverExecutor suites, so this file only covers its own API surface
@@ -15,8 +15,19 @@ import time
 import unittest
 from multiprocessing import get_all_start_methods, get_context
 from multiprocessing.context import BaseContext
+from multiprocessing.synchronize import Lock as IPCLock
 
-from jobserver._queue import SPSCQueue, resolve_context, timeout_to_deadline
+from jobserver._queue import (
+    MPMCQueue,
+    SPSCQueue,
+    resolve_context,
+    timeout_to_deadline,
+)
+
+
+def _mpmc_echo_double(inq: MPMCQueue, outq: MPMCQueue) -> None:
+    """Child: receive one item on inq and send back twice its value."""
+    outq.put(inq.get(timeout=30) * 2)
 
 
 class SPSCQueueTest(unittest.TestCase):
@@ -57,6 +68,55 @@ class SPSCQueueTest(unittest.TestCase):
             mq.put(99)
         with self.assertRaises(ValueError):
             mq.get(timeout=0)
+
+
+class MPMCQueueTest(unittest.TestCase):
+    """Unit tests for MPMCQueue."""
+
+    def test_context_manager_roundtrip(self) -> None:
+        """Context manager closes both ends; put/get raise after exit."""
+        with MPMCQueue() as mq:
+            mq.put(42)
+            self.assertEqual(42, mq.get(timeout=1))
+        with self.assertRaises(ValueError):
+            mq.put(99)
+        with self.assertRaises(ValueError):
+            mq.get(timeout=0)
+
+    def test_guards_are_interprocess_locks(self) -> None:
+        """The read/write guards are multiprocessing IPC locks."""
+        with MPMCQueue() as mq:
+            self.assertIsInstance(mq._read_lock, IPCLock)
+            self.assertIsInstance(mq._write_lock, IPCLock)
+
+    def test_getstate_preserves_locks(self) -> None:
+        """_getstate_locks preserves the live locks; setstate reuses them."""
+        with MPMCQueue() as mq:
+            read_lock, write_lock = mq._read_lock, mq._write_lock
+            state = mq.__getstate__()
+            # Unlike SPSCQueue (which emits None), the lock blob is present.
+            self.assertEqual((read_lock, write_lock), state[2])
+            mq.__setstate__(state)
+            self.assertIs(read_lock, mq._read_lock)
+            self.assertIs(write_lock, mq._write_lock)
+
+    def test_cross_process_roundtrip(self) -> None:
+        """Locks survive pickling into a child that echoes via the queue."""
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                ctx = get_context(method)
+                with (
+                    MPMCQueue(context=ctx) as inq,
+                    MPMCQueue(context=ctx) as outq,
+                ):
+                    proc = ctx.Process(
+                        target=_mpmc_echo_double, args=(inq, outq)
+                    )
+                    proc.start()
+                    inq.put(21)
+                    self.assertEqual(42, outq.get(timeout=30))
+                    proc.join(30)
+                    self.assertEqual(0, proc.exitcode)
 
 
 class ResolveContextTest(unittest.TestCase):


### PR DESCRIPTION
Introduce `MPMCQueue`, a cross-process-safe sibling of `SPSCQueue`, as
the queue-layer groundwork toward the nested-submit corruption/deadlock
in #310. No existing behavior changes: the Jobserver still uses
`SPSCQueue` for its slot tokens.

## Changes

- **Name-agnostic base machinery.** `AbstractQueue.__repr__` and the
  `get()`/`put()` after-close `ValueError`s now use
  `type(self).__name__` instead of hardcoding a concrete class name, and
  the base's docstrings no longer name a specific subclass. `SPSCQueue`
  is marked `@final`.
- **`MPMCQueue`** (multiple-producer, multiple-consumer): its read/write
  guards are multiprocessing IPC locks minted from the queue's
  multiprocessing context. It retains the resolved context so
  `_setstate_locks` can build the locks at construction, and preserves
  the lock objects through `_getstate_locks` so cross-process mutual
  exclusion survives pickling into child processes via multiprocessing
  inheritance. Unlike `SPSCQueue` (whose `threading.Lock` guards are
  rebuilt fresh per process and only serialize within one process),
  `MPMCQueue` is safe for concurrent producers and consumers spread
  across processes.
- **Lock-agnostic acquire.** `AbstractQueue.get()` now calls
  `acquire()` positionally: `threading` locks name the first parameter
  `blocking` while `multiprocessing` locks name it `block`, so a keyword
  argument would not work across both lock implementations.

## Tests

Adds a minimal `MPMCQueueTest` to `test/test_queue.py`: context-manager
put/get roundtrip and post-exit `ValueError`s, that the guards are
multiprocessing IPC locks, that `_getstate_locks` preserves the live
locks (and `__setstate__` reuses them), and a cross-process echo
confirming the locks survive pickling into a child across all start
methods.

Manually verified end to end with a drain test (one parent fills 1000
items, six children concurrently consume) across spawn/fork/forkserver:
full accounting, zero frame corruption, zero lost items.

Toward #310.

https://claude.ai/code/session_017LP1XvK7PKZFgvoTDhqpfh

---
_Generated by [Claude Code](https://claude.ai/code/session_017LP1XvK7PKZFgvoTDhqpfh)_