### PR TITLE
Add lockless FixedBytesQueue for fixed-length byte tokens

### DIFF
--- a/src/jobserver/_compat.py
+++ b/src/jobserver/_compat.py
@@ -7,6 +7,7 @@
 
 import os
 import pickle
+import select
 import signal
 
 # Failures from pickling a payload for a queue: PicklingError, an
@@ -25,6 +26,15 @@ def ignore_sigpipe() -> None:
     """
     if hasattr(signal, "SIGPIPE"):
         signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+
+
+def pipe_buf() -> int:
+    """Return the maximum number of bytes guaranteed atomic per pipe write.
+
+    On Unix this is select.PIPE_BUF; when select.PIPE_BUF is unavailable
+    (e.g. on Windows) fall back to the POSIX-minimum value of 512.
+    """
+    return getattr(select, "PIPE_BUF", 512)
 
 
 def sched_getaffinity0() -> int:

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -3,9 +3,10 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""MPMCQueue, SPSCQueue, and related utility functions."""
+"""FixedBytesQueue, MPMCQueue, SPSCQueue, and related utility functions."""
 
 import abc
+import os
 import queue
 import threading
 import time
@@ -18,7 +19,10 @@ from multiprocessing.reduction import ForkingPickler
 from multiprocessing.synchronize import Lock
 from typing import Any, Generic, Optional, TypeVar, Union, final
 
+from ._compat import pipe_buf
+
 __all__ = (
+    "FixedBytesQueue",
     "MPMCQueue",
     "SPSCQueue",
     "timeout_to_deadline",
@@ -106,10 +110,14 @@ class AbstractQueue(Generic[T], abc.ABC):
             f" writer={_conn_repr(self._writer)})"
         )
 
-    def __getstate__(self) -> tuple[Any, ...]:
+    def __getstate__(
+        self,
+    ) -> tuple[Optional[Connection], Optional[Connection]]:
         return (self._reader, self._writer)
 
-    def __setstate__(self, state: tuple[Any, ...]) -> None:
+    def __setstate__(
+        self, state: tuple[Optional[Connection], Optional[Connection]]
+    ) -> None:
         self._reader, self._writer = state
 
     def __enter__(self: Self) -> Self:
@@ -321,3 +329,99 @@ class MPMCQueue(AbstractPicklingQueue[T]):
         else:
             # Unpickled into another process: reuse the inherited locks.
             self._read_lock, self._write_lock = state_locks
+
+
+@final
+class FixedBytesQueue(AbstractQueue[bytes]):
+    """A lockless queue of fixed-length byte tokens.
+
+    Tokens are fixedlen bytes with 1 <= fixedlen < PIPE_BUF.  Each get() is a
+    single indivisible read() and each put() one atomic <= PIPE_BUF write(),
+    so whole tokens move across processes losslessly without any lock.
+    """
+
+    __slots__ = ("_fixedlen",)
+
+    def __init__(
+        self,
+        context: Union[None, str, BaseContext] = None,
+        *,
+        fixedlen: int,
+    ) -> None:
+        """Use fixedlen-byte tokens; requires 1 <= fixedlen < pipe_buf()."""
+        if not isinstance(fixedlen, int):
+            raise TypeError(f"fixedlen: int, got {type(fixedlen).__name__}")
+        if not 1 <= fixedlen < pipe_buf():
+            raise ValueError(
+                f"fixedlen must satisfy 1 <= fixedlen < {pipe_buf()}, "
+                f"got {fixedlen!r}"
+            )
+        super().__init__(context)
+        self.__setstate__((self._reader, self._writer, fixedlen))
+
+    def __getstate__(self) -> tuple[Any, ...]:
+        return (*super().__getstate__(), self._fixedlen)
+
+    def __setstate__(self, state: tuple[Any, ...]) -> None:
+        reader, writer, fixedlen = state
+        super().__setstate__((reader, writer))
+        self._fixedlen = fixedlen
+        # Non-blocking reads let a consumer that loses the post-poll() race
+        # fall through and retry rather than block on a drained pipe.
+        if self._reader is not None:
+            os.set_blocking(self._reader.fileno(), False)
+
+    def get(self, timeout: Optional[float] = None) -> bytes:
+        """Get one fixedlen-byte token, raising queue.Empty if unavailable.
+
+        Raises EOFError once the sending half has hung up and drained.
+        """
+        deadline = timeout_to_deadline(timeout)
+        while True:
+            reader = self._reader
+            if reader is None:
+                raise ValueError(
+                    f"{type(self).__name__}.get() after close_get()"
+                )
+            if not reader.poll(deadline_to_timeout(deadline)):
+                raise queue.Empty
+            # One indivisible read() of exactly fixedlen bytes, never looped,
+            # so consumers can't split a token.  Losing the post-poll() race
+            # surfaces as EAGAIN on the non-blocking reader, so retry.
+            try:
+                token = os.read(reader.fileno(), self._fixedlen)
+            except BlockingIOError:
+                continue
+            if not token:
+                raise EOFError
+            if len(token) != self._fixedlen:
+                # Cannot happen while every put()/get() honors fixedlen, but
+                # fail loudly rather than hand back a truncated token.
+                raise OSError(
+                    f"read {len(token)} bytes, expected exactly "
+                    f"{self._fixedlen}"
+                )
+            return token
+
+    def put(self, obj: bytes) -> None:
+        """Put one or more fixedlen-byte tokens in a single atomic write.
+
+        len(obj) must be a positive multiple of fixedlen and at most
+        select.PIPE_BUF so the write stays atomic.  Raises ValueError
+        otherwise, or BrokenPipeError if the receiving half has hung up.
+        """
+        n = len(obj)
+        # Fast path: a single token is always valid since fixedlen was
+        # checked in __init__.  Only multi-token writes pay for the rest.
+        if n != self._fixedlen and (
+            n == 0 or n % self._fixedlen != 0 or n > pipe_buf()
+        ):
+            raise ValueError(
+                f"put() requires a positive multiple of {self._fixedlen} "
+                f"bytes up to {pipe_buf()}, got {n}"
+            )
+        writer = self._writer
+        if writer is None:
+            raise ValueError(f"{type(self).__name__}.put() after close_put()")
+        # One atomic write() of <= PIPE_BUF bytes (whole tokens).
+        os.write(writer.fileno(), obj)

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""SPSCQueue, MPMCQueue, and low-level utility tests.
+"""SPSCQueue, MPMCQueue, FixedBytesQueue, and low-level utility tests.
 
 SPSCQueue receives heavy indirect coverage through the Jobserver and
 JobserverExecutor suites, so this file only covers its own API surface
@@ -11,13 +11,16 @@ and the resolve_context / timeout_to_deadline helpers.
 """
 
 import copy
