### PR TITLE
Rename SubmissionDied to LostResult

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 Jobserver
 =========
 
-A nestable Jobserver with thread-safe futures, callbacks, and complete
-type-hinting
+A nestable Jobserver with thread-safe futures, callbacks, and type-hinting
 
 Purpose
 -------
@@ -61,7 +60,7 @@ and
 | Lambdas/closures via `forkserver` |     no      |         no          |          no           |   no   |
 
 \* Each submission owns its own result pipe, so a pipe that closes without a
-result is reported as `SubmissionDied` against exactly that one `Future`.
+result is reported as `LostResult` against exactly that one `Future`.
 `ProcessPoolExecutor`, by contrast, cannot tell which submission lost its
 worker, so it fails all outstanding futures at once.
 
@@ -77,7 +76,7 @@ Examples
  * [ex04_cancel](examples/ex04_cancel.py) - Cancelling running work by sending
    `SIGTERM` to a worker via `Future.wait(signal=...)`.
  * [ex05_death](examples/ex05_death.py) - Detecting a submission whose result
-   pipe closes without a result (e.g. a killed worker) via `SubmissionDied`.
+   pipe closes without a result (e.g. a killed worker) via `LostResult`.
  * [ex06_sleep_fn](examples/ex06_sleep_fn.py) - Gating work acceptance on an
    external condition using `sleep_fn`.
  * [ex07_callbacks](examples/ex07_callbacks.py) - Registering `when_done`

--- a/examples/ex04_cancel.py
+++ b/examples/ex04_cancel.py
@@ -9,7 +9,7 @@ import signal
 import time
 from logging import INFO, basicConfig, captureWarnings, info
 
-from jobserver import Jobserver, SubmissionDied
+from jobserver import Jobserver, LostResult
 
 
 def main() -> None:
@@ -31,12 +31,12 @@ def main() -> None:
         )
         info("Normal result: %s", future_ok.result())
 
-        # Here, result() raises SubmissionDied for the SIGTERM-ed worker
+        # Here, result() raises LostResult for the SIGTERM-ed worker
         try:
             future_cancel.result()
-            raise RuntimeError("Expected SubmissionDied was not raised")
-        except SubmissionDied:
-            info("Caught expected SubmissionDied from cancelled worker")
+            raise RuntimeError("Expected LostResult was not raised")
+        except LostResult:
+            info("Caught expected LostResult from cancelled worker")
 
 
 if __name__ == "__main__":

--- a/examples/ex05_death.py
+++ b/examples/ex05_death.py
@@ -8,7 +8,7 @@
 import signal
 from logging import INFO, basicConfig, captureWarnings, info
 
-from jobserver import Jobserver, SubmissionDied
+from jobserver import Jobserver, LostResult
 
 
 def main() -> None:
@@ -25,12 +25,12 @@ def main() -> None:
         info("Killed worker wait: %s", future_killed.wait())
         info("Normal result: %s", future_ok.result())
 
-        # result() raises SubmissionDied for the killed worker
+        # result() raises LostResult for the killed worker
         try:
             future_killed.result()
-            raise RuntimeError("Expected SubmissionDied was not raised")
-        except SubmissionDied:
-            info("Caught expected SubmissionDied from SIGKILL worker")
+            raise RuntimeError("Expected LostResult was not raised")
+        except LostResult:
+            info("Caught expected LostResult from SIGKILL worker")
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [
     {name = "Rhys Ulerich", email = "rhys.ulerich@gmail.com"},
 ]
-description = "A nestable Jobserver with thread-safe futures, callbacks, and complete type-hinting"
+description = "A nestable Jobserver with thread-safe futures, callbacks, and type-hinting"
 readme = "README.md"
 license = "MPL-2.0"
 requires-python = ">=3.9"

--- a/src/jobserver/__init__.py
+++ b/src/jobserver/__init__.py
@@ -4,12 +4,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
-A nestable Jobserver with futures, callbacks, and complete type-hinting
+A nestable Jobserver with thread-safe futures, callbacks, and type-hinting
 
 Jobserver is similar in spirit to multiprocessing.Pool or
 concurrent.futures.Executor with a few differences:
 
- * First, the implementation choices are based upon
+ * First, the implementation choices are based upon the GNU Make
+   Jobserver at
    https://www.gnu.org/software/make/manual/html_node/POSIX-Jobserver.html.
  * Second, as a result, the Jobserver is "nestable" meaning that resource
    constraints will be shared with work submitted by other work.
