### PR TITLE
Extract pickling queue logic into AbstractPicklingQueue

### DIFF
--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -182,6 +182,22 @@ class AbstractQueue(Generic[T], abc.ABC):
             self._writer.close()
             self._writer = None
 
+    @abc.abstractmethod
+    def get(self, timeout: Optional[float] = None) -> T:
+        """Get one object, raising queue.Empty when none is available.
+
+        Raises EOFError on an exhausted queue once the sending half hangs up.
+        """
+        ...
+
+    @abc.abstractmethod
+    def put(self, obj: T) -> None:
+        """Put one object into the queue.
+
+        Raises BrokenPipeError if the receiving half has hung up.
+        """
+        ...
+
 
 class AbstractPicklingQueue(AbstractQueue[T]):
     """AbstractQueue whose get()/put() pickle generic objects.

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -182,6 +182,17 @@ class AbstractQueue(Generic[T], abc.ABC):
             self._writer.close()
             self._writer = None
 
+
+class AbstractPicklingQueue(AbstractQueue[T]):
+    """AbstractQueue whose get()/put() pickle generic objects.
+
+    Objects are serialized/deserialized with ForkingPickler and moved
+    across the pipe as length-prefixed byte frames.  Both get(...) and
+    put(...) detect and report when one end hangs up.
+    """
+
+    __slots__ = ()
+
     def get(self, timeout: Optional[float] = None) -> T:
         """
         Get one object from the queue raising queue.Empty if unavailable.
@@ -236,7 +247,7 @@ class AbstractQueue(Generic[T], abc.ABC):
 
 
 @final
-class SPSCQueue(AbstractQueue[T]):
+class SPSCQueue(AbstractPicklingQueue[T]):
     """A single-producer, single-consumer AbstractQueue.
 
     Here "single" means single process: the threading.Lock guards
@@ -255,7 +266,7 @@ class SPSCQueue(AbstractQueue[T]):
 
 
 @final
-class MPMCQueue(AbstractQueue[T]):
+class MPMCQueue(AbstractPicklingQueue[T]):
     """A multiple-producer, multiple-consumer AbstractQueue.
 
     Safe for concurrent producers and consumers across processes: the

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -203,8 +203,7 @@ class AbstractPicklingQueue(AbstractQueue[T]):
     """AbstractQueue whose get()/put() pickle generic objects.
 
     Objects are serialized/deserialized with ForkingPickler and moved
-    across the pipe as length-prefixed byte frames.  Both get(...) and
-    put(...) detect and report when one end hangs up.
+    across the pipe as length-prefixed byte frames.
     """
 
     __slots__ = ()


### PR DESCRIPTION
## Summary
This change refactors the queue implementation to better separate concerns by introducing an intermediate `AbstractPicklingQueue` class that encapsulates the pickling/serialization logic shared by concrete queue implementations.

## Key Changes
- Added abstract `get()` and `put()` method signatures to `AbstractQueue` to define the interface contract
- Created new `AbstractPicklingQueue` class that extends `AbstractQueue` and implements the pickling-based serialization logic (length-prefixed byte frames using ForkingPickler)
- Updated `SPSCQueue` and `MPMCQueue` to inherit from `AbstractPicklingQueue` instead of directly from `AbstractQueue`

## Implementation Details
- The abstract methods in `AbstractQueue` now explicitly document the expected behavior (raising `queue.Empty` on timeout, `EOFError` on exhausted queue, `BrokenPipeError` on broken pipe)
- `AbstractPicklingQueue` serves as a base class for queue implementations that serialize objects across pipes, making it easier to support alternative serialization strategies in the future
- The concrete queue classes (`SPSCQueue`, `MPMCQueue`) maintain their existing functionality while benefiting from clearer inheritance hierarchy

https://claude.ai/code/session_017LP1XvK7PKZFgvoTDhqpfh