### PR TITLE
Rename unregister functions to deregister for clarity

### DIFF
--- a/draft/JSLOCK.md
+++ b/draft/JSLOCK.md
@@ -40,7 +40,7 @@ that this plan exists to close.
 The shared resource is the `DefaultSelector` and its unsynchronized
 `_fd_to_key` dict.  `submit()` mutates it via `selector.register()`
 (`_jobserver.py:975-976`).  But it is **also** mutated by the Future
-completion callbacks `_unregister_sentinel` / `_unregister_connection`
+completion callbacks `_deregister_sentinel` / `_deregister_connection`
 (`_jobserver.py:542-572`), which call `selector.unregister()`.  Those
 callbacks fire from `Future._issue_callbacks()`, reached by **any** call to
 `Future.wait()` / `done()` / `result()` — including a user calling
@@ -368,10 +368,10 @@ def submit(self, fn, *, ..., timeout=None) -> Future[T]:
     # --- callback wiring: outside spawn lock (Future is self-synchronizing) ---
     future._when_done(fn=_restore_token, args=(self._slots, token),
                       priority=_PRIORITY_TOKEN)
-    future._when_done(fn=_unregister_sentinel,
+    future._when_done(fn=_deregister_sentinel,
                       args=(selector, process.sentinel, process),
                       priority=_PRIORITY_CLEANUP)
-    future._when_done(fn=_unregister_connection, args=(selector, recv),
+    future._when_done(fn=_deregister_connection, args=(selector, recv),
                       priority=_PRIORITY_CLEANUP)
     return future
 ```

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -339,7 +339,15 @@ class Future(Generic[T]):
         raise TypeError("Futures cannot be pickled.")
 
     def __del__(self) -> None:
-        """Emit ResourceWarning if this Future still holds OS resources."""
+        """Emit ResourceWarning if this Future still holds OS resources.
+
+        An in-flight Future is pinned alive by its Jobserver: the selector
+        registers it as the data for both of its fds, so it is not finalized
+        while that Jobserver remains open.  This warning therefore primarily
+        covers Futures that outlive a closed Jobserver.  A Future dropped
+        while its Jobserver is still open keeps its worker running and is
+        surfaced instead by Jobserver.__del__'s "running Futures" warning.
+        """
         if getattr(self, "_connection", None) is not None:
             warnings.warn(
                 f"Finalizing {self!r} with open connection",
@@ -496,7 +504,7 @@ class Future(Generic[T]):
 
             # Drop our reference so _issue_callbacks's invariant holds
             # and __del__ will not warn.  The actual close() is deferred
-            # to a _PRIORITY_BEFORE callback (see _unregister_connection)
+            # to a _PRIORITY_BEFORE callback (see _deregister_connection)
             # so the fd is unregistered from the selector before reuse.
             self._connection = None
             self._issue_callbacks()
@@ -563,7 +571,7 @@ def _restore_token(slots: FixedBytesQueue, token: Optional[bytes]) -> None:
             pass  # Queue closed; Jobserver is shutting down
 
 
-def _unregister_sentinel(
+def _deregister_sentinel(
     selector: DefaultSelector,
     sentinel: int,
     _process: BaseProcess,
@@ -577,7 +585,7 @@ def _unregister_sentinel(
         pass  # Already unregistered or selector closed
 
 
-def _unregister_connection(
+def _deregister_connection(
     selector: DefaultSelector,
     connection: Connection,
 ) -> None:
@@ -1022,7 +1030,7 @@ class Jobserver:
         # so a raising user callback cannot leak the connection fd.
         # Holding recv keeps its fd open until unregister.
         future._when_done(
-            fn=_unregister_connection,
+            fn=_deregister_connection,
             args=(selector, recv),
             priority=_PRIORITY_BEFORE,
         )
@@ -1042,7 +1050,7 @@ class Jobserver:
         # sentinel additionally happens implicitly in __exit__ and
         # __del__ when the selector is closed.
         future._when_done(
-            fn=_unregister_sentinel,
+            fn=_deregister_sentinel,
             args=(selector, process.sentinel, process),
             priority=_PRIORITY_AFTER,
         )

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -341,12 +341,10 @@ class Future(Generic[T]):
     def __del__(self) -> None:
         """Emit ResourceWarning if this Future still holds OS resources.
 
-        An in-flight Future is pinned alive by its Jobserver: the selector
-        registers it as the data for both of its fds, so it is not finalized
-        while that Jobserver remains open.  This warning therefore primarily
-        covers Futures that outlive a closed Jobserver.  A Future dropped
-        while its Jobserver is still open keeps its worker running and is
-        surfaced instead by Jobserver.__del__'s "running Futures" warning.
+        The Jobserver keeps an in-flight Future alive while it remains open,
+        so this warning mostly covers a Future that outlives a closed
+        Jobserver.  A Future dropped while the Jobserver is open keeps the
+        worker running and the Jobserver reports it on finalization instead.
         """
         if getattr(self, "_connection", None) is not None:
             warnings.warn(

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -535,5 +535,5 @@ class TestJobserverBasic(unittest.TestCase):
         with Jobserver(slots=2) as js:
             f = js.submit(fn=time.sleep, args=(0.5,), timeout=5)
         # __exit__ closed the selector; result() fires all callbacks
-        # including the _unregister_sentinel cleanup callback
+        # including the _deregister_sentinel cleanup callback
         self.assertIsNone(f.result(timeout=5))


### PR DESCRIPTION
## Summary
This PR renames internal functions and updates documentation to use more accurate terminology. The functions `_unregister_sentinel` and `_unregister_connection` are renamed to `_deregister_sentinel` and `_deregister_connection` respectively, along with related documentation updates.

## Key Changes
- Renamed `_unregister_sentinel()` to `_deregister_sentinel()` to better reflect its purpose of deregistering resources from the selector
- Renamed `_unregister_connection()` to `_deregister_connection()` for consistency
- Updated all call sites in `submit()` method to use the new function names
- Enhanced the `Future.__del__()` docstring to clarify when ResourceWarnings are emitted and the relationship between Futures and Jobserver lifecycle
- Updated documentation in `draft/JSLOCK.md` to reference the renamed functions
- Updated test comments to reference the renamed functions

## Notable Details
The terminology change from "unregister" to "deregister" is more semantically accurate since these callbacks remove resources from the selector during cleanup, which is a deregistration operation. This improves code clarity without changing any functional behavior.

https://claude.ai/code/session_01RySsSypUHUcsUsgaZPH5ry