@@ -44,7 +45,7 @@ from ._jobserver import (
     CallbackRaised,
     Future,
     Jobserver,
-    SubmissionDied,
+    LostResult,
 )
 
 __all__ = (
@@ -53,5 +54,5 @@ __all__ = (
     "Future",
     "Jobserver",
     "JobserverExecutor",
-    "SubmissionDied",
+    "LostResult",
 )

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -58,7 +58,7 @@ __all__ = (
     "CallbackRaised",
     "Future",
     "Jobserver",
-    "SubmissionDied",
+    "LostResult",
 )
 
 T = TypeVar("T")
@@ -120,14 +120,14 @@ class CallbackRaised(Exception):
 
 
 @final
-class SubmissionDied(Exception):
+class LostResult(Exception):
     """
-    Reports a submission died for unknowable reasons, e.g. being killed.
+    Reports that a submission failed to return a result.
 
-    Work that is killed, terminated, interrupted, etc. raises this exception.
-    The trigger is the result pipe closing without a result, not just the
-    worker dying. Exactly what has transpired is not reported. Do not attempt
-    to recover.
+    This happens when a worker is killed, exits, or replaces itself with
+    another program via the exec call before sending a result on the
+    shared result pipe. Exactly what transpired is not reported. Do not
+    attempt to recover.
     """
 
 
@@ -478,7 +478,7 @@ class Future(Generic[T]):
             try:
                 self._wrapper = self._connection.recv()
             except EOFError:
-                self._wrapper = ExceptionWrapper(SubmissionDied())
+                self._wrapper = ExceptionWrapper(LostResult())
             except Exception as e:
                 # A value can pickle in the child yet fail to reconstitute
                 # in the parent (e.g. a returned Connection raises
@@ -1179,21 +1179,21 @@ def _worker_entrypoint(send, env, preexec_fn, fn, args, kwargs) -> None:
         result = ExceptionWrapper(exception)
     except BaseException as base_exception:
         # When possible, send cause of death back to the parent to aid
-        # users in debugging.  Raising SubmissionDied() from the escaped
+        # users in debugging.  Raising LostResult() from the escaped
         # BaseException gives it a live traceback whose chained __cause__
         # names the SystemExit/KeyboardInterrupt for the parent to render.
-        # SubmissionDied() without __cause__ indicates this send failed,
+        # LostResult() without __cause__ indicates this send failed,
         # e.g. due to a SIGKILL.
         try:
-            raise SubmissionDied() from base_exception
-        except SubmissionDied as died:
-            result = ExceptionWrapper(died)
+            raise LostResult() from base_exception
+        except LostResult as lost:
+            result = ExceptionWrapper(lost)
         raise  # Proceed with any BaseException-specific teardown
     finally:
         try:
             # None means result assignment never ran (e.g. an interpreter
             # teardown between except and finally); let the pipe close so
-            # the parent sees EOFError -> SubmissionDied.
+            # the parent sees EOFError -> LostResult.
             if result is not None:
                 try:
                     payload = ForkingPickler.dumps(result)

--- a/test/test_design.py
+++ b/test/test_design.py
@@ -15,7 +15,7 @@ import signal
 import time
 import unittest
 
-from jobserver import Blocked, Jobserver, SubmissionDied
+from jobserver import Blocked, Jobserver, LostResult
 
 from .helpers import start_methods
 
@@ -213,7 +213,7 @@ class TestDesignForkSelector(unittest.TestCase):
 # When the Child is killed:
 #
 #   * The Parent detects Child death via EOFError on the result pipe,
-#     wraps it as SubmissionDied, and fires the Child future's internal
+#     wraps it as LostResult, and fires the Child future's internal
 #     callback restoring token 0.
 #
 #   * But the Grandchild's token-restoring callback existed only in the
@@ -260,7 +260,7 @@ class TestDesignShortcoming(unittest.TestCase):
 
                     # Kill the intermediate Child and collect it
                     future.wait(signal=signal.SIGKILL, timeout=5)
-                    with self.assertRaises(SubmissionDied):
+                    with self.assertRaises(LostResult):
                         future.result()
 
                     # Grandchild finishes but nobody reclaims its token.
@@ -293,5 +293,5 @@ class TestDesignShortcoming(unittest.TestCase):
                     # Clean up the submissions that did succeed
                     for f in futures:
                         f.wait(signal=signal.SIGKILL)
-                        with self.assertRaises(SubmissionDied):
+                        with self.assertRaises(LostResult):
                             f.result()

--- a/test/test_executor_basic.py
+++ b/test/test_executor_basic.py
@@ -25,7 +25,7 @@ import unittest
 from jobserver import (
     Jobserver,
     JobserverExecutor,
-    SubmissionDied,
+    LostResult,
     _response,
 )
 from jobserver._executor import _responses_put_failed
@@ -128,7 +128,7 @@ class TestExceptionPropagation(unittest.TestCase):
         with Jobserver(context=FAST, slots=2) as js:
             with JobserverExecutor(js) as exe:
                 f = exe.submit(signal.raise_signal, signal.SIGKILL)
-                with self.assertRaises(SubmissionDied):
+                with self.assertRaises(LostResult):
                     f.result(timeout=TIMEOUT)
                 # Executor must recover for multiple subsequent tasks
                 for i in range(5):
@@ -140,7 +140,7 @@ class TestExceptionPropagation(unittest.TestCase):
         with Jobserver(context=FAST, slots=2) as js:
             with JobserverExecutor(js) as exe:
                 f = exe.submit(sys.exit, 1)
-                with self.assertRaises(SubmissionDied):
+                with self.assertRaises(LostResult):
                     f.result(timeout=TIMEOUT)
                 # Executor must remain usable
                 g = exe.submit(len, (1, 2, 3))

--- a/test/test_executor_lifecycle.py
+++ b/test/test_executor_lifecycle.py
@@ -27,7 +27,7 @@ from unittest import mock
 from jobserver import (
     Jobserver,
     JobserverExecutor,
-    SubmissionDied,
+    LostResult,
     _request,
     _response,
 )
@@ -430,7 +430,7 @@ class TestResourceLeaks(unittest.TestCase):
         with Jobserver(context=FAST, slots=2) as js:
             with JobserverExecutor(js) as exe:
                 f = exe.submit(signal.raise_signal, signal.SIGKILL)
-                with self.assertRaises(SubmissionDied):
+                with self.assertRaises(LostResult):
                     f.result(timeout=TIMEOUT)
         time.sleep(0.5)
         after = len(multiprocessing.active_children())

--- a/test/test_jobserver_traceback.py
+++ b/test/test_jobserver_traceback.py
@@ -14,7 +14,7 @@ import traceback
 import typing
 import unittest
 
-from jobserver import Jobserver, SubmissionDied
+from jobserver import Jobserver, LostResult
 from jobserver._jobserver import (
     ExceptionWrapper,
     RemoteTraceback,
@@ -79,15 +79,15 @@ def _wrap_live_exception() -> ExceptionWrapper:
 
 
 def _wrap_live_base_exception(klass: type, *args) -> ExceptionWrapper:
-    """Mirror _worker_entrypoint's BaseException path: raise SubmissionDied
+    """Mirror _worker_entrypoint's BaseException path: raise LostResult
     from a freshly-raised control-flow BaseException, then wrap it (#167).
     """
     try:
         raise klass(*args)
     except BaseException as e:
         try:
-            raise SubmissionDied() from e
-        except SubmissionDied as died:
+            raise LostResult() from e
+        except LostResult as died:
             return ExceptionWrapper(died)
     raise AssertionError("unreachable")
 
@@ -265,7 +265,7 @@ class TestExceptionWrapperPickle(unittest.TestCase):
 
     def test_round_trip_without_traceback(self) -> None:
         """Parent-built wrappers have no tb; round-trips stay empty."""
-        w = ExceptionWrapper(SubmissionDied())
+        w = ExceptionWrapper(LostResult())
         self.assertEqual(w._raised_tb, "")
         self._assert_idempotent(w)
 
@@ -291,10 +291,10 @@ class TestExceptionWrapperPickle(unittest.TestCase):
         self._assert_idempotent(w)
 
     def test_submission_died_chained_from_keyboard_interrupt(self) -> None:
-        """SubmissionDied raised-from KeyboardInterrupt captures both."""
+        """LostResult raised-from KeyboardInterrupt captures both."""
         w = _wrap_live_base_exception(KeyboardInterrupt)
-        self.assertIsInstance(w._raised, SubmissionDied)
-        self.assertIn("SubmissionDied", w._raised_tb)
+        self.assertIsInstance(w._raised, LostResult)
+        self.assertIn("LostResult", w._raised_tb)
         self.assertIn("KeyboardInterrupt", w._raised_tb)
         self.assertIn("_wrap_live_base_exception", w._raised_tb)
         self._assert_idempotent(w)
@@ -302,15 +302,15 @@ class TestExceptionWrapperPickle(unittest.TestCase):
     def test_submission_died_chained_from_system_exit(self) -> None:
         """The chained SystemExit type renders so the parent can debug."""
         w = _wrap_live_base_exception(SystemExit, 2)
-        self.assertIsInstance(w._raised, SubmissionDied)
+        self.assertIsInstance(w._raised, LostResult)
         self.assertIn("SystemExit", w._raised_tb)
         self._assert_idempotent(w)
 
     def test_chained_base_exception_round_trips(self) -> None:
-        """unwrap() after pickle raises SubmissionDied whose RemoteTraceback
+        """unwrap() after pickle raises LostResult whose RemoteTraceback
         renders the chained control-flow cause."""
         w = self._round_trip(_wrap_live_base_exception(KeyboardInterrupt))
-        with self.assertRaises(SubmissionDied) as ctx:
+        with self.assertRaises(LostResult) as ctx:
             w.unwrap()
         self.assertIsInstance(ctx.exception.__cause__, RemoteTraceback)
         self.assertIn("KeyboardInterrupt", str(ctx.exception.__cause__))

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -26,7 +26,7 @@ from multiprocessing.reduction import ForkingPickler
 from jobserver import (
     Blocked,
     Jobserver,
-    SubmissionDied,
+    LostResult,
 )
 from jobserver._jobserver import (
     ExceptionWrapper,
@@ -88,25 +88,25 @@ class TestJobserverWorker(unittest.TestCase):
                     self.assertEqual([2, 3, 5, 7, 11], mutable)
 
                     # Confirm results or signals in reverse order
-                    with self.assertRaises(SubmissionDied):
+                    with self.assertRaises(LostResult):
                         j.result()
                     self.assertEqual(14, i.result())
-                    with self.assertRaises(SubmissionDied):
+                    with self.assertRaises(LostResult):
                         h.result()
-                    with self.assertRaises(SubmissionDied):
+                    with self.assertRaises(LostResult):
                         g.result()
-                    with self.assertRaises(SubmissionDied):
+                    with self.assertRaises(LostResult):
                         f.result()
 
     def test_base_exception_surfaces_as_submission_died(self) -> None:
-        """BaseException subclasses escaping fn surface as SubmissionDied.
+        """BaseException subclasses escaping fn surface as LostResult.
 
         sys.exit(1) raises SystemExit and helper_raise(KeyboardInterrupt)
         raises KeyboardInterrupt – both are BaseException subclasses that
         fall outside the ``except Exception:`` guard in _worker_entrypoint().
         The worker catches them via ``except BaseException``, sends a
-        SubmissionDied carrying the cause's traceback, then re-raises for
-        normal teardown.  The parent sees SubmissionDied whose __cause__ is a
+        LostResult carrying the cause's traceback, then re-raises for
+        normal teardown.  The parent sees LostResult whose __cause__ is a
         RemoteTraceback naming the originating type (see #167).
         """
         # fn, args, substring expected in the propagated child traceback.
@@ -119,7 +119,7 @@ class TestJobserverWorker(unittest.TestCase):
                 with self.subTest(method=method, fn=fn.__name__):
                     with Jobserver(context=method, slots=1) as js:
                         f = js.submit(fn=fn, args=args, timeout=5)
-                        with self.assertRaises(SubmissionDied) as ctx:
+                        with self.assertRaises(LostResult) as ctx:
                             f.result(timeout=5)
                     # The enriched path attaches the child's traceback as a
                     # cause; a silent death would leave __cause__ as None.
@@ -128,18 +128,18 @@ class TestJobserverWorker(unittest.TestCase):
                     self.assertIn(expected, str(cause))
 
     def test_os_exit_becomes_submission_died(self) -> None:
-        """os._exit() in worker produces a bare, causeless SubmissionDied.
+        """os._exit() in worker produces a bare, causeless LostResult.
 
         Unlike SystemExit/KeyboardInterrupt, os._exit() raises nothing the
         worker can catch, so no cause is sent and the parent falls back to
-        EOFError -> SubmissionDied with __cause__ None (the silent-death
+        EOFError -> LostResult with __cause__ None (the silent-death
         path that distinguishes it from the enriched #167 case).
         """
         for method in start_methods():
             with self.subTest(method=method):
                 with Jobserver(context=method, slots=1) as js:
                     f = js.submit(fn=os._exit, args=(1,), timeout=5)
-                    with self.assertRaises(SubmissionDied) as ctx:
+                    with self.assertRaises(LostResult) as ctx:
                         f.result(timeout=5)
                 self.assertIsNone(ctx.exception.__cause__)
 
@@ -151,7 +151,7 @@ class TestJobserverWorker(unittest.TestCase):
         the result is merely *undetermined* while that write end stays open:
         the worker's exit must NOT manufacture a death, so wait(timeout)
         returns False within its deadline (rather than hanging in recv() or
-        reporting SubmissionDied).  Only once the orphan is reaped does the
+        reporting LostResult).  Only once the orphan is reaped does the
         pipe reach EOF and the death legitimately surface.
 
         wait() runs on a daemon thread so a regression to an unbounded recv()
@@ -194,7 +194,7 @@ class TestJobserverWorker(unittest.TestCase):
                             except ProcessLookupError:
                                 pass
                         # Pipe now EOFs: the death legitimately surfaces.
-                        with self.assertRaises(SubmissionDied):
+                        with self.assertRaises(LostResult):
                             f.result(timeout=TIMEOUT)
 
     def test_exec_grandchild_does_not_pin_result_pipe(self) -> None:
@@ -217,7 +217,7 @@ class TestJobserverWorker(unittest.TestCase):
                         try:
                             # The pipe must reach EOF promptly; the exec'd
                             # grandchild must not hold the write end open.
-                            with self.assertRaises(SubmissionDied):
+                            with self.assertRaises(LostResult):
                                 f.result(timeout=TIMEOUT)
                         finally:
                             try:
@@ -235,7 +235,7 @@ class TestJobserverWorker(unittest.TestCase):
                 with Jobserver(context=method, slots=1) as js:
                     f = js.submit(fn=time.sleep, args=(60,))
                     self.assertTrue(f.wait(timeout=None, signal=sig))
-                    with self.assertRaises(SubmissionDied):
+                    with self.assertRaises(LostResult):
                         f.result()
 
     def test_done_signal_invalid_raises(self) -> None:
@@ -275,7 +275,7 @@ class TestJobserverWorker(unittest.TestCase):
                     f = js.submit(fn=time.sleep, args=(60,))
                     f.wait(timeout=1e-9, signal=signal.SIGTERM)
                     self.assertTrue(f.wait(timeout=5))
-                    with self.assertRaises(SubmissionDied):
+                    with self.assertRaises(LostResult):
                         f.result()
 
     def test_environ(self) -> None:
@@ -754,7 +754,7 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
     def test_deeply_nested_result_uses_fallback(self) -> None:
         """A picklable-but-too-deep result overflows the pickler with a
         RecursionError that now degrades to the descriptive fallback rather
-        than crashing the worker into a misleading SubmissionDied (#343)."""
+        than crashing the worker into a misleading LostResult (#343)."""
         send = _RecordingSend()
         _worker_entrypoint(send, {}, lambda: None, _make_deep_result, (), {})
         self.assertEqual(1, len(send.payloads))
@@ -769,12 +769,12 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
 class TestWorkerEntrypointSendBytesErrors(unittest.TestCase):
     """A broken or closed result fd is swallowed during the result-send so
     the worker closes quietly rather than escaping with a traceback and
-    degrading to a misleading SubmissionDied (#348)."""
+    degrading to a misleading LostResult (#348)."""
 
     def test_broken_result_fd_is_swallowed(self) -> None:
         """An OSError/EBADF from a closed result fd closes quietly instead
         of crashing the worker; the parent still observes EOF and reports
-        SubmissionDied, but without a noisy child traceback."""
+        LostResult, but without a noisy child traceback."""
         boom = OSError(errno.EBADF, "Bad file descriptor")
         send = _RecordingSend(fail_with=boom)
         _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})


### PR DESCRIPTION
## Summary

Rename the `SubmissionDied` exception to `LostResult`.

The exception is raised whenever a submission's result pipe closes without a result. After the `FD_CLOEXEC` change (#368), that includes a worker that replaces itself via `exec` rather than one that dies, so the old name speculated about a cause that may not have occurred. `LostResult` names what actually happened — the result was lost — without claiming why.

## Changes

- Rename the class and every reference across `src/`, `test/`, `examples/`, and `README.md` (62 occurrences). No deprecation alias, per request.
- Rewrite the class docstring to drop the death framing:
  > Reports that a submission failed to return a result.
  >
  > This happens when a worker is killed, exits, or replaces itself with another program via the exec call before sending a result on the shared result pipe. Exactly what transpired is not reported. Do not attempt to recover.
- Align the package docstring (`__init__.py`) with the README's duplicated Purpose text: add "thread-safe" to the tagline (matching `pyproject.toml`) and name the GNU Make Jobserver in the first bullet.

The snake_case test method names (`test_submission_died`, etc.) are left unchanged: they describe scenarios where the worker genuinely dies, which is still accurate.

## Verification

`./ci` passes: 261 tests OK, ruff clean, mypy "no issues", black unchanged, sdist builds.

Closes #370

https://claude.ai/code/session_01Emkoce9ToQ5YuE7mstA3eb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Emkoce9ToQ5YuE7mstA3eb)_