### PR TITLE
Add ex04_cancel demonstrating SIGTERM cancellation of running work

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,21 +49,23 @@ Examples
    `wait()`, and `result()`, plus `reclaim_resources()` and cleanup.
  * [ex03_nested](examples/ex03_nested.py) - Nesting submissions so child work
    shares slot constraints with its parent.
- * [ex04_death](examples/ex04_death.py) - Detecting when a worker process is
+ * [ex04_cancel](examples/ex04_cancel.py) - Cancelling running work by sending
+   `SIGTERM` to a worker via `Future.wait(signal=...)`.
+ * [ex05_death](examples/ex05_death.py) - Detecting when a worker process is
    killed unexpectedly via `SubmissionDied`.
- * [ex05_sleep_fn](examples/ex05_sleep_fn.py) - Gating work acceptance on an
+ * [ex06_sleep_fn](examples/ex06_sleep_fn.py) - Gating work acceptance on an
    external condition using `sleep_fn`.
- * [ex06_callbacks](examples/ex06_callbacks.py) - Registering `when_done`
+ * [ex07_callbacks](examples/ex07_callbacks.py) - Registering `when_done`
    callbacks and draining errors via `CallbackRaised`.
- * [ex07_environment](examples/ex07_environment.py) - Setting and unsetting
+ * [ex08_environment](examples/ex08_environment.py) - Setting and unsetting
    environment variables in child processes via `env=`.
- * [ex08_preexec_fn](examples/ex08_preexec_fn.py) - Using `preexec_fn` as
+ * [ex09_preexec_fn](examples/ex09_preexec_fn.py) - Using `preexec_fn` as
    a plain callable or context manager factory for entry/exit semantics.
- * [ex09_timeouts](examples/ex09_timeouts.py) - Using non-blocking polling,
+ * [ex10_timeouts](examples/ex10_timeouts.py) - Using non-blocking polling,
    finite deadlines, and `Blocked` from `result()` and `submit()`.
- * [ex10_pdeathsig](examples/ex10_pdeathsig.py) - On Linux, using `preexec_fn`
+ * [ex11_pdeathsig](examples/ex11_pdeathsig.py) - On Linux, using `preexec_fn`
    to call `prctl(PR_SET_PDEATHSIG)` so a child dies when its parent does.
- * [ex11_executor](examples/ex11_executor.py) - Using `JobserverExecutor` as
+ * [ex12_executor](examples/ex12_executor.py) - Using `JobserverExecutor` as
    a context manager supporting `map()` and `c.f.Future` cancellation.
 
 Comparison with the Python Standard Library
@@ -79,6 +81,7 @@ and
 | Nested work shares the slot pool  |   no   |          no           |     yes     |         yes         |
 | Background thread                 |  yes   |          yes          |     no      |         yes         |
 | Cancel pending work               |   no   |          yes          |     no      |         yes         |
+| Cancel running work               |   no   |          no           |     yes     |         no          |
 | Detects individual worker death   |   no   |       partial\*       |     yes     |         yes         |
 | User-defined launch criteria      |   no   |          no           |     yes     |         yes         |
 | Lambdas/closures via `fork`       |   no   |          no           |     yes     |         no          |

--- a/examples/ex04_cancel.py
+++ b/examples/ex04_cancel.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Example 4 shows cancelling running work by signalling the worker."""
+
+import signal
+import time
+from logging import INFO, basicConfig, captureWarnings, info
+
+from jobserver import Jobserver, SubmissionDied
+
+
+def main() -> None:
+    """Shows cancelling running work via SIGTERM through Future.wait()."""
+    with Jobserver(slots=2) as jobserver:
+        # Submit long-running work that would otherwise never finish here.
+        future_cancel = jobserver.submit(fn=time.sleep, args=(3600,))
+
+        # Submit normal work alongside the doomed submission.
+        future_ok = jobserver.submit(fn=len, args=("hello",))
+
+        # wait(signal=...) sends a signal to the running worker, then waits.
+        # wait() returns True once completion (here, death) is confirmed.
+        info(
+            "Cancelled worker wait: %s",
+            future_cancel.wait(signal=signal.SIGTERM),
+        )
+        info("Normal result: %s", future_ok.result())
+
+        # result() raises SubmissionDied for the cancelled worker.
+        try:
+            future_cancel.result()
+            raise RuntimeError("Expected SubmissionDied was not raised")
+        except SubmissionDied:
+            info("Caught expected SubmissionDied from cancelled worker")
+
+
+if __name__ == "__main__":
+    basicConfig(
+        level=INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    captureWarnings(True)
+    main()

--- a/examples/ex05_death.py
+++ b/examples/ex05_death.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 4 shows detecting when a worker process dies unexpectedly."""
+"""Example 5 shows detecting when a worker process dies unexpectedly."""
 
 import signal
 from logging import INFO, basicConfig, captureWarnings, info

