### PR TITLE
Move Blocked→TimeoutError translation to Executor.map()

### DIFF
--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -210,13 +210,27 @@ class JobserverExecutor(concurrent.futures.Executor):
         buffersize: Optional[int] = None,
     ) -> Iterator[T]:
         """Return an iterator of fn applied to each iterables entry."""
-        return self._jobserver.map(
+        # Jobserver.map() validates its arguments eagerly and returns a
+        # generator that raises Blocked on deadline overrun.  The stdlib
+        # Executor.map() contract requires concurrent.futures.TimeoutError.
+        inner = self._jobserver.map(
             fn=fn,
             argses=zip(*iterables),
             timeout=timeout,
             chunksize=chunksize,
             buffersize=buffersize,
         )
+        return self._translate_blocked(inner)
+
+    @staticmethod
+    def _translate_blocked(inner: Iterator[T]) -> Iterator[T]:
+        """Yield from inner, re-raising the first Blocked as TimeoutError."""
+        try:
+            yield from inner
+        except Blocked:
+            # concurrent.futures.TimeoutError (not builtin TimeoutError) so
+            # that callers catching either type see it on Python < 3.11.
+            raise concurrent.futures.TimeoutError() from None
 
     def shutdown(
         self, wait: bool = True, *, cancel_futures: bool = False

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -6,7 +6,6 @@
 """Implementation of the Jobserver and related classes."""
 
 import abc
-import concurrent.futures
 import functools
 import heapq
 import os
@@ -1082,11 +1081,10 @@ class Jobserver:
         Individual args and kwargs are always collected eagerly.
 
         Timeout is given in seconds from this call; if a result is
-        not available by the deadline, the iterator raises
-        concurrent.futures.TimeoutError.  Function calls are sent to
-        workers in groups of chunksize.  Consistent with
-        concurrent.futures, all chunksize results are materialized
-        in memory at once.
+        not available by the deadline, the iterator raises Blocked.
+        Function calls are sent to workers in groups of chunksize.
+        Consistent with concurrent.futures, all chunksize results are
+        materialized in memory at once.
 
         Stopping iteration early neither cancels nor waits for running work.
         Slots are retained until next reclaim_resources() or __exit__.
@@ -1428,10 +1426,6 @@ def _map_generate(
             yield from futures.popleft().result(
                 timeout=deadline_to_timeout(deadline)
             )
-    except Blocked:
-        # concurrent.futures.TimeoutError (not builtin TimeoutError) so that
-        # callers catching either type see it on Python < 3.11.
-        raise concurrent.futures.TimeoutError() from None
     finally:
         # On teardown explicitly clear still-held Futures, then reclaim
         # finished workers' slots.  Loop since reclaim aborts on the first

--- a/test/test_jobserver_map.py
+++ b/test/test_jobserver_map.py
@@ -9,14 +9,13 @@ Exercises the map API covering argument handling, chunking, buffering,
 timeout semantics, and error propagation.
 """
 
-import concurrent.futures
 import gc
 import os
 import tempfile
 import time
 import unittest
 
-from jobserver import Jobserver
+from jobserver import Blocked, Jobserver
 
 from .helpers import (
     FAST,
@@ -264,10 +263,8 @@ class TestJobserverMap(unittest.TestCase):
                     )
                     self.assertEqual(results, list(range(4)))
 
-    # concurrent.futures.TimeoutError differs from builtin TimeoutError
-    # before Python 3.11.
     def test_timeout_expired_raises(self) -> None:
-        """Expired deadline raises TimeoutError."""
+        """Expired deadline raises Blocked."""
         with Jobserver(context=FAST, slots=1) as js:
             for timeout in [0, 0.2]:
                 with self.subTest(timeout=timeout):
@@ -275,17 +272,15 @@ class TestJobserverMap(unittest.TestCase):
                     it = js.map(
                         fn=_slow_identity, argses=argses, timeout=timeout
                     )
-                    with self.assertRaises(concurrent.futures.TimeoutError):
+                    with self.assertRaises(Blocked):
                         list(it)
 
-    # concurrent.futures.TimeoutError differs from builtin TimeoutError
-    # before Python 3.11.
     def test_timeout_is_from_map_call(self) -> None:
         """Timeout counts from the map() call, not from __next__."""
         with Jobserver(context=FAST, slots=2) as js:
             argses = [(i, 0.3) for i in range(5)]
             it = js.map(fn=_slow_identity, argses=argses, timeout=0.5)
-            with self.assertRaises(concurrent.futures.TimeoutError):
+            with self.assertRaises(Blocked):
                 list(it)
 
     def test_exception_propagates(self) -> None:


### PR DESCRIPTION
## Summary
This change moves the responsibility for translating `Blocked` exceptions to `concurrent.futures.TimeoutError` from the `Jobserver.map()` method to the `Executor.map()` wrapper method. This better separates concerns by keeping the low-level jobserver API focused on its own exception types, while the executor wrapper handles the translation needed to comply with the `concurrent.futures.Executor` contract.

## Key Changes
- **Executor.map()**: Added `_translate_blocked()` helper method that wraps the inner jobserver iterator and catches `Blocked` exceptions, re-raising them as `concurrent.futures.TimeoutError`
- **Jobserver.map()**: Removed the `Blocked` → `TimeoutError` exception translation logic and updated docstring to reflect that it raises `Blocked` instead
- **Tests**: Updated `test_jobserver_map.py` to expect `Blocked` exceptions when calling `Jobserver.map()` directly, and removed comments about Python 3.11 differences (now only relevant at the Executor level)
- **Imports**: Removed unused `concurrent.futures` import from `_jobserver.py`

## Implementation Details
The `_translate_blocked()` method is a static helper that uses a try/except block around `yield from` to catch `Blocked` exceptions from the inner iterator. This approach ensures the translation happens transparently to callers of `Executor.map()` while keeping the jobserver implementation cleaner and more focused on its core responsibility.

https://claude.ai/code/session_01AwdeSp4ntM6vqEMwXstx5C