### PR TITLE
Use lockless FixedBytesQueue for the Jobserver slot pool (fixes #310)

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -34,10 +34,11 @@ from typing import Any, Generic, NoReturn, Optional, TypeVar, Union, cast
 from ._compat import (
     PICKLE_DUMP_ERRORS,
     ignore_sigpipe,
+    pipe_buf,
     sched_getaffinity0,
 )
 from ._queue import (
-    SPSCQueue,
+    FixedBytesQueue,
     deadline_to_timeout,
     resolve_context,
     timeout_to_deadline,
@@ -513,7 +514,7 @@ class SlotsSentinel:
         return None
 
 
-def _restore_token(slots: SPSCQueue, token: Optional[int]) -> None:
+def _restore_token(slots: FixedBytesQueue, token: Optional[bytes]) -> None:
     """Restore token to slots, tolerating a closed queue."""
     if token is not None:
         try:
@@ -553,12 +554,6 @@ def _unregister_connection(
     except KeyError:
         pass  # Already unregistered or selector closed
     connection.close()
-
-
-# Upper bound on slots, rejected above.  A pipe's buffer is finite, so
-# put()ing one token per slot blocks forever once it fills.  2048 tokens
-# fill ~36 KiB, fitting comfortably within a 64 KiB pipe.
-_MAX_SLOTS = 2048
 
 
 class Jobserver:
@@ -614,16 +609,18 @@ class Jobserver:
             raise TypeError(f"slots: int, got {type(slots).__name__}")
         if slots < 1:
             raise ValueError(f"slots must be >= 1, got {slots!r}")
-        if slots > _MAX_SLOTS:
-            raise ValueError(f"slots must be <= {_MAX_SLOTS}, got {slots!r}")
+        # All tokens are written in one atomic put(), which FixedBytesQueue
+        # bounds at pipe_buf() bytes; one byte per slot caps slots there too.
+        if slots > pipe_buf():
+            raise ValueError(f"slots must be <= {pipe_buf()}, got {slots!r}")
 
         # Obtain some multiprocessing Context and the slot-tracking queue
         self._context = resolve_context(context)
-        self._slots: SPSCQueue[int] = SPSCQueue(self._context)
+        self._slots = FixedBytesQueue(self._context, fixedlen=1)
 
-        # Issue one token for each requested slot
-        for token in range(slots):
-            self._slots.put(token)
+        # One single-byte token per slot, written in one atomic put().  The
+        # byte value is opaque, so "J" (for Jobserver) is as good as any.
+        self._slots.put(b"J" * slots)
 
         # Tracks outstanding Futures via their process sentinels.  Built
         # lazily by _lazy_selector(); None means "not yet built" and
@@ -1181,8 +1178,8 @@ def _maybe_obtain_token(
     reclaim_tokens_fn: Callable[[], Any],
     selector: DefaultSelector,
     sleep_fn: SleepFn,
-    slots: SPSCQueue[int],
-) -> Optional[int]:
+    slots: FixedBytesQueue,
+) -> Optional[bytes]:
     """
     Either retrieve a requested token or raise Blocked while trying.
 
@@ -1193,7 +1190,7 @@ def _maybe_obtain_token(
     if type(consume) is not int or consume not in (0, 1):
         raise ValueError(f"consume must be 0 or 1, got {consume!r}")
     # Acquire the requested token or raise Blocked when impossible
-    token: Optional[int] = None
+    token: Optional[bytes] = None
     # Ready fds the previous pass could not reclaim
     # If they recur, back off to avoid busy spinning
     stall_fds: set[int] = set()

--- a/test/test_jobserver_slots.py
+++ b/test/test_jobserver_slots.py
@@ -5,10 +5,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """slots is bounded so construction cannot hang (issue #302).
 
-Filling a token pipe is O(slots) and, worse, deadlocks once the pipe
-buffer fills: put() blocks forever waiting for space no reader frees.
-Construction therefore rejects slots beyond _MAX_SLOTS with an
-informative ValueError, and the largest allowed value still fits.
+All tokens are written in one atomic FixedBytesQueue.put(), which is
+capped at pipe_buf() bytes; one single-byte token per slot caps slots
+there too.  Construction therefore rejects slots beyond pipe_buf() with
+an informative ValueError, and the largest allowed value still fits.
 """
 
 import threading
@@ -16,20 +16,20 @@ import time
 import unittest
 
 from jobserver import Jobserver
-from jobserver._jobserver import _MAX_SLOTS
+from jobserver._compat import pipe_buf
 
 from .helpers import FAST, TIMEOUT
 
 
 class TestLargeSlots(unittest.TestCase):
-    """slots above _MAX_SLOTS is rejected; the boundary still works."""
+    """slots above pipe_buf() is rejected; the boundary still works."""
 
     def test_slots_above_max_raises_informative_valueerror(self) -> None:
         """Jobserver(slots=10**9) fails fast rather than hanging."""
         with self.assertRaises(ValueError) as cm:
             Jobserver(context=FAST, slots=10**9)
         message = str(cm.exception)
-        self.assertIn(str(_MAX_SLOTS), message)
+        self.assertIn(str(pipe_buf()), message)
         self.assertIn(repr(10**9), message)
 
     def test_max_slots_constructs_quickly_and_runs(self) -> None:
@@ -38,7 +38,7 @@ class TestLargeSlots(unittest.TestCase):
 
         def build() -> None:
             # Construct and immediately tear down; both must be fast.
-            with Jobserver(context=FAST, slots=_MAX_SLOTS):
+            with Jobserver(context=FAST, slots=pipe_buf()):
                 pass
             done.set()
 
@@ -56,7 +56,7 @@ class TestLargeSlots(unittest.TestCase):
 
     def test_max_slots_still_runs_work(self) -> None:
         """A max-slots Jobserver still accepts and completes work."""
-        with Jobserver(context=FAST, slots=_MAX_SLOTS) as js:
+        with Jobserver(context=FAST, slots=pipe_buf()) as js:
             future = js.submit(fn=abs, args=(-7,))
             self.assertEqual(future.result(timeout=TIMEOUT), 7)
 


### PR DESCRIPTION
Switch `Jobserver._slots` from `SPSCQueue` to `FixedBytesQueue(fixedlen=1)`,
the cross-process-safe single-byte token pool, **fixing the nested-submit
corruption and deadlock in #310**.

## Why this fixes #310

The nestable design requires multiple worker *processes* to share the
slot-token queue concurrently. `SPSCQueue`'s `threading.Lock` guards are
intra-process and rebuilt per process, so there was no cross-process
mutual exclusion on the token pipe — concurrent length-prefixed reads
interleaved, corrupting frames and losing tokens until everything
deadlocked. `FixedBytesQueue` uses single-byte tokens: each `put`/`get`
is one atomic `write()`/indivisible `read()`, so tokens move between
processes losslessly **without any lock**.

The issue's reproducer (8 nested parents × 40 nested submits over
`slots=4`) previously deadlocked ~deterministically; it now returns
`[40]×8`.

## Changes

- `self._slots = FixedBytesQueue(self._context, fixedlen=1)`.
- Populate every slot in **one atomic `put()`** — `put(b"J" * slots)` —
  using the multi-token `put()` semantics. The byte value is opaque (only
  the count matters); `"J"` is for Jobserver.
- Remove `_MAX_SLOTS`; the bound is now `_compat.pipe_buf()`, since all
  tokens are written in a single atomic put capped at `PIPE_BUF`, so one
  byte per slot caps slots there. `slots <= pipe_buf()` is allowed
  (POSIX atomicity is "`PIPE_BUF` or fewer bytes", inclusive).
- Tokens are now `bytes` not `int`: updated `_maybe_obtain_token` /
  `_restore_token` types and the slots-bound test (it imported
  `_MAX_SLOTS`).

Everything else — `waitable()`, `close_*`, selector wiring, the
consume/unwind/restore paths — used the queue's public interface and was
already token-value-agnostic, so the swap is otherwise drop-in.

Full CI green (245 tests); the #310 reproducer passes.

Fixes #310.

https://claude.ai/code/session_017LP1XvK7PKZFgvoTDhqpfh

---
_Generated by [Claude Code](https://claude.ai/code/session_017LP1XvK7PKZFgvoTDhqpfh)_