--- a/examples/ex06_sleep_fn.py
+++ b/examples/ex06_sleep_fn.py
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
-Example 5 shows gating work acceptance on external conditions.
+Example 6 shows gating work acceptance on external conditions.
 
 Availability of RAM is a more common use case but ill-suited for an example.
 """

--- a/examples/ex07_callbacks.py
+++ b/examples/ex07_callbacks.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 6 shows callbacks, exception handling, and CallbackRaised."""
+"""Example 7 shows callbacks, exception handling, and CallbackRaised."""
 
 from logging import INFO, basicConfig, captureWarnings, info
 

--- a/examples/ex08_environment.py
+++ b/examples/ex08_environment.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 7 shows environment variable injection for child processes."""
+"""Example 8 shows environment variable injection for child processes."""
 
 import os
 from logging import INFO, basicConfig, captureWarnings, info

--- a/examples/ex09_preexec_fn.py
+++ b/examples/ex09_preexec_fn.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 8 shows preexec_fn as a plain callable and context manager factory.
+"""Example 9 shows preexec_fn as a plain callable and context manager factory.
 
 preexec_fn is called in the worker before the task function.  If it returns
 None, it acts as a plain pre-execution hook.  If it returns a context manager,

--- a/examples/ex10_timeouts.py
+++ b/examples/ex10_timeouts.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 9 shows timeout handling for submit(), done(), wait(), result()."""
+"""Example 10 shows timeout handling for submit(), done(), wait(), result()."""
 
 import time
 from logging import INFO, basicConfig, captureWarnings, info

--- a/examples/ex11_pdeathsig.py
+++ b/examples/ex11_pdeathsig.py
@@ -4,7 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
-Example 10 shows preexec_fn setting PR_SET_PDEATHSIG via prctl.
+Example 11 shows preexec_fn setting PR_SET_PDEATHSIG via prctl.
 
 This example will not work on all operating systems.
 """

--- a/examples/ex12_executor.py
+++ b/examples/ex12_executor.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 11 shows JobserverExecutor with an owned or shared Jobserver.
+"""Example 12 shows JobserverExecutor with an owned or shared Jobserver.
 
 Prefer JobserverExecutor for drop-in concurrent.futures compatibility and
 cancellable PENDING futures; use Jobserver directly for thread-free nesting.


### PR DESCRIPTION
## Summary

The README implied Jobserver cannot cancel work, but it can: `Future.wait(signal=...)` sends a signal such as `SIGTERM` to a running worker, cancelling its work so that `Future.result()` raises `SubmissionDied`. This PR demonstrates that capability and documents it.

- Add `examples/ex04_cancel.py` showing SIGTERM cancellation via `Future.wait(signal=...)`, written in the style of examples 1–3.
- Renumber the subsequent examples up by one (`ex04_death` → `ex05_death`, … `ex11_executor` → `ex12_executor`), preserving history via `git mv` and bumping each module docstring's "Example N".
- Update the README example list and add a **"Cancel running work"** row to the comparison table (`Jobserver` = yes; the existing "Cancel pending work" row is left intact since it captures the distinct `cf.Future.cancel()` semantic).

## Testing

`./ci` passes locally: 258 tests OK, `ruff` clean, `mypy` clean (19 files), `black --check` clean, and the sdist builds.

https://claude.ai/code/session_016dJSYg9836UJJjSZ7M9R67

---
_Generated by [Claude Code](https://claude.ai/code/session_016dJSYg9836UJJjSZ7M9R67)_