### PR TITLE
Fix kwargs collision with worker entrypoint parameters

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -951,8 +951,7 @@ class Jobserver:
             recv, send = self._context.Pipe(duplex=False)
             process = self._context.Process(  # type: ignore
                 target=_worker_entrypoint,
-                args=((send, env, preexec_fn, fn) + args),
-                kwargs=kwargs,
+                args=(send, env, preexec_fn, fn, args, kwargs),
                 daemon=False,
                 name="Jobserver-worker",
             )
@@ -1099,7 +1098,7 @@ class Jobserver:
         )
 
 
-def _worker_entrypoint(send, env, preexec_fn, fn, *args, **kwargs) -> None:
+def _worker_entrypoint(send, env, preexec_fn, fn, args, kwargs) -> None:
     """Entry point for workers to run fn(...) due to some submit(...)."""
     ignore_sigpipe()
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -117,6 +117,11 @@ def helper_return(arg: T) -> T:
     return arg
 
 
+def helper_return_kwargs(**kwargs: typing.Any) -> dict:
+    """Helper returning whatever keyword arguments it received."""
+    return kwargs
+
+
 def helper_marker_return(directory: str, arg: T) -> T:
     """Create a marker file named for arg under directory then return arg.
 

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -44,6 +44,7 @@ from .helpers import (
     helper_raise,
     helper_return,
     helper_return_connection,
+    helper_return_kwargs,
 )
 
 
@@ -562,7 +563,7 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         boom = AttributeError("misbehaving connection")
         send = _RecordingSend(fail_with=boom)
         with self.assertRaises(AttributeError) as ctx:
-            _worker_entrypoint(send, {}, lambda: None, len, (1, 2, 3))
+            _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})
         self.assertIs(boom, ctx.exception)
         # No "not picklable" rewrap was sent in place of the real error.
         self.assertEqual([], send.payloads)
@@ -570,7 +571,7 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
     def test_picklable_result_sent_unchanged(self) -> None:
         """A picklable result rides the happy path to a single send."""
         send = _RecordingSend()
-        _worker_entrypoint(send, {}, lambda: None, len, (1, 2, 3))
+        _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
         self.assertIsInstance(wrapper, ResultWrapper)
@@ -580,7 +581,9 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
     def test_unpicklable_result_uses_fallback(self) -> None:
         """A genuinely unpicklable result still degrades to the fallback."""
         send = _RecordingSend()
-        _worker_entrypoint(send, {}, lambda: None, _make_unpicklable_result)
+        _worker_entrypoint(
+            send, {}, lambda: None, _make_unpicklable_result, (), {}
+        )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
         self.assertIsInstance(wrapper, ExceptionWrapper)
@@ -588,6 +591,35 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
             wrapper.unwrap()
         self.assertIn("not picklable", str(ctx.exception))
         self.assertTrue(send.closed)
+
+
+class TestKwargsNameCollisions(unittest.TestCase):
+    """A target's kwargs must forward verbatim for any key name, including
+    those shared with the internal worker entrypoint parameters (#322)."""
+
+    def test_entrypoint_parameter_names_forward(self) -> None:
+        """fn/env/preexec_fn/send no longer collide with the entrypoint."""
+        names = (
+            "send",
+            "env",
+            "preexec_fn",
+            "fn",
+            "args",
+            "kwargs",
+            "timeout",
+            "consume",
+            "sleep_fn",
+        )
+        for method in get_all_start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=method, slots=2) as js:
+                    for name in names:
+                        with self.subTest(name=name):
+                            future = js.submit(
+                                fn=helper_return_kwargs,
+                                kwargs={name: 1},
+                            )
+                            self.assertEqual({name: 1}, future.result())
 
 
 class TestResultNotReconstructable(unittest.TestCase):


### PR DESCRIPTION
## Summary
This PR fixes a bug where keyword arguments passed to `submit()` could collide with internal worker entrypoint parameter names, causing them to be lost or misinterpreted.

## Key Changes
- **Modified `_worker_entrypoint` signature**: Changed from `_worker_entrypoint(send, env, preexec_fn, fn, *args, **kwargs)` to `_worker_entrypoint(send, env, preexec_fn, fn, args, kwargs)` to explicitly separate internal parameters from user-provided arguments and keyword arguments.

- **Updated `submit()` method**: Changed how arguments are passed to the worker process:
  - Before: `args=((send, env, preexec_fn, fn) + args), kwargs=kwargs`
  - After: `args=(send, env, preexec_fn, fn, args, kwargs)`
  
  This ensures user-provided `args` and `kwargs` are passed as distinct positional arguments rather than being unpacked into the Process constructor.

- **Added test coverage**: New `TestKwargsNameCollisions` test class that verifies all internal parameter names (`send`, `env`, `preexec_fn`, `fn`, `args`, `kwargs`, `timeout`, `consume`, `sleep_fn`) can be safely used as keyword argument names without collision.

- **Added helper function**: `helper_return_kwargs()` in test helpers to support testing kwargs forwarding.

## Implementation Details
The root cause was that user kwargs were being passed directly to the Process constructor's `kwargs` parameter, which could conflict with internal parameter names. By explicitly passing `args` and `kwargs` as positional arguments to the entrypoint, we ensure they are treated as user data and forwarded verbatim to the target function, regardless of their key names.

https://claude.ai/code/session_019S1x8CuZSZxPFegMsXndkG