### PR TITLE
Document that when_done callbacks run inline on the observing thread

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -350,9 +350,11 @@ class Future(Generic[T]):
         """
         Register fn(*args, **kwargs) for execution after Future.done(...).
 
-        When already done(...) function fn(...) will be invoked immediately
-        after completion of any currently executing or registered callbacks
-        for *this* Future.
+        Callbacks run synchronously, inline, on whichever thread first
+        observes completion.  There is no background thread or timeout.
+        When already done(...) function fn(...) will be invoked
+        immediately after completion of any currently executing or
+        registered callbacks for *this* Future.
 
         The Future is not automatically passed; to receive it, bind it
         explicitly via args, e.g. future.when_done(cb, future).


### PR DESCRIPTION
Documents the intentional inline-callback behavior of `Future.when_done(...)`: callbacks run synchronously on whichever thread first observes completion, with no background thread, timeout, or isolation.

Closes #352

https://claude.ai/code/session_01U4tDegsBc3uFtPAFBL6kXC

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4tDegsBc3uFtPAFBL6kXC)_