### PR TITLE
map(): reject a bare Mapping passed as argses or kwargses

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -1064,6 +1064,24 @@ class Jobserver:
         if buffersize is not None and buffersize < 1:
             raise ValueError("buffersize must be >= 1")
 
+        # A bare Mapping is almost certainly a mistake: iterating argses
+        # would silently yield its keys (splitting each str key into
+        # per-character positional args), and kwargses expects an iterable
+        # of mappings, not a single mapping.  Fail fast with a clear error.
+        if isinstance(argses, Mapping):
+            raise TypeError(
+                "argses: expected an iterable of positional-argument"
+                " iterables (e.g. a list of tuples), got"
+                f" {type(argses).__name__}; iterating it would silently"
+                " yield its keys"
+            )
+        if isinstance(kwargses, Mapping):
+            raise TypeError(
+                "kwargses: expected an iterable of mappings (e.g. a list"
+                f" of dicts), got a single {type(kwargses).__name__};"
+                " iterating it would silently yield its keys"
+            )
+
         deadline = timeout_to_deadline(timeout)
 
         # Build a (possibly lazy) iterator of (args, kwargs) pairs

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -1064,10 +1064,6 @@ class Jobserver:
         if buffersize is not None and buffersize < 1:
             raise ValueError("buffersize must be >= 1")
 
-        # A bare Mapping is almost certainly a mistake: iterating argses
-        # would silently yield its keys (splitting each str key into
-        # per-character positional args), and kwargses expects an iterable
-        # of mappings, not a single mapping.  Fail fast with a clear error.
         if isinstance(argses, Mapping):
             raise TypeError(
                 "argses: expected an iterable of positional-argument"

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -1066,14 +1066,14 @@ class Jobserver:
 
         if isinstance(argses, Mapping):
             raise TypeError(
-                "argses: expected an iterable of positional-argument"
-                " iterables (e.g. a list of tuples), got"
+                "argses: expected an Iterable of positional-argument"
+                " Iterables (e.g. a list of tuples), got"
                 f" {type(argses).__name__}; iterating it would silently"
                 " yield its keys"
             )
         if isinstance(kwargses, Mapping):
             raise TypeError(
-                "kwargses: expected an iterable of mappings (e.g. a list"
+                "kwargses: expected an Iterable of Mappings (e.g. a list"
                 f" of dicts), got a single {type(kwargses).__name__};"
                 " iterating it would silently yield its keys"
             )

--- a/test/test_jobserver_map.py
+++ b/test/test_jobserver_map.py
@@ -138,6 +138,22 @@ class TestJobserverMap(unittest.TestCase):
                     with self.assertRaises(ValueError):
                         js.map(fn=_kw_sum, argses=argses, kwargses=kwargses)
 
+    def test_argses_mapping_raises(self) -> None:
+        """A bare Mapping as argses raises TypeError, not silent keys."""
+        with Jobserver(context=FAST, slots=2) as js:
+            for argses in [{"ab": 1, "cde": 2}, {}]:
+                with self.subTest(argses=argses):
+                    with self.assertRaises(TypeError):
+                        js.map(fn=helper_return, argses=argses)
+
+    def test_kwargses_mapping_raises(self) -> None:
+        """A bare Mapping as kwargses raises TypeError, not silent keys."""
+        with Jobserver(context=FAST, slots=2) as js:
+            for kwargses in [{"x": 1, "y": 2}, {}]:
+                with self.subTest(kwargses=kwargses):
+                    with self.assertRaises(TypeError):
+                        js.map(fn=_kw_only, kwargses=kwargses)
+
     def test_preserves_order(self) -> None:
         """Results are yielded in submission order, not completion."""
         with Jobserver(context=FAST, slots=4) as js:


### PR DESCRIPTION
## Summary

Fixes #353.

Passing a `Mapping` (e.g. a `dict`) as `argses` to `map()` silently iterated its **keys**. Each `str` key was then passed through `_validate_args_kwargs` → `tuple(args)`, and `tuple("ab")` is `('a', 'b')`, so a key was spread one-character-per-arg. The result was coherent-looking nonsense rather than an error.

This change guards both inputs at the top of `map()` and fails fast with a clear `TypeError`:

- **argses**: a bare `Mapping` is rejected — iterating it would silently yield keys.
- **kwargses**: `kwargses` expects an *iterable of* mappings, so a single bare `Mapping` is likewise a mistake and is rejected.

This is consistent with the rest of `map()`'s up-front validation (lengths, chunksize, buffersize, per-element iterability).

## Testing

- Added `test_argses_mapping_raises` and `test_kwargses_mapping_raises` covering both non-empty and empty dict inputs.
- `./ci` passes (unit tests, examples, ruff, mypy, black, sdist build).

https://claude.ai/code/session_01Verg6atb9yTN5zek8eQUyJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Verg6atb9yTN5zek8eQUyJ)_