### PR TITLE
Drain Future callbacks iteratively to bound re-entrant when_done()

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -280,7 +280,8 @@ class Future(Generic[T]):
         "_connection",
         "_wrapper",
         "_callbacks",
-        "_callback_seqno",
+        "_callbacks_issuing",
+        "_callbacks_seqno",
     )
 
     def __init__(self, process: BaseProcess, connection: Connection) -> None:
@@ -302,10 +303,15 @@ class Future(Generic[T]):
         # (priority, callback_seqno, ...) so token restoration fires before
         # user callbacks, which fire before sentinel cleanup.
         self._callbacks: list[tuple] = []
+
+        # True iff callbacks are actively being issued.
+        # Flag should only be observed/manipulated within _issue_callbacks()
+        self._callbacks_issuing = False
+
         # Monotonic seqno needed due to reentrancy.  Starting at -3 lets the
         # three internal registrations submit() makes (token restoration plus
         # sentinel and connection cleanup) consume -3, -2, -1 so user 0-based.
-        self._callback_seqno = -3
+        self._callbacks_seqno = -3
 
     def __repr__(self) -> str:
         with self._rlock:
@@ -344,7 +350,10 @@ class Future(Generic[T]):
         """
         Register fn(*args, **kwargs) for execution after Future.done(...).
 
-        When already done(...) the requested function is immediately invoked.
+        When already done(...) function fn(...) will be invoked immediately
+        after completion of any currently executing or registered callbacks
+        for *this* Future.
+
         The Future is not automatically passed; to receive it, bind it
         explicitly via args, e.g. future.when_done(cb, future).
         May raise CallbackRaised from at most this new callback.
@@ -353,11 +362,11 @@ class Future(Generic[T]):
         the resulting CallbackRaised reports it via CallbackRaised.seqno.
         """
         # _when_done assigns and returns the seqno under the same lock.
-        # self._callback_seqno is an int, so the partial curries a copy.
+        # self._callbacks_seqno is an int, so the partial curries a copy.
         with self._rlock:
             return self._when_done(
                 fn=functools.partial(
-                    _callback_wrapper, self._callback_seqno, fn
+                    _callback_wrapper, self._callbacks_seqno, fn
                 ),
                 args=args,
                 kwargs=kwargs,
@@ -373,7 +382,7 @@ class Future(Generic[T]):
     ) -> int:
         """Register a callback with some priority, returning its seqno."""
         with self._rlock:
-            seqno = self._callback_seqno
+            seqno = self._callbacks_seqno
             heapq.heappush(
                 self._callbacks,
                 (
@@ -384,7 +393,7 @@ class Future(Generic[T]):
                     {} if kwargs is None else kwargs,
                 ),
             )
-            self._callback_seqno += 1
+            self._callbacks_seqno += 1
             if self._connection is None:
                 self._issue_callbacks()
             return seqno
@@ -496,9 +505,19 @@ class Future(Generic[T]):
         # _is_owned is expected on RLock but not guaranteed; skip if absent
         assert getattr(self._rlock, "_is_owned", object)(), "must hold _rlock"
         assert self._connection is None and self._process is None, "Invariant"
-        while self._callbacks:
-            _, _, fn, args, kwargs = heapq.heappop(self._callbacks)
-            fn(*args, **kwargs)
+
+        # Avoiding nested drains converts unbounded recursion into a flat loop
+        # Otherwise callbacks re-registering themselves blow out the stack
+        if self._callbacks_issuing:
+            return
+
+        self._callbacks_issuing = True
+        try:
+            while self._callbacks:
+                _, _, fn, args, kwargs = heapq.heappop(self._callbacks)
+                fn(*args, **kwargs)
+        finally:
+            self._callbacks_issuing = False
 
     def result(self, timeout: Optional[float] = None) -> T:
         """

--- a/test/test_jobserver_callbacks.py
+++ b/test/test_jobserver_callbacks.py
@@ -44,11 +44,10 @@ class TestJobserverCallbacks(unittest.TestCase):
             ):
                 self.fail("child did not exit")
 
-    def helper_check_semantics(self, f: Future[None]) -> None:
+    def helper_check_semantics(
+        self, f: Future[None], mutable: list[int]
+    ) -> None:
         """Helper checking Future semantics *inside* a callback as expected."""
-        # Prepare how callbacks will be observed
-        mutable = [0]
-
         # Confirm that inside a callback the Future reports done()
         self.assertTrue(f.done())
         self.assertTrue(f.wait(timeout=0))
@@ -58,15 +57,28 @@ class TestJobserverCallbacks(unittest.TestCase):
         f.when_done(helper_callback, mutable, 0, 1)
         f.when_done(helper_callback, mutable, 0, 2)
 
-        # Confirm that inside a callback above work was immediately performed
-        self.assertEqual(mutable[0], 3, "Two callbacks observed")
+        # Confirm that *inside* this callback above callbacks haven't happened
+        # Those helper_callback(...) calls occur *after* helper_check_semantics
+        self.assertEqual(mutable[0], 0, "Zero callbacks observed")
 
     def test_callback_semantics(self) -> None:
         """Inside a Future's callback the Future reports done() is True."""
+        # Prepare how callbacks will be observed
+        mutable_a = [0]
+        mutable_b = [0]
+
         with Jobserver(context=FAST, slots=3) as js:
+            # First, test registering callbacks before waiting for result()
             f = js.submit(fn=len, args=((1, 2, 3),))
-            f.when_done(self.helper_check_semantics, f)
+            f.when_done(self.helper_check_semantics, f, mutable_a)
             self.assertEqual(3, f.result())
+            self.assertEqual(mutable_a[0], 3, "Two callbacks observed")
+
+            # Second, test registering callbacks after waiting for result()
+            g = js.submit(fn=len, args=((1, 2, 3, 4),))
+            self.assertEqual(4, g.result())
+            g.when_done(self.helper_check_semantics, g, mutable_b)
+            self.assertEqual(mutable_b[0], 3, "Two callbacks observed")
 
     def test_done_callback_raises(self) -> None:
         """Future.wait() raises CallbackRaised from processing callbacks."""


### PR DESCRIPTION
## Problem

On an already-completed `Future`, `when_done()` issued callbacks inline. A callback that re-registered itself therefore re-entered callback issuance recursively, growing the stack until `RecursionError` (surfaced wrapped in `CallbackRaised`). Callback re-entrancy was unbounded.

## Fix

Guard `_issue_callbacks()` with a per-Future `_callbacks_issuing` flag. When a drain is already in progress, a newly registered callback is pushed onto the heap and picked up by the running loop instead of starting a nested drain — turning unbounded recursion into a flat loop. A `try/finally` clears the flag so a raising callback still preserves at-most-one-`CallbackRaised` semantics and leaves the remainder for a later `wait()`.

## Semantics change

Callbacks registered from *within* a firing callback on an already-completed Future now run immediately after the currently executing callback completes (for that Future), rather than synchronously nested. The `when_done()` docstring is updated to state this, and `test_callback_semantics` now exercises both the pre- and post-completion registration paths.

Closes #332

https://claude.ai/code/session_012q3uqXRDYuRBATamy7eRcE

---
_Generated by [Claude Code](https://claude.ai/code/session_012q3uqXRDYuRBATamy7eRcE)_