### PR TITLE
Classify RecursionError/oversized sends as descriptive worker failures

### DIFF
--- a/src/jobserver/_compat.py
+++ b/src/jobserver/_compat.py
@@ -11,10 +11,19 @@ import select
 import signal
 
 # Failures from pickling a payload for a queue: PicklingError, an
-# AttributeError for a locally-defined (unpicklable-by-name) class, or a
-# TypeError for a fundamentally unpicklable object.  Shared so the worker
-# and executor fallbacks classify dump failures identically.
-PICKLE_DUMP_ERRORS = (pickle.PicklingError, AttributeError, TypeError)
+# AttributeError for a locally-defined (unpicklable-by-name) class, a
+# TypeError for a fundamentally unpicklable object, a ValueError raised by
+# some reducers (e.g. ctypes pointers, empty cells), or a RecursionError
+# from a picklable-but-too-deeply-nested object overflowing the recursive
+# pickler.  Shared so the worker and executor fallbacks classify dump
+# failures identically.
+PICKLE_DUMP_ERRORS = (
+    pickle.PicklingError,
+    AttributeError,
+    TypeError,
+    ValueError,
+    RecursionError,
+)
 
 
 def ignore_sigpipe() -> None:

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -523,6 +523,15 @@ def _make_unpicklable_result() -> object:
     return Local()
 
 
+def _make_deep_result() -> object:
+    """Return a picklable list nested far deeper than the recursive pickler
+    can serialize, provoking a RecursionError from ForkingPickler.dumps."""
+    x: object = []
+    for _ in range(sys.getrecursionlimit() * 100):
+        x = [x]
+    return x
+
+
 class _RecordingSend:
     """Stand-in for a worker's pipe end recording send_bytes payloads.
 
@@ -583,6 +592,20 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         _worker_entrypoint(
             send, {}, lambda: None, _make_unpicklable_result, (), {}
         )
+        self.assertEqual(1, len(send.payloads))
+        wrapper = ForkingPickler.loads(send.payloads[0])
+        self.assertIsInstance(wrapper, ExceptionWrapper)
+        with self.assertRaises(RuntimeError) as ctx:
+            wrapper.unwrap()
+        self.assertIn("not picklable", str(ctx.exception))
+        self.assertTrue(send.closed)
+
+    def test_deeply_nested_result_uses_fallback(self) -> None:
+        """A picklable-but-too-deep result overflows the pickler with a
+        RecursionError that now degrades to the descriptive fallback rather
+        than crashing the worker into a misleading SubmissionDied (#343)."""
+        send = _RecordingSend()
+        _worker_entrypoint(send, {}, lambda: None, _make_deep_result, (), {})
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
         self.assertIsInstance(wrapper, ExceptionWrapper)


### PR DESCRIPTION
## Summary

Fixes #343.

A worker result that is picklable but very deeply *nested* overflows the recursive pickler with `RecursionError`. Because `RecursionError` was outside `PICKLE_DUMP_ERRORS`, the worker's "result not picklable" fallback did not catch it — the worker crashed and the caller saw a misleading `SubmissionDied` instead of a clear pickling error.

## Changes

- **`src/jobserver/_compat.py`** — broaden the shared `PICKLE_DUMP_ERRORS` classifier with `RecursionError` (over-deep picklable objects) and `ValueError` (reducers such as ctypes pointers / empty cells). Being shared, this fixes the same misclassification in the executor's `_responses_put_failed` fallback too.
- **`src/jobserver/_jobserver.py`** — extract a small `_worker_failure_payload` helper for the descriptive fallback, and additionally catch the `ValueError` that `send_bytes` raises for an oversized payload, degrading it to a `"... too large to send: ..."` error rather than crashing the worker into an EOF the parent cannot diagnose (the related concern noted in the issue).
- **`test/test_jobserver_worker.py`** — add coverage for the deeply-nested-result and oversized-payload fallbacks; extend `_RecordingSend` with a `fail_once` mode to emulate an oversized send that the small fallback then succeeds at.

## Verification

Before: a deeply nested result raised `SubmissionDied`. After:

```
PASS: descriptive RuntimeError -> Result of type list not picklable: RecursionError('maximum recursion depth excee...
```

`./ci` passes in full (unit tests, examples, ruff, mypy, black, sdist build).

https://claude.ai/code/session_01AgptMrJFkvJfUf2WZsJczs

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgptMrJFkvJfUf2WZsJczs)_