### PR TITLE
docs(map): note individual args/kwargs are collected eagerly

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -1075,9 +1075,10 @@ class Jobserver:
         element of kwargses provides keyword arguments for one call
         to fn.  Non-None argses and kwargses must have equal length.
 
-        Inputs are collected immediately unless buffersize limits
-        the number of outstanding submissions, in which case inputs
-        are consumed lazily as results are yielded.
+        Input argses and kwargses are collected immediately unless
+        buffersize limits the number of outstanding submissions, in
+        which case they are consumed lazily as results are yielded.
+        Individual args and kwargs are always collected eagerly.
 
         Timeout is given in seconds from this call; if a result is
         not available by the deadline, the iterator raises


### PR DESCRIPTION
The `map()` docstring described laziness only at the outer level (`argses`/`kwargses`, which stream when `buffersize` is set). But each per-call `args`/`kwargs` is always materialized in `submit()` via `tuple(args)`/`dict(kwargs)`, so an infinite *inner* iterable hangs even in streaming mode. This clarifies the two levels.

Matches the analysis in #347: the stdlib executors are eager in the same way (`Executor.map` and `ProcessPoolExecutor.map` both drain inputs up front; laziness only arrived with Python 3.14's `buffersize`), so this is a docs-only fix with no behavior change.

Closes #347

https://claude.ai/code/session_01KLpyETrGGG3yc8hhDh7snw

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLpyETrGGG3yc8hhDh7snw)_