### PR TITLE
Set FD_CLOEXEC on result pipe to prevent grandchild inheritance

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -1152,6 +1152,9 @@ def _worker_entrypoint(send, env, preexec_fn, fn, args, kwargs) -> None:
     """Entry point for workers to run fn(...) due to some submit(...)."""
     ignore_sigpipe()
 
+    # Enforce close-on-exec so exec()'d grandchildren don't inherit the pipe.
+    os.set_inheritable(send.fileno(), False)
+
     # Wrapper usage tracks whether a value was returned or raised
     # in degenerate case where client code returns an Exception
     result: Optional[Wrapper[Any]] = None

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -211,6 +211,23 @@ def helper_fork_orphan_then_die(q: SPSCQueue[int]) -> typing.NoReturn:
     os._exit(0)  # worker dies WITHOUT sending a result
 
 
+def helper_exec_grandchild_then_die(q: SPSCQueue[int]) -> typing.NoReturn:
+    """Exec a long-lived grandchild via subprocess.Popen, then die silently.
+
+    The grandchild is a plain ``sleep`` process that would inherit the
+    result-pipe write end without FD_CLOEXEC.  With close-on-exec set (the
+    fix for #368) exec() closes the fd in the grandchild, so when the worker
+    exits the pipe reaches EOF and the Future completes promptly.
+
+    The grandchild's pid is sent via q so the test can reap it.
+    """
+    import subprocess
+
+    proc = subprocess.Popen(["sleep", "60"])
+    q.put(proc.pid)
+    os._exit(0)  # worker dies WITHOUT sending a result
+
+
 def helper_preexec_fn() -> None:
     """Mutates os.environ so that the change can be observed."""
     os.environ["JOBSERVER_TEST_ENVIRON"] = "PREEXEC_FN"

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -39,6 +39,7 @@ from .helpers import (
     TIMEOUT,
     helper_callback,
     helper_current_process_name,
+    helper_exec_grandchild_then_die,
     helper_fork_orphan_then_die,
     helper_nonblocking,
     helper_noop,
@@ -195,6 +196,35 @@ class TestJobserverWorker(unittest.TestCase):
                         # Pipe now EOFs: the death legitimately surfaces.
                         with self.assertRaises(SubmissionDied):
                             f.result(timeout=TIMEOUT)
+
+    def test_exec_grandchild_does_not_pin_result_pipe(self) -> None:
+        """An exec'd grandchild does not hold the result pipe open (#368).
+
+        A worker spawns a grandchild via subprocess.Popen (which exec()s) and
+        exits without sending a result.  With FD_CLOEXEC set on the write end,
+        exec() closes the fd in the grandchild, the pipe reaches EOF when the
+        worker exits, and the Future completes promptly -- in contrast to the
+        bare-fork case in test_open_result_pipe_keeps_future_undetermined.
+        """
+        for method in start_methods():
+            with self.subTest(method=method):
+                with SPSCQueue(context=method) as q:
+                    with Jobserver(context=method, slots=1) as js:
+                        f = js.submit(
+                            fn=helper_exec_grandchild_then_die, args=(q,)
+                        )
+                        grandchild_pid = q.get(timeout=TIMEOUT)
+                        try:
+                            # The pipe must reach EOF promptly; the exec'd
+                            # grandchild must not hold the write end open.
+                            with self.assertRaises(SubmissionDied):
+                                f.result(timeout=TIMEOUT)
+                        finally:
+                            try:
+                                os.kill(grandchild_pid, signal.SIGKILL)
+                                os.waitpid(grandchild_pid, 0)
+                            except (ProcessLookupError, ChildProcessError):
+                                pass
 
     def test_done_signal_terminates(self) -> None:
         """Future.wait(..., signal=...) accepts Signals enum and int forms."""
@@ -661,6 +691,10 @@ class _RecordingSend:
         self.payloads: list[bytes] = []
         self.closed = False
         self._fail_with = fail_with
+        self._fd = os.open(os.devnull, os.O_WRONLY)
+
+    def fileno(self) -> int:
+        return self._fd
 
     def send_bytes(self, payload: typing.Any) -> None:
         if self._fail_with is not None:
@@ -670,6 +704,7 @@ class _RecordingSend:
 
     def close(self) -> None:
         self.closed = True
+        os.close(self._fd)
 
 
 class TestWorkerEntrypointPickleFallback(unittest.TestCase):


### PR DESCRIPTION
## Summary
This PR fixes an issue where exec'd grandchildren could inherit and hold open the result pipe file descriptor, preventing futures from completing when a worker spawns a subprocess and exits without sending a result.

## Changes
- **src/jobserver/_jobserver.py**: Added `os.set_inheritable(send.fileno(), False)` in `_worker_entrypoint()` to set FD_CLOEXEC on the result pipe write end. This ensures that when a worker spawns a grandchild via `subprocess.Popen` (which calls exec()), the file descriptor is automatically closed in the child process, allowing the pipe to reach EOF when the worker exits.

- **test/helpers.py**: Added `helper_exec_grandchild_then_die()` helper function that spawns a long-lived `sleep` process via `subprocess.Popen` and exits without sending a result. This reproduces the scenario from issue #368.

- **test/test_jobserver_worker.py**: 
  - Added import of `helper_exec_grandchild_then_die`
  - Added `test_exec_grandchild_does_not_pin_result_pipe()` test that verifies the fix works across all start methods. The test confirms that the future completes promptly (via `SubmissionDied` exception) rather than hanging indefinitely.
  - Enhanced `_MockConnection` class with `fileno()` method and proper file descriptor cleanup to support testing the fix.

## Implementation Details
The fix leverages the POSIX close-on-exec flag (FD_CLOEXEC) which is automatically applied when a process calls exec(). By marking the result pipe as non-inheritable before the worker runs user code, any grandchildren spawned via exec() will have the file descriptor closed automatically, preventing them from holding the pipe open.

https://claude.ai/code/session_01L4BPNypKEk8o32SYGKkMVJ