### PR TITLE
Mark public classes with @final decorator

### DIFF
--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -16,7 +16,7 @@ import weakref
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from multiprocessing.connection import Connection, wait
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, Optional, TypeVar, Union, final
 
 from . import _request, _response
 from ._compat import PICKLE_DUMP_ERRORS, ignore_sigpipe
@@ -35,6 +35,7 @@ _LOG = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+@final
 class JobserverExecutor(concurrent.futures.Executor):
     """A concurrent.futures.Executor that delegates to a Jobserver.
 

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -29,7 +29,16 @@ from multiprocessing.context import BaseContext
 from multiprocessing.process import BaseProcess
 from multiprocessing.reduction import ForkingPickler
 from selectors import EVENT_READ, DefaultSelector
-from typing import Any, Generic, NoReturn, Optional, TypeVar, Union, cast
+from typing import (
+    Any,
+    Generic,
+    NoReturn,
+    Optional,
+    TypeVar,
+    Union,
+    cast,
+    final,
+)
 
 from ._compat import (
     PICKLE_DUMP_ERRORS,
@@ -69,10 +78,12 @@ EnvItems = Union[
 ]
 
 
+@final
 class Blocked(Exception):
     """Reports that Jobserver.submit(...) or Future.result(...) is blocked."""
 
 
+@final
 class CallbackRaised(Exception):
     """
     Reports an Exception raised from callbacks registered with a Future.
@@ -106,6 +117,7 @@ class CallbackRaised(Exception):
     __str__ = __repr__
 
 
+@final
 class SubmissionDied(Exception):
     """
     Reports a submission died for unknowable reasons, e.g. being killed.
@@ -246,6 +258,7 @@ def _callback_wrapper(seqno: int, fn, *args, **kwargs) -> None:
         raise CallbackRaised(seqno) from e
 
 
+@final
 class Future(Generic[T]):
     """
     Future instances are obtained by submitting work to a Jobserver.
@@ -556,6 +569,7 @@ def _unregister_connection(
     connection.close()
 
 
+@final
 class Jobserver:
     """A Jobserver exposing a Future interface built atop multiprocessing.
 


### PR DESCRIPTION
This change adds the `@final` decorator from the `typing` module to all public-facing classes in the jobserver package to prevent subclassing.

## Summary
Applied the `@final` decorator to classes that are part of the public API to enforce that they should not be subclassed. This helps maintain API stability and prevents users from creating incompatible subclasses.

## Key Changes
- Added `final` to the `typing` imports in both `_jobserver.py` and `_executor.py`
- Applied `@final` decorator to the following classes:
  - `Blocked` exception class
  - `CallbackRaised` exception class
  - `SubmissionDied` exception class
  - `Future` generic class
  - `Jobserver` main class
  - `JobserverExecutor` executor class

## Implementation Details
The `@final` decorator is a typing construct that signals to type checkers and developers that these classes are not intended to be subclassed. This is particularly important for exception classes and core infrastructure classes where subclassing could lead to unexpected behavior or API incompatibilities.

https://claude.ai/code/session_01DrufC7wkUMByMDLc8Tck55