### PR TITLE
Wait on the result pipe alone so liveness never declares a death

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Purpose
    queues consequently permitting the implementation to play well with
    more 3rd party libraries.
  * Fourth, Futures are eagerly scanned to quickly reclaim resources.
- * Fifth, Futures can detect when a child process died unexpectedly.
+ * Fifth, Futures can detect when a result pipe closes without a result.
  * Sixth, the user can specify additional work acceptance criteria.
    For example, not launching work unless some amount of RAM is available.
  * Lastly, the API communicates when Exceptions occur within a callback.
@@ -54,15 +54,16 @@ and
 | Background thread                 |     no      |         yes         |          yes          |  yes   |
 | Cancel pending work               |     no      |         yes         |          yes          |   no   |
 | Cancel running work               |     yes     |         no          |          no           |   no   |
-| Detects individual worker death   |     yes     |         yes         |       partial\*       |   no   |
+| Detects individual lost results   |     yes     |         yes         |       partial\*       |   no   |
 | User-defined launch criteria      |     yes     |         yes         |          no           |   no   |
 | Lambdas/closures via `fork`       |     yes     |         no          |          no           |   no   |
 | Lambdas/closures via `spawn`      |     no      |         no          |          no           |   no   |
 | Lambdas/closures via `forkserver` |     no      |         no          |          no           |   no   |
 
-\* `ProcessPoolExecutor` notices a worker died but cannot pin it to a single
-submission, so it fails every outstanding future at once instead of just the
-one whose worker died.
+\* Each submission owns its own result pipe, so a pipe that closes without a
+result is reported as `SubmissionDied` against exactly that one `Future`.
+`ProcessPoolExecutor`, by contrast, cannot tell which submission lost its
+worker, so it fails all outstanding futures at once.
 
 Examples
 --------
@@ -75,8 +76,8 @@ Examples
    shares slot constraints with its parent.
  * [ex04_cancel](examples/ex04_cancel.py) - Cancelling running work by sending
    `SIGTERM` to a worker via `Future.wait(signal=...)`.
- * [ex05_death](examples/ex05_death.py) - Detecting when a worker process is
-   killed unexpectedly via `SubmissionDied`.
+ * [ex05_death](examples/ex05_death.py) - Detecting a submission whose result
+   pipe closes without a result (e.g. a killed worker) via `SubmissionDied`.
  * [ex06_sleep_fn](examples/ex06_sleep_fn.py) - Gating work acceptance on an
    external condition using `sleep_fn`.
  * [ex07_callbacks](examples/ex07_callbacks.py) - Registering `when_done`

--- a/examples/ex05_death.py
+++ b/examples/ex05_death.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-"""Example 5 shows detecting when a worker process dies unexpectedly."""
+"""Example 5 shows detecting a submission that ends without a result."""
 
 import signal
 from logging import INFO, basicConfig, captureWarnings, info
@@ -12,16 +12,16 @@ from jobserver import Jobserver, SubmissionDied
 
 
 def main() -> None:
-    """Shows detecting when a worker process dies unexpectedly."""
+    """Shows detecting a submission that ends without a result."""
     with Jobserver(context="spawn", slots=2) as jobserver:
-        # To emulate unexpected process death within a work,
-        # submit work that will kill itself when it runs
+        # Submit work that SIGKILLs itself, closing the result pipe
+        # without sending a result.
         future_killed = jobserver(signal.raise_signal, signal.SIGKILL)
 
         # Submit normal work alongside the doomed submission
         future_ok = jobserver.submit(fn=len, args=("hello",))
 
-        # wait() returns True even for dead submissions
+        # wait() returns True once settled, even when the submission died
         info("Killed worker wait: %s", future_killed.wait())
         info("Normal result: %s", future_ok.result())
 

--- a/src/jobserver/__init__.py
+++ b/src/jobserver/__init__.py
@@ -17,7 +17,7 @@ concurrent.futures.Executor with a few differences:
    queues consequently permitting the implementation to play well with
    more 3rd party libraries.
  * Fourth, Futures are eagerly scanned to quickly reclaim resources.
