### PR TITLE
Documentation review: new examples, expanded timeout coverage, and a stdlib comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,24 +45,49 @@ Examples
 
  * [ex01_basic](examples/ex01_basic.py) - Submitting jobs and collecting results
    via shorthand, keyword args, and `submit()`.
- * [ex02_nested](examples/ex02_nested.py) - Nesting submissions so child work
+ * [ex02_lifecycle](examples/ex02_lifecycle.py) - Polling with `done()`,
+   `wait()`, and `result()`, plus `reclaim_resources()` and cleanup.
+ * [ex03_nested](examples/ex03_nested.py) - Nesting submissions so child work
    shares slot constraints with its parent.
- * [ex03_death](examples/ex03_death.py) - Detecting when a worker process is
+ * [ex04_death](examples/ex04_death.py) - Detecting when a worker process is
    killed unexpectedly via `SubmissionDied`.
- * [ex04_sleep_fn](examples/ex04_sleep_fn.py) - Gating work acceptance on an
+ * [ex05_sleep_fn](examples/ex05_sleep_fn.py) - Gating work acceptance on an
    external condition using `sleep_fn`.
- * [ex05_callbacks](examples/ex05_callbacks.py) - Registering `when_done`
+ * [ex06_callbacks](examples/ex06_callbacks.py) - Registering `when_done`
    callbacks and draining errors via `CallbackRaised`.
- * [ex06_environment](examples/ex06_environment.py) - Setting and unsetting
+ * [ex07_environment](examples/ex07_environment.py) - Setting and unsetting
    environment variables in child processes via `env=`.
- * [ex07_preexec_fn](examples/ex07_preexec_fn.py) - Using `preexec_fn` as
+ * [ex08_preexec_fn](examples/ex08_preexec_fn.py) - Using `preexec_fn` as
    a plain callable or context manager factory for entry/exit semantics.
- * [ex08_timeouts](examples/ex08_timeouts.py) - Using non-blocking polling,
+ * [ex09_timeouts](examples/ex09_timeouts.py) - Using non-blocking polling,
    finite deadlines, and `Blocked` from `result()` and `submit()`.
- * [ex09_pdeathsig](examples/ex09_pdeathsig.py) - On Linux, using `preexec_fn`
+ * [ex10_pdeathsig](examples/ex10_pdeathsig.py) - On Linux, using `preexec_fn`
    to call `prctl(PR_SET_PDEATHSIG)` so a child dies when its parent does.
- * [ex10_executor](examples/ex10_executor.py) - Using `JobserverExecutor` as
+ * [ex11_executor](examples/ex11_executor.py) - Using `JobserverExecutor` as
    a context manager supporting `map()` and `c.f.Future` cancellation.
+
+Comparison with the Python Standard Library
+-------------------------------------------
+
+How `Jobserver` and `JobserverExecutor` compare to the standard library's
+[`Pool`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool)
+and
+[`ProcessPoolExecutor`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ProcessPoolExecutor):
+
+| Feature                           | `Pool` | `ProcessPoolExecutor` | `Jobserver` | `JobserverExecutor` |
+|-----------------------------------|:------:|:---------------------:|:-----------:|:-------------------:|
+| Nested work shares the slot pool  |   no   |          no           |     yes     |         yes         |
+| Background thread                 |  yes   |          yes          |     no      |         yes         |
+| Cancel pending work               |   no   |          yes          |     no      |         yes         |
+| Detects individual worker death   |   no   |       partial\*       |     yes     |         yes         |
+| User-defined launch criteria      |   no   |          no           |     yes     |         yes         |
+| Lambdas/closures via `fork`       |   no   |          no           |     yes     |         no          |
+| Lambdas/closures via `spawn`      |   no   |          no           |     no      |         no          |
+| Lambdas/closures via `forkserver` |   no   |          no           |     no      |         no          |
+
+\* `ProcessPoolExecutor` notices a worker died but cannot pin it to a single
+submission, so it fails every outstanding future at once instead of just the
+one whose worker died.
 
 Testing
 -------

--- a/examples/ex01_basic.py
+++ b/examples/ex01_basic.py
@@ -34,7 +34,19 @@ def main() -> None:
         lengths = list(jobserver.map(fn=len, argses=[("ab",), ("cde",)]))
         info("lengths via map: %s", lengths)
 
+        # A worker raising an ordinary Exception has it re-raised by result().
+        future_err = jobserver.submit(fn=int, args=("not a number",))
+        try:
+            future_err.result()
+            raise RuntimeError("Expected ValueError was not raised")
+        except ValueError as e:
+            info("Worker raised and result() re-raised: %r", e)
+            # __cause__ shows the worker's traceback for the original failure.
+            info("Child traceback preserved via __cause__: %s", e.__cause__)
 
