### PR TITLE
WIP: Let dropped running Futures finalize and warn (#338)

### DIFF
--- a/draft/JSLOCK.md
+++ b/draft/JSLOCK.md
@@ -40,7 +40,7 @@ that this plan exists to close.
 The shared resource is the `DefaultSelector` and its unsynchronized
 `_fd_to_key` dict.  `submit()` mutates it via `selector.register()`
 (`_jobserver.py:975-976`).  But it is **also** mutated by the Future
-completion callbacks `_unregister_sentinel` / `_unregister_connection`
+completion callbacks `_deregister_sentinel` / `_deregister_connection`
 (`_jobserver.py:542-572`), which call `selector.unregister()`.  Those
 callbacks fire from `Future._issue_callbacks()`, reached by **any** call to
 `Future.wait()` / `done()` / `result()` — including a user calling
@@ -368,10 +368,10 @@ def submit(self, fn, *, ..., timeout=None) -> Future[T]:
     # --- callback wiring: outside spawn lock (Future is self-synchronizing) ---
     future._when_done(fn=_restore_token, args=(self._slots, token),
                       priority=_PRIORITY_TOKEN)
-    future._when_done(fn=_unregister_sentinel,
+    future._when_done(fn=_deregister_sentinel,
                       args=(selector, process.sentinel, process),
                       priority=_PRIORITY_CLEANUP)
-    future._when_done(fn=_unregister_connection, args=(selector, recv),
+    future._when_done(fn=_deregister_connection, args=(selector, recv),
                       priority=_PRIORITY_CLEANUP)
     return future
 ```

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -278,6 +278,7 @@ class Future(Generic[T]):
     """
 
     __slots__ = (
+        "__weakref__",
         "_rlock",
         "_process",
         "_connection",
@@ -285,7 +286,6 @@ class Future(Generic[T]):
         "_callbacks",
         "_callbacks_issuing",
         "_callbacks_seqno",
-        "__weakref__",
     )
 
     def __init__(self, process: BaseProcess, connection: Connection) -> None:
@@ -547,17 +547,16 @@ def noop(*args, **kwargs) -> None:
 
 @dataclass(frozen=True)
 class SlotsSentinel:
-    """Callable selector data for the slots waitable: __call__ returns
-    self so reclaim_resources() resolves a live Future via its weakref
-    and this entry via itself.
+    """Callable selector data for the slots waitable.
 
-    Frozen, hence hashable, so reclaim can dedup selector data with a set
-    instead of via id(); a no-op done() lets reclaim_resources() treat it
-    like a Future.
+    __call__ returns self so reclaim_resources() resolves a live Future
+    via its weakref and this entry via itself.  Frozen, hence hashable,
+    so reclaim can dedup selector data with a set instead of via id(); a
+    no-op done() lets reclaim_resources() treat it like a Future.
     """
 
+    # TODO: return typing.Self once Python 3.11 is the minimum version.
     def __call__(self) -> "SlotsSentinel":
-        # TODO: return typing.Self once Python 3.11 is the minimum version.
         return self
 
     def done(self) -> None:

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -547,16 +547,17 @@ def noop(*args, **kwargs) -> None:
 
 @dataclass(frozen=True)
 class SlotsSentinel:
-    """Selector data for the slots waitable; its no-op done() lets
-    reclaim_resources() treat it like a Future.  Frozen, hence hashable,
-    so reclaim can dedup selector data with a set instead of via id().
+    """Callable selector data for the slots waitable: __call__ returns
+    self so reclaim_resources() resolves a live Future via its weakref
+    and this entry via itself.
 
-    A Future is registered weakly via weakref.ref so __call__ returns self
-    to let reclaim_resources() resolve any selector data uniformly: a live
-    Future via its weakref, this entry via itself.
+    Frozen, hence hashable, so reclaim can dedup selector data with a set
+    instead of via id(); a no-op done() lets reclaim_resources() treat it
+    like a Future.
     """
 
     def __call__(self) -> "SlotsSentinel":
+        # TODO: return typing.Self once Python 3.11 is the minimum version.
         return self
 
     def done(self) -> None:
@@ -693,7 +694,7 @@ class Jobserver:
         self._sleep_fn = sleep_fn
 
     def _tracked(self) -> int:
-        """Live Futures in the selector, excluding the slots entry.
+        """Live Futures in the selector, excluding any slots entry.
 
         Tolerates partial construction (returns 0 when __init__ raised
         before _selector was assigned) and a closed selector (get_map()
@@ -710,10 +711,10 @@ class Jobserver:
         # whose weakref now resolves to None.
         return len(
             {
-                t
-                for k in sm.values()
-                if (t := k.data()) is not None
-                and not isinstance(t, SlotsSentinel)
+                target
+                for key in sm.values()
+                if (target := key.data()) is not None
+                and not isinstance(target, SlotsSentinel)
             }
         )
 
@@ -1029,14 +1030,12 @@ class Jobserver:
             # while its child stays blocked mid-send() and thus unexited.
             #
             # Reference the Future weakly so dropping it before completion
-            # lets it finalize and emit Future.__del__'s ResourceWarning
-            # instead of being pinned alive until the Jobserver closes;
-            # reclaim_resources() reaps the abandoned registration on its
-            # next poll.  One shared weakref keeps the two fds collapsing
-            # to a single reclaim.
-            ref = weakref.ref(future)
-            selector.register(recv, EVENT_READ, data=ref)
-            selector.register(process.sentinel, EVENT_READ, data=ref)
+            # finalizes it, emitting Future.__del__'s ResourceWarning rather
+            # than pinning it until the Jobserver closes; reclaim_resources()
+            # reaps the abandoned registration, shared so the fds collapse.
+            reference = weakref.ref(future)
+            selector.register(recv, EVENT_READ, data=reference)
+            selector.register(process.sentinel, EVENT_READ, data=reference)
         except Exception:
             # Undo any registration that succeeded before the failure.
             # The connection registers first, so cleanup it first too.

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -17,6 +17,7 @@ import time
 import traceback
 import types
 import warnings
+import weakref
 from collections import deque
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import AbstractContextManager, ExitStack
@@ -284,6 +285,7 @@ class Future(Generic[T]):
         "_callbacks",
         "_callbacks_issuing",
         "_callbacks_seqno",
+        "__weakref__",
     )
 
     def __init__(self, process: BaseProcess, connection: Connection) -> None:
@@ -496,7 +498,7 @@ class Future(Generic[T]):
 
             # Drop our reference so _issue_callbacks's invariant holds
             # and __del__ will not warn.  The actual close() is deferred
-            # to a _PRIORITY_BEFORE callback (see _unregister_connection)
+            # to a _PRIORITY_BEFORE callback (see _deregister_connection)
             # so the fd is unregistered from the selector before reuse.
             self._connection = None
             self._issue_callbacks()
@@ -548,7 +550,14 @@ class SlotsSentinel:
     """Selector data for the slots waitable; its no-op done() lets
     reclaim_resources() treat it like a Future.  Frozen, hence hashable,
     so reclaim can dedup selector data with a set instead of via id().
+
+    A Future is registered weakly via weakref.ref so __call__ returns self
+    to let reclaim_resources() resolve any selector data uniformly: a live
+    Future via its weakref, this entry via itself.
     """
+
+    def __call__(self) -> "SlotsSentinel":
+        return self
 
     def done(self) -> None:
         return None
@@ -563,21 +572,22 @@ def _restore_token(slots: FixedBytesQueue, token: Optional[bytes]) -> None:
             pass  # Queue closed; Jobserver is shutting down
 
 
-def _unregister_sentinel(
+def _deregister_sentinel(
     selector: DefaultSelector,
     sentinel: int,
-    _process: BaseProcess,
+    _process: Optional[BaseProcess],
 ) -> None:
     """Unregister sentinel from selector, tolerating prior close."""
     # Argument _process is unused but required to prevent garbage
-    # collection of the Process until after this callback fires.
+    # collection of the Process until after this callback fires.  It is
+    # None when reclaim_resources() reaps an already-collected Future.
     try:
         selector.unregister(sentinel)
     except KeyError:
         pass  # Already unregistered or selector closed
 
 
-def _unregister_connection(
+def _deregister_connection(
     selector: DefaultSelector,
     connection: Connection,
 ) -> None:
@@ -683,7 +693,7 @@ class Jobserver:
         self._sleep_fn = sleep_fn
 
     def _tracked(self) -> int:
-        """Futures in the selector, excluding any slots entry.
+        """Live Futures in the selector, excluding the slots entry.
 
         Tolerates partial construction (returns 0 when __init__ raised
         before _selector was assigned) and a closed selector (get_map()
@@ -695,10 +705,17 @@ class Jobserver:
         sm = selector.get_map()  # None once the selector is closed
         if not sm:
             return 0
-        # Each Future registers two fds (sentinel and connection) beyond
-        # the lone self._slots.waitable() entry.  Approximate while a
-        # completing Future is transiently half-unregistered.
-        return (len(sm) - 1) // 2
+        # Each live Future's two fds resolve to one weakref target, so dedupe
+        # them and drop the slots sentinel and any garbage-collected Future
+        # whose weakref now resolves to None.
+        return len(
+            {
+                t
+                for k in sm.values()
+                if (t := k.data()) is not None
+                and not isinstance(t, SlotsSentinel)
+            }
+        )
 
     def __repr__(self) -> str:
         method = self._context.get_start_method()
@@ -870,13 +887,27 @@ class Jobserver:
         # a non-blocking poll returning only the k ready entries.
         # done() triggers callbacks mutating the selector.
         #
-        # A Future's two fds (connection and sentinel) share one data and
-        # are often ready together; the set collapses them so done() runs
-        # once, and it materializes before any done() mutates the selector.
-        ready = self._lazy_selector().select(timeout=0)
-        for data in {key.data for key, _ in ready}:
-            assert hasattr(data, "done"), type(data)
-            data.done()
+        # A Future's two fds (connection and sentinel) share one weakref and
+        # are often ready together; deduping the resolved targets collapses
+        # them so done() runs once.
+        targets = set()
+        selector = self._lazy_selector()
+        for key, _ in selector.select(timeout=0):
+            # None means the weakly-held Future was garbage-collected: the
+            # caller released its last reference before the work completed.
+            if (target := key.data()) is not None:
+                targets.add(target)
+            elif isinstance(key.fileobj, int):
+                # Garbage-collected Future requires reaping its sentinel fd.
+                _deregister_sentinel(selector, key.fileobj, None)
+            else:
+                # Garbage-collected Future requires reaping its connection.
+                assert isinstance(key.fileobj, Connection), type(key.fileobj)
+                _deregister_connection(selector, key.fileobj)
+
+        # Must be fully materialized before any done() mutates the selector.
+        for target in targets:
+            target.done()
 
     def submit(
         self,
@@ -996,8 +1027,16 @@ class Jobserver:
             # Register both the connection and the sentinel for O(k) polling.
             # Observing the connection reclaims a Future whose result is ready
             # while its child stays blocked mid-send() and thus unexited.
-            selector.register(recv, EVENT_READ, data=future)
-            selector.register(process.sentinel, EVENT_READ, data=future)
+            #
+            # Reference the Future weakly so dropping it before completion
+            # lets it finalize and emit Future.__del__'s ResourceWarning
+            # instead of being pinned alive until the Jobserver closes;
+            # reclaim_resources() reaps the abandoned registration on its
+            # next poll.  One shared weakref keeps the two fds collapsing
+            # to a single reclaim.
+            ref = weakref.ref(future)
+            selector.register(recv, EVENT_READ, data=ref)
+            selector.register(process.sentinel, EVENT_READ, data=ref)
         except Exception:
             # Undo any registration that succeeded before the failure.
             # The connection registers first, so cleanup it first too.
@@ -1022,7 +1061,7 @@ class Jobserver:
         # so a raising user callback cannot leak the connection fd.
         # Holding recv keeps its fd open until unregister.
         future._when_done(
-            fn=_unregister_connection,
+            fn=_deregister_connection,
             args=(selector, recv),
             priority=_PRIORITY_BEFORE,
         )
@@ -1042,7 +1081,7 @@ class Jobserver:
         # sentinel additionally happens implicitly in __exit__ and
         # __del__ when the selector is closed.
         future._when_done(
-            fn=_unregister_sentinel,
+            fn=_deregister_sentinel,
             args=(selector, process.sentinel, process),
             priority=_PRIORITY_AFTER,
         )

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -535,5 +535,5 @@ class TestJobserverBasic(unittest.TestCase):
         with Jobserver(slots=2) as js:
             f = js.submit(fn=time.sleep, args=(0.5,), timeout=5)
         # __exit__ closed the selector; result() fires all callbacks
-        # including the _unregister_sentinel cleanup callback
+        # including the _deregister_sentinel cleanup callback
         self.assertIsNone(f.result(timeout=5))

--- a/test/test_resource_warning.py
+++ b/test/test_resource_warning.py
@@ -55,6 +55,29 @@ class TestResourceWarning(unittest.TestCase):
         self.assertRegex(str(rw[0].message), r"Finalizing .* running Future")
         self.assertIsNotNone(rw[0].source)
 
+    def test_future_warning_when_dropped_before_completion(self) -> None:
+        """A running Future dropped while its Jobserver is alive warns.
+
+        The selector references the Future weakly (see issue #338), so
+        releasing the last reference finalizes it and Future.__del__
+        fires its per-Future "open connection" ResourceWarning rather
+        than the Future being pinned until the Jobserver is closed.  No
+        reclaim runs between submit and del, so the connection stays open
+        and a worker finishing first does not create a race.
+        """
+        with Jobserver(context=FAST, slots=1) as js:
+            f = js.submit(fn=helper_return, args=(42,))
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                del f
+                gc.collect()
+            rw = [w for w in caught if issubclass(w.category, ResourceWarning)]
+            self.assertEqual(len(rw), 1)
+            self.assertRegex(
+                str(rw[0].message),
+                r"Finalizing Future.* with open connection",
+            )
+
     def test_no_warning_when_properly_closed(self) -> None:
         """__del__ is silent after the context manager cleans up."""
         with Jobserver(context=FAST, slots=1) as js:


### PR DESCRIPTION
**Work in progress — recorded for reference, not intended to merge as-is.**

Addresses #338: the per-Future `ResourceWarning` was unreachable in the common case because the selector pinned each running Future (`data=future`), so dropping a Future while its Jobserver stayed alive never finalized it.

## Change

- Register each Future in the selector **weakly** (one shared `weakref.ref` for its two fds) instead of `data=future`.
- `Future.__del__` then fires when the caller releases its last reference; `reclaim_resources()` reaps the abandoned sentinel/connection on its next poll via the existing `_deregister_*` helpers.
- `SlotsSentinel.__call__` returns `self` so selector data resolves uniformly (a live Future via its weakref, the slots entry via itself).
- `_tracked()` counts distinct live weakref targets.
- `Future.__del__` itself is unchanged — still the sole warning path.
- Regression test: `test_future_warning_when_dropped_before_completion`.

CI is green (263 tests, ruff/mypy/black clean, sdist builds).

## Why this is WIP — the tradeoff

Making the warning reachable and preserving the old ownership invariant are in **genuine opposition**: the only way to warn early is to let the Future die early, and the only way to let it die early is to stop pinning it. There is no version that keeps both.

**The invariant that was lost.** Before, the `data=future` strong reference made the selector a co-owner of every outstanding Future, giving the Jobserver an unconditional capability: for any work it had started, it could drive that work to `done()` — restoring the token, running completion callbacks, closing fds. Ownership story: *the server owns in-flight work and can always finish what it started.*

After, that capability narrows from *any* outstanding Future to *only those the user still references*. Drop the handle, let GC run, and the weakref resolves to `None`; the Jobserver can never call `done()` on it again — and `done()` is the only path that restores the token and runs user callbacks. Reaping is not completion; it is a lossy salvage of two fds. So this manufactures a state the old design made impossible: **work still in-flight, still holding its slot, that no entity in the system can complete — only abandon.** The slot leaks until teardown.

Two things worth naming:

1. **Handle vs. work.** Is a Future a user-owned handle that merely lends observability, or a server-owned unit of work? The old code answered "server-owned" (via the pin); this quietly relitigates it to "user-owned," changing who is responsible for completion. Note `concurrent.futures` answers "server-owned" — you cannot drop a running future and have the executor forget it.
2. **Couples resource semantics to GC.** Whether a slot can be cleanly reclaimed now depends on *when* the collector runs and whether a reference lingers — deterministic-ish under CPython refcounting, not under PyPy or with a reference cycle. The old behavior was independent of GC timing.

The issue's own primary recommendation is to treat this as a **documentation fix** and keep the pin, precisely because a guaranteed-completion invariant may be worth more than a reachable diagnostic. This branch is the clean implementation of the alternative, kept as a record of what that costs.

https://claude.ai/code/session_01RySsSypUHUcsUsgaZPH5ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01RySsSypUHUcsUsgaZPH5ry)_