- * Fifth, Futures can detect when a child process died unexpectedly.
+ * Fifth, Futures can detect when a result pipe closes without a result.
  * Sixth, the user can specify additional work acceptance criteria.
    For example, not launching work unless some amount of RAM is available.
  * Lastly, the API communicates when Exceptions occur within a callback.

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -1306,7 +1306,7 @@ def _maybe_obtain_token(
 
             # (8) A sentinel wakeup normally means a child exited and the next
             # reclaim_tokens_fn() pass will restore its slot, so loop at once.
-            # But if that Future's lock is held elsewhere, reclaim cannot
+            # But if its pipe stays open or its lock is held, reclaim cannot
             # complete it and its sentinel stays ready, so re-select()ing would
             # peg a CPU.  Back off only when a sentinel-only wakeup repeats
             # fds the prior pass failed to reclaim, bounded by the deadline.

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -125,7 +125,9 @@ class SubmissionDied(Exception):
     Reports a submission died for unknowable reasons, e.g. being killed.
 
     Work that is killed, terminated, interrupted, etc. raises this exception.
-    Exactly what has transpired is not reported.  Do not attempt to recover.
+    The trigger is the result pipe closing without a result, not just the
+    worker dying. Exactly what has transpired is not reported. Do not attempt
+    to recover.
     """
 
 
@@ -427,7 +429,8 @@ class Future(Generic[T]):
         Waiting at most timeout, return True if result(timeout=0) must succeed.
 
         First, sends any provided signal to any underlying, running process.
-        Second, returns True if process completion confirmed by the timeout.
+        Second, returns True once the result pipe yields a result or closes
+        without one. The work is not done until the pipe is closed.
         Timeout is given in seconds with None meaning to block indefinitely.
         Never raises Blocked but instead returns False on unavailable result.
 
@@ -461,19 +464,17 @@ class Future(Generic[T]):
                 except ProcessLookupError:
                     pass
 
-            # Wait for either pipe data or process death
+            # The result pipe is the contract: a readable connection has data
+            # or has closed without one. Wait on it, not on process exit.
             assert self._process is not None
-            ready = wait(
-                [self._connection, self._process.sentinel],
+            if not wait(
+                [self._connection],
                 timeout=deadline_to_timeout(deadline),
-            )
-            # Sentinel ready implies process exited; trust it over is_alive()
-            # because Linux closes fds before marking the process as a zombie
-            if not ready and self._process.is_alive():
+            ):
                 return False
 
-            # Attempt to read the result Wrapper from the Connection
-            # EOFError is an unexpected hang up from the other end
+            # The connection is readable, so recv() will not block past the
+            # deadline.  EOFError is the contract closing without a result.
             try:
                 self._wrapper = self._connection.recv()
             except EOFError:

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -195,6 +195,22 @@ def helper_noop() -> None:
     """A do-nothing callable picklable for spawn/forkserver contexts."""
 
 
+def helper_fork_orphan_then_die(q: SPSCQueue[int]) -> typing.NoReturn:
+    """Fork a grandchild that inherits the result pipe, then die silently.
+
+    The grandchild reports its pid via q (so the test can reap it) and then
+    sleeps, keeping the inherited result-pipe write end open.  The worker
+    exits via os._exit() WITHOUT sending a result, so the pipe never reaches
+    EOF: from the parent the Future is *undetermined* -- not dead -- until
+    the orphan is reaped and the last write end closes (see #328).
+    """
+    if os.fork() == 0:  # grandchild keeps the inherited result pipe open
+        q.put(os.getpid())
+        time.sleep(60)
+        os._exit(0)
+    os._exit(0)  # worker dies WITHOUT sending a result
+
+
 def helper_preexec_fn() -> None:
     """Mutates os.environ so that the change can be observed."""
     os.environ["JOBSERVER_TEST_ENVIRON"] = "PREEXEC_FN"

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -16,6 +16,7 @@ import itertools
 import os
 import signal
 import sys
+import threading
 import time
 import typing
 import unittest
@@ -35,8 +36,10 @@ from jobserver._jobserver import (
 from jobserver._queue import SPSCQueue
 
 from .helpers import (
+    TIMEOUT,
     helper_callback,
     helper_current_process_name,
+    helper_fork_orphan_then_die,
     helper_nonblocking,
     helper_noop,
     helper_preexec_cm,
@@ -138,6 +141,60 @@ class TestJobserverWorker(unittest.TestCase):
                     with self.assertRaises(SubmissionDied) as ctx:
                         f.result(timeout=5)
                 self.assertIsNone(ctx.exception.__cause__)
+
+    def test_open_result_pipe_keeps_future_undetermined(self) -> None:
+        """An open result pipe leaves a Future undetermined, not dead (#328).
+
+        A worker forks a grandchild that inherits the result-pipe write end,
+        then exits without sending a result.  Per the pipe-as-contract model
+        the result is merely *undetermined* while that write end stays open:
+        the worker's exit must NOT manufacture a death, so wait(timeout)
+        returns False within its deadline (rather than hanging in recv() or
+        reporting SubmissionDied).  Only once the orphan is reaped does the
+        pipe reach EOF and the death legitimately surface.
+
+        wait() runs on a daemon thread so a regression to an unbounded recv()
+        shows up as the thread failing to finish rather than wedging the suite.
+        """
+        for method in start_methods():
+            with self.subTest(method=method):
+                # The grandchild reports its pid here so the test can reap it.
+                with SPSCQueue(context=method) as q:
+                    with Jobserver(context=method, slots=1) as js:
+                        f = js.submit(
+                            fn=helper_fork_orphan_then_die, args=(q,)
+                        )
+                        # Block until the orphan exists and holds the pipe.
+                        orphan_pid = q.get(timeout=TIMEOUT)
+                        returned = threading.Event()
+                        out: list = []
+
+                        # Bind loop vars as defaults so the closure captures
+                        # this iteration's objects (ruff B023).
+                        def _waiter(f=f, ev=returned, sink=out) -> None:
+                            sink.append(f.wait(timeout=0.5))
+                            ev.set()
+
+                        t = threading.Thread(target=_waiter, daemon=True)
+                        t.start()
+                        try:
+                            self.assertTrue(
+                                returned.wait(TIMEOUT),
+                                "wait() ignored its timeout",
+                            )
+                            # Undetermined: a finite wait returns False, with
+                            # no death synthesized from the worker's exit.
+                            self.assertEqual(out, [False])
+                        finally:
+                            # Reaping the orphan closes the last write end so
+                            # the pipe reaches EOF (also unwedges any hang).
+                            try:
+                                os.kill(orphan_pid, signal.SIGKILL)
+                            except ProcessLookupError:
+                                pass
+                        # Pipe now EOFs: the death legitimately surfaces.
+                        with self.assertRaises(SubmissionDied):
+                            f.result(timeout=TIMEOUT)
 
     def test_done_signal_terminates(self) -> None:
         """Future.wait(..., signal=...) accepts Signals enum and int forms."""


### PR DESCRIPTION
## Summary

`Future.wait()` could block indefinitely, ignoring its `timeout`, when a worker died without sending a result while some other process (e.g. a grandchild it forked) kept the result pipe's write end open. The wait saw a sentinel-only wakeup, then issued an unbounded `connection.recv()` and hung there.

The root cause was conflating two distinct questions through one mechanism:

- **"Is a result coming?"** — answered by the result pipe.
- **"Is the worker still running?"** — answered by process liveness.

Waiting on the process sentinel and then committing to a blocking `recv()` let a process-exit signal authorize the read, even though an open pipe means a result may still arrive.

## Fix

Treat the result pipe as the sole contract. `wait()` now waits on the connection alone:

- a **readable** connection yields a result (data) or has closed without one (EOF → `SubmissionDied`);
- an **elapsed timeout** reports the work as not done via `False`.

Process exit is no longer consulted, so death is reported only when the pipe actually closes and is never synthesized from `is_alive()`. A finite timeout is always honored, and `timeout=None` waits for the contract to resolve.

## Test

`test_open_result_pipe_keeps_future_undetermined` forks a grandchild that holds the result pipe open past the worker's death and asserts `wait(timeout)` returns `False` within its deadline, then that the death surfaces as `SubmissionDied` once the orphan is reaped. The wait runs on a daemon thread so a regression to an unbounded `recv()` shows up as a non-returning thread rather than wedging the suite.

## Docs

The README, package docstring, `ex05_death` example, and the `wait()` and `SubmissionDied` docstrings are aligned with this model: death is the result pipe closing without a result, not the worker process exiting.

## Verification

`./ci` passes: 260 tests OK, ruff clean, mypy "no issues", black unchanged, sdist builds.

Closes #328

https://claude.ai/code/session_01Emkoce9ToQ5YuE7mstA3eb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Emkoce9ToQ5YuE7mstA3eb)_