+import queue
 import time
 import unittest
 from multiprocessing import get_all_start_methods, get_context
 from multiprocessing.context import BaseContext
 from multiprocessing.synchronize import Lock as IPCLock
 
+from jobserver._compat import pipe_buf
 from jobserver._queue import (
+    FixedBytesQueue,
     MPMCQueue,
     SPSCQueue,
     resolve_context,
@@ -28,6 +31,11 @@ from jobserver._queue import (
 def _mpmc_echo_double(inq: MPMCQueue, outq: MPMCQueue) -> None:
     """Child: receive one item on inq and send back twice its value."""
     outq.put(inq.get(timeout=30) * 2)
+
+
+def _fbq_echo(inq: FixedBytesQueue, outq: FixedBytesQueue) -> None:
+    """Child: receive one token on inq and send it back unchanged on outq."""
+    outq.put(inq.get(timeout=30))
 
 
 class SPSCQueueTest(unittest.TestCase):
@@ -115,6 +123,119 @@ class MPMCQueueTest(unittest.TestCase):
                     proc.start()
                     inq.put(21)
                     self.assertEqual(42, outq.get(timeout=30))
+                    proc.join(30)
+                    self.assertEqual(0, proc.exitcode)
+
+
+class FixedBytesQueueTest(unittest.TestCase):
+    """Unit tests for FixedBytesQueue.
+
+    The headline property is that, restricted to fixedlen-byte payloads,
+    FixedBytesQueue is observationally indistinguishable from MPMCQueue
+    used on bytes: same FIFO values, same Empty/EOF/closed semantics.
+    """
+
+    @staticmethod
+    def _byte_queues():
+        """Factories for a FixedBytesQueue and an MPMCQueue using 4-byte
+        tokens, the regime in which the two must be indistinguishable."""
+        return (
+            ("FixedBytesQueue", lambda: FixedBytesQueue(fixedlen=4)),
+            ("MPMCQueue", lambda: MPMCQueue()),
+        )
+
+    def test_roundtrip_matches_mpmc(self) -> None:
+        """Both queues return the same bytes in the same FIFO order."""
+        tokens = [b"AAAA", b"BBBB", b"CCCC", b"DDDD"]
+        results = {}
+        for name, factory in self._byte_queues():
+            with factory() as q:
+                for token in tokens:
+                    q.put(token)
+                results[name] = [q.get(timeout=1) for _ in tokens]
+        self.assertEqual(tokens, results["FixedBytesQueue"])
+        self.assertEqual(results["FixedBytesQueue"], results["MPMCQueue"])
+
+    def test_empty_raises_queue_empty_like_mpmc(self) -> None:
+        """get() on an empty queue raises queue.Empty for both."""
+        for name, factory in self._byte_queues():
+            with self.subTest(queue=name), factory() as q:
+                with self.assertRaises(queue.Empty):
+                    q.get(timeout=0)
+
+    def test_eof_after_close_put_like_mpmc(self) -> None:
+        """Draining then reading a hung-up queue raises EOFError for both."""
+        for name, factory in self._byte_queues():
+            with self.subTest(queue=name):
+                q = factory()
+                try:
+                    q.put(b"AAAA")
+                    q.close_put()
+                    self.assertEqual(b"AAAA", q.get(timeout=1))
+                    with self.assertRaises(EOFError):
+                        q.get(timeout=1)
+                finally:
+                    q.close_get()
+
+    def test_after_close_raises_valueerror_like_mpmc(self) -> None:
+        """put()/get() after the context manager exits raise for both."""
+        for name, factory in self._byte_queues():
+            with self.subTest(queue=name):
+                with factory() as q:
+                    q.put(b"AAAA")
+                    self.assertEqual(b"AAAA", q.get(timeout=1))
+                with self.assertRaises(ValueError):
+                    q.put(b"AAAA")
+                with self.assertRaises(ValueError):
+                    q.get(timeout=0)
+
+    def test_init_rejects_out_of_range_fixedlen(self) -> None:
+        """fixedlen must satisfy 1 <= fixedlen < pipe_buf()."""
+        for bad in (0, -1, pipe_buf(), pipe_buf() + 1):
+            with self.subTest(fixedlen=bad), self.assertRaises(ValueError):
+                FixedBytesQueue(fixedlen=bad)
+
+    def test_init_rejects_non_int_fixedlen(self) -> None:
+        """A non-int fixedlen raises TypeError."""
+        with self.assertRaises(TypeError):
+            FixedBytesQueue(fixedlen=4.0)
+
+    def test_put_rejects_non_multiple_length(self) -> None:
+        """put() rejects empty and non-multiple-of-fixedlen payloads."""
+        with FixedBytesQueue(fixedlen=4) as q:
+            for bad in (b"", b"abc", b"abcde"):
+                with self.subTest(payload=bad), self.assertRaises(ValueError):
+                    q.put(bad)
+
+    def test_put_rejects_over_pipe_buf(self) -> None:
+        """put() rejects a whole-token payload exceeding pipe_buf()."""
+        with FixedBytesQueue(fixedlen=4) as q:
+            over = b"a" * (((pipe_buf() // 4) + 1) * 4)
+            with self.assertRaises(ValueError):
+                q.put(over)
+
+    def test_multi_token_put_reads_individually(self) -> None:
+        """A multi-token put() is read back one token at a time."""
+        with FixedBytesQueue(fixedlen=4) as q:
+            q.put(b"AAAABBBBCCCC")
+            self.assertEqual(
+                [b"AAAA", b"BBBB", b"CCCC"],
+                [q.get(timeout=1) for _ in range(3)],
+            )
+
+    def test_cross_process_roundtrip(self) -> None:
+        """Tokens survive being shared with a child across start methods."""
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                ctx = get_context(method)
+                with (
+                    FixedBytesQueue(ctx, fixedlen=4) as inq,
+                    FixedBytesQueue(ctx, fixedlen=4) as outq,
+                ):
+                    proc = ctx.Process(target=_fbq_echo, args=(inq, outq))
+                    proc.start()
+                    inq.put(b"PING")
+                    self.assertEqual(b"PING", outq.get(timeout=30))
                     proc.join(30)
                     self.assertEqual(0, proc.exitcode)
 


### PR DESCRIPTION
Add `FixedBytesQueue(AbstractQueue[bytes])`, a lockless token pool, plus
the `_compat.pipe_buf()` helper it relies on. Groundwork toward the
nested-submit deadlock in #310; nothing is wired into the Jobserver yet.

## What & why

Tokens are `fixedlen` bytes with `1 <= fixedlen < select.PIPE_BUF`, so
each `get()` is a single indivisible `read()` and each `put()` one atomic
`<= PIPE_BUF` `write()`. POSIX guarantees a write of `<= PIPE_BUF` bytes
does not interleave with other writers, and that a single `read()`
syscall is indivisible, so whole tokens move across processes **without
any lock** — the GNU make jobserver model.

- `put()` accepts any positive multiple of `fixedlen` up to `PIPE_BUF`
  (so several tokens can be restored in one atomic write) and rejects
  everything else; the common single-token case is a fast-path equality
  check.
- `get()` reads exactly `fixedlen` via a non-blocking reader, retrying on
  the post-`poll()` race and raising on a short read.
- `_compat.pipe_buf()` returns `select.PIPE_BUF`, falling back to 512 when
  unavailable (e.g. on Windows).

Also tightens `AbstractQueue.__getstate__`/`__setstate__` to the precise
`(Connection | None, Connection | None)` 2-tuple.

## Tests

Adds `FixedBytesQueueTest`: `fixedlen` and `put()` validation, multi-token
puts, cross-process roundtrips across all start methods, and the headline
property that on `fixedlen`-byte payloads `FixedBytesQueue` is
observationally indistinguishable from `MPMCQueue` (same FIFO values and
Empty/EOF/closed semantics).

Toward #310.

https://claude.ai/code/session_017LP1XvK7PKZFgvoTDhqpfh