### PR TITLE
Fix connection fd leak when a raising user callback aborts drain

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -233,12 +233,15 @@ class ExceptionWrapper(Wrapper[Any]):
         return f"Exception of type {type(self._raised).__name__}"
 
 
-# Callback priorities for the Future heapq-based callback queue.
-# Token restoration fires first, user callbacks in the middle,
-# and sentinel cleanup fires last.
-_PRIORITY_TOKEN = 0
+# Internal callbacks may run before and after user callbacks.
+#
+# _PRIORITY_AFTER callbacks may not run because of (a) the user
+# observing a CallbackRaised without draining remaining callbacks
+# or (b) BaseExceptions escaping user callbacks.  Consider
+# _PRIORITY_AFTER best-effort for resource cleanup purposes.
+_PRIORITY_BEFORE = 0
 _PRIORITY_USER = 1
-_PRIORITY_CLEANUP = 2
+_PRIORITY_AFTER = 2
 
 
 def _callback_wrapper(seqno: int, fn, *args, **kwargs) -> None:
@@ -479,11 +482,10 @@ class Future(Generic[T]):
             self._process.join()
             self._process = None
 
-            # Drop our reference so _issue_callbacks's invariant holds and
-            # __del__ will not warn.  The actual close() is deferred to a
-            # _PRIORITY_CLEANUP callback (see _unregister_connection) so the
-            # connection fd stays registered, and thus unreusable, until
-            # after it is unregistered from the Jobserver's selector.
+            # Drop our reference so _issue_callbacks's invariant holds
+            # and __del__ will not warn.  The actual close() is deferred
+            # to a _PRIORITY_BEFORE callback (see _unregister_connection)
+            # so the fd is unregistered from the selector before reuse.
             self._connection = None
             self._issue_callbacks()
             return True
@@ -928,7 +930,7 @@ class Jobserver:
         #
         #   (A) Silently ignore the CallbackRaised?
         #       No, client code must know about Exceptions it causes.
-        #   (B) Issue callback priorities <= _PRIORITY_TOKEN?
+        #   (B) Issue callback priorities <= _PRIORITY_BEFORE?
         #       No, client used a callback because client wanted immediacy.
         #       Otherwise, the client could do its own work after done()
         #       and would not have employed callbacks in the first place.
@@ -994,30 +996,33 @@ class Jobserver:
                 self._slots.put(token)
             raise
 
+        # Unregister and close the result connection before user callbacks
+        # so a raising user callback cannot leak the connection fd.
+        # Holding recv keeps its fd open until unregister.
+        future._when_done(
+            fn=_unregister_connection,
+            args=(selector, recv),
+            priority=_PRIORITY_BEFORE,
+        )
+
         # As above process.start() succeeded, now Future must restore token
         future._when_done(
             fn=_restore_token,
             args=(self._slots, token),
-            priority=_PRIORITY_TOKEN,
+            priority=_PRIORITY_BEFORE,
         )
 
-        # After token restoration, stop tracking this Future's sentinel.
-        # Prevent premature garbage collection of process (which closes
-        # the sentinel fd and silently removes it from epoll) by
-        # holding a reference until this last-priority callback fires.
+        # The sentinel stays registered so the Future remains discoverable
+        # if a raising user callback aborts the drain.  Prevent premature
+        # GC of process (closing the sentinel fd) by holding a reference.
+        #
+        # Because _PRIORITY_AFTER is best-effort, unregistering the
+        # sentinel additionally happens implicitly in __exit__ and
+        # __del__ when the selector is closed.
         future._when_done(
             fn=_unregister_sentinel,
             args=(selector, process.sentinel, process),
-            priority=_PRIORITY_CLEANUP,
-        )
-
-        # Likewise unregister and close the result connection.  Holding recv
-        # here keeps its fd open until unregister so its integer cannot be
-        # reused by a concurrent submit() before removal from the selector.
-        future._when_done(
-            fn=_unregister_connection,
-            args=(selector, recv),
-            priority=_PRIORITY_CLEANUP,
+            priority=_PRIORITY_AFTER,
         )
 
         # Finally, return a viable Future to the caller


### PR DESCRIPTION
## Summary

Fixes the connection fd leak described in #330. When a user callback raises `CallbackRaised`, the callback drain aborts. Previously, `_unregister_connection` was a `_PRIORITY_CLEANUP` callback that ran *after* user callbacks, so it was skipped — leaking the connection fd and its selector registration.

**What this PR does:**

- Renames the callback priority tiers: `_PRIORITY_TOKEN` → `_PRIORITY_BEFORE`, `_PRIORITY_CLEANUP` → `_PRIORITY_AFTER` (with `_PRIORITY_USER` unchanged).
- Moves `_unregister_connection` to `_PRIORITY_BEFORE` so the connection fd is unregistered from the selector and closed *before* any user callback can abort the drain.
- Registers `_unregister_connection` before `_restore_token` (both `_PRIORITY_BEFORE`) so the connection fd is closed before the token is restored, preventing a concurrent `submit()` from reusing the fd number while it is still registered in the selector.

**What this PR does NOT fix:**

The sentinel registration leak remains — `_unregister_sentinel` stays at `_PRIORITY_AFTER` deliberately. This is necessary because the sentinel keeps the Future discoverable in the selector for subsequent `reclaim_resources()` passes when a raising user callback leaves undrained callbacks. This leak is deemed acceptable because:

1. **It is bounded by `Jobserver.__exit__`** — the `while True` drain loop in `__exit__` rediscovers the future via its sentinel and drains all remaining callbacks.
2. **`__del__` closes the selector** — even without an explicit `__exit__`, garbage collection of the Jobserver closes the selector, releasing the sentinel registration.
3. **It is the lesser cost** — the sentinel is a single fd holding a Process reference. The connection fd leak was the real resource exhaustion risk (open pipe fd per undrained completion).

`_PRIORITY_AFTER` is now documented as best-effort for resource cleanup purposes.

## Test plan

- [x] Full `./ci` passes (258 tests)
- [x] No user-observable behavior change: `_unregister_connection` runs before user callbacks, but the connection is already inaccessible (`_connection = None`) before any callbacks fire

Closes #330

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhKiyapzfQD5f3jGyFvEBJ)_