### PR TITLE
Fix five hands-off lifecycle and input-validation defects

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -723,6 +723,9 @@ class Jobserver:
         repeatedly until every ready callback has been attempted.
         Each suppressed CallbackRaised emits a RuntimeWarning.
         """
+        # Idempotent: once closed, reclaim_resources() below would raise.
+        if self._selector_closed:
+            return
         # Each call drains at most one CallbackRaised per future
         while True:
             try:

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -622,7 +622,7 @@ class Jobserver:
         # invalid inputs cannot leave pipes or semaphores behind.
         if slots is None:
             slots = sched_getaffinity0()
-        if not isinstance(slots, int):
+        if isinstance(slots, bool) or not isinstance(slots, int):
             raise TypeError(f"slots: int, got {type(slots).__name__}")
         if slots < 1:
             raise ValueError(f"slots must be >= 1, got {slots!r}")

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -1226,7 +1226,11 @@ def _maybe_obtain_token(
         # sleep_fn() duration is properly accounted for.
         sleep = sleep_fn()
         if sleep is not None:
-            if not sleep >= 0.0:
+            if (
+                isinstance(sleep, bool)
+                or not isinstance(sleep, (int, float))
+                or not sleep >= 0.0
+            ):
                 raise ValueError(
                     "sleep_fn must return None or non-negative "
                     f"seconds, got {sleep!r}"

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -52,9 +52,13 @@ def timeout_to_deadline(timeout: Optional[float]) -> float:
     When timeout is None a large, finite deadline is returned per
     poll()/select() restrictions.
     """
-    return (
-        _MAX_TIMEOUT_SECS if timeout is None else timeout
-    ) + time.monotonic()
+    if timeout is None:
+        return _MAX_TIMEOUT_SECS + time.monotonic()
+    if isinstance(timeout, (int, float)) and not isinstance(timeout, bool):
+        return timeout + time.monotonic()
+    raise TypeError(
+        f"timeout: None or a real number, got {type(timeout).__name__}"
+    )
 
 
 def deadline_to_timeout(deadline: float) -> float:

--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -156,7 +156,11 @@ class AbstractQueue(Generic[T], abc.ABC):
         Closes the underlying pipe end so EOF propagates on crash.
         """
         if self._reader is not None:
-            self._reader.close()
+            try:
+                self._reader.close()
+            except OSError:
+                # Tolerate EBADF from an already-closed or duplicated fd.
+                pass
             self._reader = None
 
     def close_put(self) -> None:
@@ -165,7 +169,11 @@ class AbstractQueue(Generic[T], abc.ABC):
         Closes the underlying pipe end so EOF propagates on crash.
         """
         if self._writer is not None:
-            self._writer.close()
+            try:
+                self._writer.close()
+            except OSError:
+                # Tolerate EBADF from an already-closed or duplicated fd.
+                pass
             self._writer = None
 
     @abc.abstractmethod

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -487,6 +487,27 @@ class TestJobserverBasic(unittest.TestCase):
             with js:
                 pass
 
