### PR TITLE
Swallow broken/closed result fd in worker send like BrokenPipeError (#348)

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -1157,8 +1157,6 @@ def _worker_entrypoint(send, env, preexec_fn, fn, args, kwargs) -> None:
             result = ExceptionWrapper(died)
         raise  # Proceed with any BaseException-specific teardown
     finally:
-        # Ignore broken pipes which naturally occur when the destination
-        # terminates (or otherwise hangs up) before the result is ready
         try:
             # None means result assignment never ran (e.g. an interpreter
             # teardown between except and finally); let the pipe close so
@@ -1175,12 +1173,14 @@ def _worker_entrypoint(send, env, preexec_fn, fn, args, kwargs) -> None:
                             cause=result,
                         )
                     )
-                send.send_bytes(payload)  # ValueError => object too large
-        except BrokenPipeError:
+                send.send_bytes(payload)
+        except OSError:
+            # Broken or closed result fd (BrokenPipeError, EBADF, ...):
+            # close quietly and let the parent see EOFError instead.
             pass
         try:
             send.close()
-        except BrokenPipeError:
+        except OSError:
             pass
 
 

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -10,6 +10,7 @@ delivery, environment customization via env and preexec_fn, sleep_fn
 scheduling control, and propagation of __init__ defaults to submit().
 """
 
+import errno
 import functools
 import itertools
 import os
@@ -620,6 +621,29 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         with self.assertRaises(RuntimeError) as ctx:
             wrapper.unwrap()
         self.assertIn("not picklable", str(ctx.exception))
+        self.assertTrue(send.closed)
+
+
+class TestWorkerEntrypointSendBytesErrors(unittest.TestCase):
+    """A broken or closed result fd is swallowed during the result-send so
+    the worker closes quietly rather than escaping with a traceback and
+    degrading to a misleading SubmissionDied (#348)."""
+
+    def test_broken_result_fd_is_swallowed(self) -> None:
+        """An OSError/EBADF from a closed result fd closes quietly instead
+        of crashing the worker; the parent still observes EOF and reports
+        SubmissionDied, but without a noisy child traceback."""
+        boom = OSError(errno.EBADF, "Bad file descriptor")
+        send = _RecordingSend(fail_with=boom)
+        _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})
+        self.assertEqual([], send.payloads)
+        self.assertTrue(send.closed)
+
+    def test_broken_pipe_still_swallowed(self) -> None:
+        """The original BrokenPipeError handling is preserved."""
+        send = _RecordingSend(fail_with=BrokenPipeError())
+        _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})
+        self.assertEqual([], send.payloads)
         self.assertTrue(send.closed)
 
 


### PR DESCRIPTION
## Summary

Addresses #348. Rebased atop `master` (which already landed #342/#343, broadening `PICKLE_DUMP_ERRORS` with `ValueError`/`RecursionError`).

Issue #348 conflates two cases; only one is real:

- **Real:** an `OSError`/`EBADF` from a closed or broken result fd (e.g. a worker that slams its own fds shut before returning) was only caught as `BrokenPipeError`, so it escaped `_worker_entrypoint`, crashed the worker with a traceback, and degraded to a misleading `SubmissionDied`.
- **Phantom:** the `# ValueError => object too large` case. On supported CPython, `Connection.send_bytes` **cannot** raise `ValueError` for an oversized payload — `_send_bytes` switches to an 8-byte (`!Q`) length header above `0x7fffffff`, covering up to 2⁶⁴−1 bytes, so the historic >2 GiB limit is gone (and even back then it would have raised `struct.error`, which is not a `ValueError`). The `ValueError`s that *do* occur during `dumps` (ctypes pointers, empty cells) are already classified via `PICKLE_DUMP_ERRORS` on master.

So the fix is minimal:

- Broaden the result-send and `send.close()` catches from `BrokenPipeError` to `OSError` (`BrokenPipeError` is an `OSError` subclass, so prior behavior is preserved). A gone destination fd now closes quietly and the parent observes `EOFError -> SubmissionDied` without a child traceback.
- Drop the stale, misleading `# ValueError => object too large` comment (per the issue's "update or remove the comment" recommendation).

No speculative oversized-payload handling is added, since that branch is unreachable.

## Tests

`TestWorkerEntrypointSendBytesErrors`:
- `OSError`/`EBADF` → swallowed, pipe closed, nothing propagates;
- `BrokenPipeError` → original quiet-close behavior preserved.

The pre-existing `test_send_error_propagates_not_rewrapped` (a non-`OSError` like `AttributeError`) still propagates unchanged.

`./ci` passes (unit tests, examples, ruff, mypy, black, sdist build).

https://claude.ai/code/session_01MgfvfrEckHAhf6CrwFaccj