+
+# The spawn and forkserver start methods re-import this module in every
+# child, so the if __name__ == "__main__" guard below is required.
 if __name__ == "__main__":
     basicConfig(
         level=INFO,

--- a/examples/ex02_lifecycle.py
+++ b/examples/ex02_lifecycle.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Example 2 shows the Future lifecycle, polling, and resource cleanup."""
+
+from logging import INFO, basicConfig, captureWarnings, info
+
+from jobserver import Jobserver
+
+
+def main() -> None:
+    """Shows the Future lifecycle, polling, and resource cleanup."""
+    # A "with" block is optional but convenient: on exit it reclaims any
+    # outstanding Futures, avoiding a ResourceWarning at finalization.
+    with Jobserver(slots=2) as jobserver:
+        # jobserver.submit(...) can be abbreviated to
+        # jobserver(fn, *args, **kwargs).
+        future1 = jobserver(len, "lifecycle")
+
+        # done(): a cheap progress check that never blocks the caller.
+        info("done() poll: %s", future1.done())
+
+        # wait(): block for completion when the value itself is not needed.
+        info("wait() blocks then returns: %s", future1.wait())
+
+        # result(): block for and return the value, re-raising on failure.
+        info("result(): %r", future1.result())
+
+        # reclaim_resources() frees resources and issues callbacks for
+        # finished Futures you never waited on, like invoking the garbage
+        # collector, generally unnecessary but occasionally useful.
+        reclaimed: list = []
+        future2 = jobserver(len, "second")
+        future2.when_done(reclaimed.append, "callback fired")
+
+        # Exiting the "with" block would reclaim this implicitly.
+        while not reclaimed:
+            jobserver.reclaim_resources()
+
+        info("reclaim_resources() handled future2: %s", reclaimed)
+
+
+if __name__ == "__main__":
+    basicConfig(
+        level=INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    captureWarnings(True)
+    main()

--- a/examples/ex03_nested.py
+++ b/examples/ex03_nested.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 2 shows nested submissions sharing slot constraints."""
+"""Example 3 shows nested submissions sharing slot constraints."""
 
 from logging import INFO, basicConfig, captureWarnings, info
 from multiprocessing import get_all_start_methods

--- a/examples/ex04_death.py
+++ b/examples/ex04_death.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 3 shows detecting when a worker process dies unexpectedly."""
+"""Example 4 shows detecting when a worker process dies unexpectedly."""
 
 import signal
 from logging import INFO, basicConfig, captureWarnings, info

--- a/examples/ex05_sleep_fn.py
+++ b/examples/ex05_sleep_fn.py
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
-Example 4 shows gating work acceptance on external conditions.
+Example 5 shows gating work acceptance on external conditions.
 
 Availability of RAM is a more common use case but ill-suited for an example.
 """

--- a/examples/ex06_callbacks.py
+++ b/examples/ex06_callbacks.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 5 shows callbacks, exception handling, and CallbackRaised."""
+"""Example 6 shows callbacks, exception handling, and CallbackRaised."""
 
 from logging import INFO, basicConfig, captureWarnings, info
 

--- a/examples/ex07_environment.py
+++ b/examples/ex07_environment.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 6 shows environment variable injection for child processes."""
+"""Example 7 shows environment variable injection for child processes."""
 
 import os
 from logging import INFO, basicConfig, captureWarnings, info

--- a/examples/ex08_preexec_fn.py
+++ b/examples/ex08_preexec_fn.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 7 shows preexec_fn as a plain callable and context manager factory.
+"""Example 8 shows preexec_fn as a plain callable and context manager factory.
 
 preexec_fn is called in the worker before the task function.  If it returns
 None, it acts as a plain pre-execution hook.  If it returns a context manager,

--- a/examples/ex09_timeouts.py
+++ b/examples/ex09_timeouts.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 8 shows non-blocking polling, finite deadlines, and Blocked."""
+"""Example 9 shows timeout handling for submit(), done(), wait(), result()."""
 
 import time
 from logging import INFO, basicConfig, captureWarnings, info
@@ -12,29 +12,40 @@ from jobserver import Blocked, Jobserver
 
 
 def main() -> None:
-    """Shows non-blocking polling, finite deadlines, and Blocked."""
+    """Shows the timeout argument on submit(), done(), wait(), result()."""
+    # Timeouts are in seconds: None blocks (default for wait()/result()), 0
+    # polls, and a positive value waits at most that long.  On expiry submit()
+    # and result() raise Blocked while done() and wait() return False.
     with Jobserver(context="spawn", slots=1) as jobserver:
         # Submit a slow task that occupies the only slot
         future = jobserver.submit(fn=task_slow, args=(0.5,))
 
-        # done() is a non-blocking poll; False while the task is still running
+        # timeout=0 polls without blocking; done() is exactly wait(timeout=0)
         info("done() before: %s", future.done())
 
-        # result() with a finite timeout raises Blocked if not ready
+        # done(timeout=0.1) waits up to 0.1s, returning False if not ready
+        info("done(timeout=0.1): %s", future.done(timeout=0.1))
+
+        # A positive timeout waits at most that long.  wait() then returns
+        # False rather than raising when the result is not yet ready.
+        info("wait(timeout=0.1) not ready: %s", future.wait(timeout=0.1))
+
+        # result() with the same finite timeout instead raises Blocked
         try:
             future.result(timeout=0.1)
             raise RuntimeError("Expected Blocked was not raised")
         except Blocked:
             info("Caught expected Blocked from result(timeout=0.1)")
 
-        # submit() with timeout=0 raises Blocked when no slots available
+        # submit(timeout=0) is non-blocking and raises Blocked at once when no
+        # slot is available; timeout=None would instead block until one frees
         try:
             jobserver.submit(fn=len, args=("rejected",), timeout=0)
             raise RuntimeError("Expected Blocked was not raised")
         except Blocked:
             info("Caught expected Blocked: no slots for new work")
 
-        # wait() blocks until the future is ready and returns True
+        # timeout=None (the default) blocks indefinitely until the result is in
         info("wait() after: %s", future.wait())
         # done() on a completed future also returns True (non-blocking)
         info("done() after: %s", future.done())

--- a/examples/ex10_pdeathsig.py
+++ b/examples/ex10_pdeathsig.py
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
-Example 9 shows preexec_fn setting PR_SET_PDEATHSIG via prctl.
+Example 10 shows preexec_fn setting PR_SET_PDEATHSIG via prctl.
 
 This example will not work on all operating systems.
 """

--- a/examples/ex11_executor.py
+++ b/examples/ex11_executor.py
@@ -3,7 +3,11 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 10 shows JobserverExecutor with an owned or shared Jobserver."""
+"""Example 11 shows JobserverExecutor with an owned or shared Jobserver.
+
+Prefer JobserverExecutor for drop-in concurrent.futures compatibility and
+cancellable PENDING futures; use Jobserver directly for thread-free nesting.
+"""
 
 import os
 import time

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -573,6 +573,9 @@ def _unregister_connection(
 class Jobserver:
     """A Jobserver exposing a Future interface built atop multiprocessing.
 
+    A slot is one unit of process concurrency, roughly one running worker.
+    Slots default to the number of CPUs available to the current process.
+
     Concurrent submit() / reclaim_resources() calls on a Jobserver are not
     thread-safe.  In contrast, returned Futures are thread-safe.
 


### PR DESCRIPTION
A new-user documentation review of the README, examples, and exported-class
docstrings, applied as focused improvements. No library behavior changes;
docstrings, comments, examples, and the README only.

**Examples**
- Add `ex02_lifecycle.py` demonstrating `done()` / `wait()` / `result()`
  polling, `reclaim_resources()`, and `with`-block cleanup / `ResourceWarning`.
- Renumber the later examples accordingly (`ex02_nested` … `ex10_executor`
  become `ex03` … `ex11`) and update the README list.
- `ex01_basic.py`: show ordinary worker exceptions being re-raised by
  `result()` with the child traceback preserved via `__cause__`, and note the
  `if __name__ == "__main__"` guard required under spawn/forkserver.
- `ex09_timeouts.py`: document the full `timeout` argument behavior across
  `submit()` / `done()` / `wait()` / `result()` — the None/0/positive regimes
  and the `Blocked`-vs-`False` distinction.
- `ex11_executor.py`: add a two-line note on choosing `JobserverExecutor`
  versus a bare `Jobserver`.

**README**
- Add a "Comparison with the Python Standard Library" table contrasting
  `Pool`, `ProcessPoolExecutor`, `Jobserver`, and `JobserverExecutor` across
  slot nesting, background threads, cancellation, individual worker-death
  detection (with footnote), user-defined launch criteria, and per-start-method
  pickling of unpicklable callables. Links to `Pool` / `ProcessPoolExecutor`
  use version-less docs URLs.

**Docstring**
- Describe the slot concept (one unit of process concurrency; default to the
  number of available CPUs) in the `Jobserver` class docstring.

**Follow-up issues filed**
- #325 — inconsistent timeout exception (`Jobserver.map()` raises
  `TimeoutError` while `submit()`/`result()` raise `Blocked`).
- #326 — revisit the thread-safety decision for concurrent
  `submit()` / `reclaim_resources()`.
- #327 — determine whether unpicklable callables can be supported under
  `forkserver`.

`./ci` passes locally: 246 tests OK, all examples run, ruff/mypy/black clean,
sdist builds.

https://claude.ai/code/session_013uvjDZQjPvYEaMTnz4S3DK