+    def test_exit_is_idempotent(self) -> None:
+        """A second __exit__ is a no-op, not RuntimeError (#331)."""
+        js = Jobserver(slots=2)
+        js.__enter__()
+        self.assertEqual(7, js.submit(fn=abs, args=(-7,)).result(timeout=5))
+        js.__exit__(None, None, None)
+        # Second (and third) close must not raise "Jobserver is closed".
+        js.__exit__(None, None, None)
+        js.__exit__(None, None, None)
+
+    def test_nested_with_same_instance(self) -> None:
+        """Nested with on one instance: outer __exit__ must no-op (#346)."""
+        js = Jobserver(slots=2)
+        with js:
+            with js:  # inner __exit__ closes the shared instance
+                self.assertEqual(
+                    1, js.submit(fn=helper_return, args=(1,)).result(timeout=5)
+                )
+            # Outer __exit__ now runs on an already-closed instance and must
+            # be a harmless no-op rather than raising.
+
     def test_context_manager_lingering_future(self) -> None:
         """Lingering Future completes and fires callbacks after exit."""
         results: list[typing.Any] = []

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -475,6 +475,17 @@ class TestJobserverBasic(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     js.submit(fn=helper_return, args=(1,), consume=bad)
 
+    def test_timeout_non_numeric_raises_typeerror(self) -> None:
+        """submit()/result() reject a non-numeric timeout clearly (#342)."""
+        with Jobserver(slots=2) as js:
+            for bad in ("5", object()):
+                with self.assertRaises(TypeError):
+                    js.submit(fn=helper_return, args=(1,), timeout=bad)
+            f = js.submit(fn=helper_return, args=(7,))
+            with self.assertRaises(TypeError):
+                f.result(timeout="soon")
+            self.assertEqual(7, f.result(timeout=5))
+
     def test_context_manager(self) -> None:
         """Context manager closes slots; submit raises after exit."""
         with Jobserver(slots=2) as js:

--- a/test/test_jobserver_slots.py
+++ b/test/test_jobserver_slots.py
@@ -60,6 +60,19 @@ class TestLargeSlots(unittest.TestCase):
             future = js.submit(fn=abs, args=(-7,))
             self.assertEqual(future.result(timeout=TIMEOUT), 7)
 
+    def test_slots_rejects_bool(self) -> None:
+        """slots=True/False is a TypeError, not a silent slots=1 (#336)."""
+        for bad in (True, False):
+            with self.assertRaises(TypeError) as cm:
+                Jobserver(context=FAST, slots=bad)
+            self.assertIn("bool", str(cm.exception))
+
+    def test_slots_rejects_non_int(self) -> None:
+        """slots must be an int; str/float are TypeErrors (#336)."""
+        for bad in ("2", 2.0):
+            with self.assertRaises(TypeError):
+                Jobserver(context=FAST, slots=bad)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -278,6 +278,14 @@ class TestJobserverWorker(unittest.TestCase):
                     self.assertIn("-1.0", str(c.exception))
                     with self.assertRaises(ValueError):
                         js.submit(fn=len, sleep_fn=lambda: float("nan"))
+                    # A non-numeric return is a clean ValueError, not a raw
+                    # TypeError from the `>= 0.0` comparison (#333).
+                    with self.assertRaises(ValueError) as c:
+                        js.submit(fn=len, sleep_fn=lambda: "soon")
+                    self.assertIn("'soon'", str(c.exception))
+                    # bool is ruled out even though it is an int subclass.
+                    with self.assertRaises(ValueError):
+                        js.submit(fn=len, sleep_fn=lambda: True)
 
                     # Confirm sleep_fn(...) returning zero can proceed
                     zs = iter(itertools.cycle((0, None)))

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -304,3 +304,11 @@ class TimeoutToDeadlineTest(unittest.TestCase):
         after = time.monotonic()
         self.assertGreaterEqual(deadline, before + 5.0)
         self.assertLessEqual(deadline, after + 5.0 + 0.01)
+
+    def test_non_numeric_raises_typeerror(self) -> None:
+        """A non-numeric timeout is a clear TypeError, not raw arithmetic
+        failure (#342); bool is rejected as an int subclass."""
+        for bad in ("5", object(), [], True, False):
+            with self.assertRaises(TypeError) as cm:
+                timeout_to_deadline(bad)
+            self.assertIn("timeout", str(cm.exception))

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -11,6 +11,7 @@ and the resolve_context / timeout_to_deadline helpers.
 """
 
 import copy
+import os
 import queue
 import time
 import unittest
@@ -68,6 +69,20 @@ class SPSCQueueTest(unittest.TestCase):
         # Both ends already closed by __exit__; repeat must not raise
         mq.close_get()
         mq.close_put()
+
+    def test_close_tolerates_already_closed_fd(self) -> None:
+        """close_*() swallows OSError/EBADF from a stale fd (#335).
+
+        Mirrors a pickled in-process clone sharing the same fd: closing
+        the underlying handle after it has already gone must not raise.
+        """
+        mq: SPSCQueue = SPSCQueue()
+        # Close the raw fds out from under the queue, then close_*() must
+        # tolerate the resulting EBADF rather than propagating it.
+        os.close(mq._writer.fileno())
+        os.close(mq._reader.fileno())
+        mq.close_put()  # would raise OSError(EBADF) without the guard
+        mq.close_get()
 
     def test_context_manager(self) -> None:
         """Context manager closes both ends; put/get raise after exit."""


### PR DESCRIPTION
## Summary

Five small, self-contained fixes for defects found during API review. Each is a clean, low-risk change (no API or behavioral decisions) with a focused regression test, in its own commit. The branch is based on the latest `master`; the full `./ci` (unittest + examples + ruff + mypy + black + sdist build) passes after every commit.

## Changes

| Commit | Issue(s) | What changed |
|--------|----------|--------------|
| Make `Jobserver.__exit__` idempotent | Closes #331, #346 | A second `__exit__` (e.g. a nested `with` on one instance, where the inner block already closed it) previously raised `RuntimeError("Jobserver is closed")` from `reclaim_resources()` → `_lazy_selector()`. Now returns early when already closed, so teardown is a no-op. |
| Tolerate `OSError` when closing queue pipe ends | Closes #335 | `close_get()`/`close_put()` now swallow `OSError` (e.g. `EBADF`) from closing an already-closed/duplicated handle, matching the existing `AttributeError` tolerance in `__del__`. Pickling a `Jobserver` in-process yields a clone sharing the slots-pipe fds; at finalization both `__del__`s closed the same fd, emitting "Exception ignored in `__del__`: OSError: [Errno 9] Bad file descriptor". |
| Reject `bool` (and non-int) `slots` | Closes #336 | `bool` is an `int` subclass, so `slots=True` previously slipped through as `slots=1` while `submit(consume=True)` was correctly rejected. Now rejected for consistency with the `consume` validation. |
| Validate non-numeric `timeout` with a clear `TypeError` | Closes #342 | A non-numeric `timeout` previously raised a confusing `TypeError` from the deadline arithmetic (`timeout + monotonic()`). Validated centrally in `timeout_to_deadline` so `submit()`/`result()`/`wait()`/`map()` all surface a descriptive `TypeError`; `bool` rejected for consistency. |
| Validate non-numeric `sleep_fn` return with a clear `ValueError` | Closes #333 | A `sleep_fn` returning a non-numeric value (e.g. a `str`) previously raised a raw `TypeError` from the `sleep >= 0.0` comparison. Now surfaces the same descriptive `ValueError` as negative/NaN. The documented behavior that an exception *raised* by `sleep_fn` propagates unchanged is preserved. |

## Scope

- Touches only `src/jobserver/_jobserver.py`, `src/jobserver/_queue.py`, and four `test/` files (+113/−4).
- No public API changes; all five are stricter validation or more-tolerant cleanup. Each adds a regression test.

Closes #331
Closes #333
Closes #335
Closes #336
Closes #342
Closes #346