### PR TITLE
Apply sleep_fn admission gate to consume=0 submissions

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -905,7 +905,7 @@ class Jobserver:
         in which case the result is None.
 
         Optional sleep_fn() permits injecting additional logic as
-        to when a slot may be consumed.  For example, one can accept work
+        to when any work may be accepted.  For example, one can accept work
         only when sufficient RAM is available.  Function sleep_fn()
         should either return None when work is acceptable or return the
         non-negative number of seconds for which this process should sleep.
@@ -1260,8 +1260,8 @@ def _maybe_obtain_token(
         # (1) Eagerly clean up any completed work to avoid deadlocks
         reclaim_tokens_fn()
 
-        # (2) Exit loop if all requested resources have been acquired
-        if consume == 0 or token is not None:
+        # (2) Exit once a consume == 1 submission already holds its slot.
+        if token is not None:
             break
 
         # (3) When sleep_fn() vetoes new work proceed to sleep.
@@ -1284,22 +1284,26 @@ def _maybe_obtain_token(
                 raise Blocked()
             continue
 
+        # (4) Gate passed; a consume == 0 submission needs no slot.
+        if consume == 0:
+            break
+
         try:
-            # (4) Grab any immediately available token
+            # (5) Grab any immediately available token
             token = slots.get(timeout=0)
         except queue.Empty:
-            # (5) Otherwise, possibly throw in the towel...
+            # (6) Otherwise, possibly throw in the towel...
             monotonic = time.monotonic()
             if monotonic >= deadline:
                 raise Blocked() from None
 
-            # (6) ...then block until some interesting event.
+            # (7) ...then block until some interesting event.
             # O(k) via the persistent selector: _lazy_selector() places
             # slots.waitable() once so only one epoll_wait is needed here.
             # No rebuilding of the interest set.
             keys_events = selector.select(timeout=deadline - monotonic)
 
-            # (7) A sentinel wakeup normally means a child exited and the next
+            # (8) A sentinel wakeup normally means a child exited and the next
             # reclaim_tokens_fn() pass will restore its slot, so loop at once.
             # But if that Future's lock is held elsewhere, reclaim cannot
             # complete it and its sentinel stays ready, so re-select()ing would

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -319,6 +319,56 @@ class TestJobserverWorker(unittest.TestCase):
                     self.assertEqual(1, f.result())
                     self.assertEqual(0, g.result())
 
+    def test_sleep_fn_consume_zero(self) -> None:
+        """sleep_fn gates consume == 0 work too, uniformly (#340).
+
+        A consume == 0 submission consumes no slot but still spawns real
+        work, so the admission gate must apply.
+        """
+        for method in start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=method, slots=1) as js:
+                    # A vetoing gate must block consume == 0 work to timeout
+                    # rather than letting it slip through ungated; fn never
+                    # runs because the gate is never satisfied.
+                    veto_calls = [0]
+
+                    def veto(veto_calls=veto_calls) -> float:
+                        veto_calls[0] += 1
+                        return 0.05
+
+                    with self.assertRaises(Blocked):
+                        js.submit(
+                            fn=len,
+                            args=((),),
+                            consume=0,
+                            sleep_fn=veto,
+                            timeout=0.1,
+                        )
+                    self.assertGreater(
+                        veto_calls[0],
+                        0,
+                        "sleep_fn never consulted for consume == 0 work",
+                    )
+
+                    # A permissive gate admits consume == 0 work and is
+                    # consulted at least once on the way in.
+                    allow_calls = [0]
+
+                    def allow(allow_calls=allow_calls):
+                        allow_calls[0] += 1
+                        return None
+
+                    f = js.submit(
+                        fn=len, args=((1, 2),), consume=0, sleep_fn=allow
+                    )
+                    self.assertEqual(2, f.result(timeout=5))
+                    self.assertGreater(
+                        allow_calls[0],
+                        0,
+                        "sleep_fn never consulted for admitted consume == 0",
+                    )
+
     def test_sleep_fn_timeout_not_overshot(self) -> None:
         """sleep_fn veto must raise Blocked once the deadline passes.
 


### PR DESCRIPTION
## Summary

A `submit(..., consume=0)` submission spawns real work but consumes no slot, and `_maybe_obtain_token` broke out of its loop as soon as `consume == 0` — before `sleep_fn` was ever consulted. Any admission gate built on `sleep_fn` (e.g. "only start work when enough RAM is free") was therefore silently bypassed for zero-slot work, exactly when the system is under pressure.

This consults `sleep_fn` before admitting **every** submission, honoring the deadline and `Blocked` semantics, and only then breaks out for the no-slot `consume == 0` case. The gate now behaves uniformly regardless of `consume`.

The `submit()` docstring previously described `sleep_fn` as governing "when a slot may be consumed", which was the source of the ambiguity; it now describes work acceptance.

## Changes

- `_maybe_obtain_token`: move the early `consume == 0` break to *after* the `sleep_fn` gate, so zero-slot work is gated like slot-consuming work.
- `submit()` docstring: reword to "when any work may be accepted".
- New test `test_sleep_fn_consume_zero`: a vetoing gate blocks `consume=0` work to timeout (previously it slipped through); a permissive gate admits it. Runs across all start methods.

## Verification

`./ci` passes locally: 259 tests, `ruff`, `mypy`, `black --check`, and sdist build all clean.

Closes #340

https://claude.ai/code/session_01FkQZQhL2nSQU5QTjuxC4tn

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkQZQhL2nSQU5QTjuxC4tn)_