### PR TITLE
Fix #345: close response pipe write end in workers to prevent stuck futures

### DIFF
--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -481,6 +481,13 @@ def _dispatch_pending(
     Keeps c.f.Future in PENDING (cancellable) until a process is
     spawned.  Stops on first Blocked since remaining will be too.
     """
+    # Close response writer for methods with workers inheriting open fds,
+    # allowing dispatcher death to be detected quickly despite live workers.
+    if jobserver.context.get_start_method() == "fork":
+        preexec_fn = responses.close_put
+    else:
+        preexec_fn = None
+
     pending = state.pending
     while pending:
         # Peek the oldest entry; insertion order makes dispatch FIFO.
@@ -491,6 +498,7 @@ def _dispatch_pending(
                 args=item.args,
                 kwargs=item.kwargs,
                 timeout=0,
+                preexec_fn=preexec_fn,
             )
         except Blocked:
             return

--- a/test/test_executor_lifecycle.py
+++ b/test/test_executor_lifecycle.py
@@ -454,6 +454,34 @@ class TestResourceLeaks(unittest.TestCase):
             finally:
                 exe.shutdown(wait=True)
 
+    def test_dispatcher_death_with_running_worker_fails_promptly(
+        self,
+    ) -> None:
+        """Killing the dispatcher fails futures promptly with a live worker.
+
+        Issue #345: a worker inherits the response pipe write end.
+        Without the fix EOF never arrives until the worker exits.
+        With the fix the worker closes the fd via preexec_fn promptly.
+        """
+        with Jobserver(context=FAST, slots=1) as js:
+            exe = JobserverExecutor(js)
+            try:
+                # Long sleep so the worker outlives the prompt-fail window.
+                f = exe.submit(time.sleep, 60)
+                # Wait until the future is RUNNING (worker is live, dispatcher
+                # has dispatched and is still alive).
+                wait_until(lambda: f.running(), timeout=TIMEOUT)
+                self.assertTrue(f.running())
+                pid = exe._dispatcher.pid
+                os.kill(pid, signal.SIGKILL)
+                # Must raise BrokenExecutor well before the 60 s worker exits.
+                with self.assertRaises(
+                    (concurrent.futures.BrokenExecutor, RuntimeError)
+                ):
+                    f.result(timeout=10)
+            finally:
+                exe.shutdown(wait=False)
+
     def test_submit_after_dispatcher_death(self) -> None:
         """submit() after dispatcher death raises RuntimeError."""
         with Jobserver(context=FAST, slots=2) as js:


### PR DESCRIPTION
Under fork, workers spawned by the dispatcher inherited the response pipe's write end. Killing the dispatcher left that fd open in live workers, so the receiver never saw EOF and outstanding futures hung until the worker exited.

**Fix:** pass `preexec_fn=responses.close_put` to `jobserver.submit()` when the context is `"fork"`. Workers close their inherited copy immediately on spawn. `close_put` already handles `None` and suppresses `OSError`.

**Test:** submit a 60-second sleep, kill the dispatcher, assert the future raises within 10 seconds rather than blocking.

Closes #345

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnfPhmpbLDszE1LcSruPud)_