### PR TITLE
WIP: prototype pre-pickled worker payload for inbound reconstruction errors (#351)

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -988,14 +988,9 @@ class Jobserver:
             # Grab resources for processing the submitted work
             # Why use a Pipe instead of a Queue?  Pipes can detect EOFError!
             recv, send = self._context.Pipe(duplex=False)
-            # Deliver the reconstruction-prone payload so that the worker,
-            # not multiprocessing's bootstrap, performs any failure-prone
-            # unpickling.  Under fork the child inherits memory and nothing
-            # is unpickled inbound, so the live objects ride along (keeping
-            # fork-only lambda/closure support).  Under spawn/forkserver the
-            # bootstrap would otherwise unpickle fn/args/kwargs/preexec_fn
-            # before _worker_entrypoint runs, so pre-pickle them to an opaque
-            # blob the worker unpickles itself inside its try/except (#351).
+            # Pre-pickle under spawn/forkserver so the worker, not the
+            # bootstrap, unpickles fn/args inside its try/except (#351).
+            # Fork inherits memory, so pass live objects (keeps lambdas).
             if self._context.get_start_method() == "fork":
                 payload = _Payload.from_live(preexec_fn, fn, args, kwargs)
             else:
@@ -1168,25 +1163,7 @@ class Jobserver:
 
 
 class _Payload:
-    """Carries (preexec_fn, fn, args, kwargs) from submit() to a worker.
-
-    The reconstruction-prone payload is delivered one of two ways:
-
-      * Under fork the child inherits parent memory, so nothing is pickled
-        on the way in; the live tuple is held directly and resolve() returns
-        it.  This preserves fork-only support for lambdas and local closures,
-        which cannot survive pickling.
-
-      * Under spawn/forkserver multiprocessing pickles the Process target's
-        args in the parent and unpickles them in the child *before*
-        _worker_entrypoint runs -- outside any try/except jobserver controls.
-        An argument whose __setstate__ raises would therefore crash the
-        bootstrap and degrade to a bare LostResult (#351).  To avoid that,
-        submit() pre-pickles the payload to an opaque bytes blob here; the
-        blob reconstitutes trivially in the bootstrap and resolve() performs
-        the real, failure-prone unpickling inside the worker's try/except so
-        an inbound reconstruction failure is reported like an outbound one.
-    """
+    """Carries (preexec_fn, fn, args, kwargs) to a worker, live or pickled."""
 
     __slots__ = ("_live", "_blob")
 
@@ -1199,29 +1176,16 @@ class _Payload:
 
     @classmethod
     def from_live(cls, preexec_fn, fn, args, kwargs) -> "_Payload":
-        """Hold the live objects; used under fork (no inbound pickling)."""
         return cls(live=(preexec_fn, fn, args, kwargs), blob=None)
 
     @classmethod
     def from_blob(cls, preexec_fn, fn, args, kwargs) -> "_Payload":
-        """Pre-pickle the payload; used under spawn/forkserver.
-
-        ForkingPickler (not plain pickle) so the same reductions
-        multiprocessing would apply to the Process args -- e.g. for a
-        nested Jobserver's queue -- still hold.  bytes() copies the buffer
-        view out so the blob itself pickles trivially when the bootstrap
-        re-pickles the Process args.  Any outbound pickling failure raises
-        here, inside submit()'s try, exactly as process.start() raised before.
-        """
+        # ForkingPickler so multiprocessing's reductions apply; bytes() so
+        # the blob re-pickles trivially in the bootstrap.
         blob = bytes(ForkingPickler.dumps((preexec_fn, fn, args, kwargs)))
         return cls(live=None, blob=blob)
 
     def resolve(self) -> tuple:
-        """Return (preexec_fn, fn, args, kwargs), unpickling if blob-backed.
-
-        Called inside _worker_entrypoint's try/except so a blob that fails
-        to reconstruct surfaces as an ExceptionWrapper, not a dead worker.
-        """
         if self._blob is not None:
             return ForkingPickler.loads(self._blob)
         assert self._live is not None
@@ -1239,10 +1203,8 @@ def _worker_entrypoint(send, env, inbound: _Payload) -> None:
     # in degenerate case where client code returns an Exception
     result: Optional[Wrapper[Any]] = None
     try:
-        # Reconstruct the inbound payload here, inside the try, so an argument
-        # that pickles in the parent but fails to unpickle in the worker (e.g.
-        # a __setstate__ that raises) is reported as an ExceptionWrapper rather
-        # than crashing the bootstrap into a bare LostResult (#351).
+        # Unpickle inside the try so an inbound reconstruction failure is
+        # reported, not crashed into a bare LostResult (#351).
         preexec_fn, fn, args, kwargs = inbound.resolve()
         # None invalid in os.environ so interpret as sentinel for popping
         for key, value in env.items():

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -991,10 +991,9 @@ class Jobserver:
             # Pre-pickle under spawn/forkserver so the worker, not the
             # bootstrap, unpickles fn/args inside its try/except (#351).
             # Fork inherits memory, so pass live objects (keeps lambdas).
-            if self._context.get_start_method() == "fork":
-                payload = _Payload.from_live(preexec_fn, fn, args, kwargs)
-            else:
-                payload = _Payload.from_blob(preexec_fn, fn, args, kwargs)
+            payload: Union[tuple, bytes] = (preexec_fn, fn, args, kwargs)
+            if self._context.get_start_method() != "fork":
+                payload = bytes(ForkingPickler.dumps(payload))
             process = self._context.Process(  # type: ignore
                 target=_worker_entrypoint,
                 args=(send, env, payload),
@@ -1162,37 +1161,7 @@ class Jobserver:
         )
 
 
-class _Payload:
-    """Carries (preexec_fn, fn, args, kwargs) to a worker, live or pickled."""
-
-    __slots__ = ("_live", "_blob")
-
-    _live: Optional[tuple]
-    _blob: Optional[bytes]
-
-    def __init__(self, live: Optional[tuple], blob: Optional[bytes]) -> None:
-        self._live = live
-        self._blob = blob
-
-    @classmethod
-    def from_live(cls, preexec_fn, fn, args, kwargs) -> "_Payload":
-        return cls(live=(preexec_fn, fn, args, kwargs), blob=None)
-
-    @classmethod
-    def from_blob(cls, preexec_fn, fn, args, kwargs) -> "_Payload":
-        # ForkingPickler so multiprocessing's reductions apply; bytes() so
-        # the blob re-pickles trivially in the bootstrap.
-        blob = bytes(ForkingPickler.dumps((preexec_fn, fn, args, kwargs)))
-        return cls(live=None, blob=blob)
-
-    def resolve(self) -> tuple:
-        if self._blob is not None:
-            return ForkingPickler.loads(self._blob)
-        assert self._live is not None
-        return self._live
-
-
-def _worker_entrypoint(send, env, inbound: _Payload) -> None:
+def _worker_entrypoint(send, env, payload) -> None:
     """Entry point for workers to run fn(...) due to some submit(...)."""
     ignore_sigpipe()
 
@@ -1203,9 +1172,11 @@ def _worker_entrypoint(send, env, inbound: _Payload) -> None:
     # in degenerate case where client code returns an Exception
     result: Optional[Wrapper[Any]] = None
     try:
-        # Unpickle inside the try so an inbound reconstruction failure is
-        # reported, not crashed into a bare LostResult (#351).
-        preexec_fn, fn, args, kwargs = inbound.resolve()
+        # Unpickle a blob inside the try so an inbound reconstruction failure
+        # is reported, not crashed into a bare LostResult (#351).
+        if isinstance(payload, bytes):
+            payload = ForkingPickler.loads(payload)
+        preexec_fn, fn, args, kwargs = payload
         # None invalid in os.environ so interpret as sentinel for popping
         for key, value in env.items():
             if value is None:

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -76,6 +76,13 @@ EnvItems = Union[
     Mapping[str, Optional[str]],
     Iterable[tuple[str, Optional[str]]],
 ]
+# Worker payload: (preexec_fn, fn, args, kwargs) delivered to a worker.
+Payload = tuple[
+    PreexecFn,
+    Callable[..., Any],
+    tuple[Any, ...],
+    dict[str, Any],
+]
 
 
 @final
@@ -989,9 +996,9 @@ class Jobserver:
             # Why use a Pipe instead of a Queue?  Pipes can detect EOFError!
             recv, send = self._context.Pipe(duplex=False)
             # Pre-pickle under spawn/forkserver so the worker, not the
-            # bootstrap, unpickles fn/args inside its try/except (#351).
+            # bootstrap, unpickles fn/args inside its try/except.
             # Fork inherits memory, so pass live objects (keeps lambdas).
-            payload: Union[tuple, bytes] = (preexec_fn, fn, args, kwargs)
+            payload: Union[Payload, bytes] = (preexec_fn, fn, args, kwargs)
             if self._context.get_start_method() != "fork":
                 payload = bytes(ForkingPickler.dumps(payload))
             process = self._context.Process(  # type: ignore
@@ -1161,7 +1168,7 @@ class Jobserver:
         )
 
 
-def _worker_entrypoint(send, env, payload) -> None:
+def _worker_entrypoint(send, env, payload: Union[Payload, bytes]) -> None:
     """Entry point for workers to run fn(...) due to some submit(...)."""
     ignore_sigpipe()
 
@@ -1172,11 +1179,14 @@ def _worker_entrypoint(send, env, payload) -> None:
     # in degenerate case where client code returns an Exception
     result: Optional[Wrapper[Any]] = None
     try:
-        # Unpickle a blob inside the try so an inbound reconstruction failure
-        # is reported, not crashed into a bare LostResult (#351).
-        if isinstance(payload, bytes):
-            payload = ForkingPickler.loads(payload)
-        preexec_fn, fn, args, kwargs = payload
+        # Unpickle a blob inside the try so unpickling errors do not crash
+        # the worker but are reported like any other failure.
+        resolved: Payload = (
+            ForkingPickler.loads(payload)
+            if isinstance(payload, bytes)
+            else payload
+        )
+        preexec_fn, fn, args, kwargs = resolved
         # None invalid in os.environ so interpret as sentinel for popping
         for key, value in env.items():
             if value is None:

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -988,9 +988,21 @@ class Jobserver:
             # Grab resources for processing the submitted work
             # Why use a Pipe instead of a Queue?  Pipes can detect EOFError!
             recv, send = self._context.Pipe(duplex=False)
+            # Deliver the reconstruction-prone payload so that the worker,
+            # not multiprocessing's bootstrap, performs any failure-prone
+            # unpickling.  Under fork the child inherits memory and nothing
+            # is unpickled inbound, so the live objects ride along (keeping
+            # fork-only lambda/closure support).  Under spawn/forkserver the
+            # bootstrap would otherwise unpickle fn/args/kwargs/preexec_fn
+            # before _worker_entrypoint runs, so pre-pickle them to an opaque
+            # blob the worker unpickles itself inside its try/except (#351).
+            if self._context.get_start_method() == "fork":
+                payload = _Payload.from_live(preexec_fn, fn, args, kwargs)
+            else:
+                payload = _Payload.from_blob(preexec_fn, fn, args, kwargs)
             process = self._context.Process(  # type: ignore
                 target=_worker_entrypoint,
-                args=(send, env, preexec_fn, fn, args, kwargs),
+                args=(send, env, payload),
                 daemon=False,
                 name="Jobserver-worker",
             )
@@ -1155,7 +1167,68 @@ class Jobserver:
         )
 
 
-def _worker_entrypoint(send, env, preexec_fn, fn, args, kwargs) -> None:
+class _Payload:
+    """Carries (preexec_fn, fn, args, kwargs) from submit() to a worker.
+
+    The reconstruction-prone payload is delivered one of two ways:
+
+      * Under fork the child inherits parent memory, so nothing is pickled
+        on the way in; the live tuple is held directly and resolve() returns
+        it.  This preserves fork-only support for lambdas and local closures,
+        which cannot survive pickling.
+
+      * Under spawn/forkserver multiprocessing pickles the Process target's
+        args in the parent and unpickles them in the child *before*
+        _worker_entrypoint runs -- outside any try/except jobserver controls.
+        An argument whose __setstate__ raises would therefore crash the
+        bootstrap and degrade to a bare LostResult (#351).  To avoid that,
+        submit() pre-pickles the payload to an opaque bytes blob here; the
+        blob reconstitutes trivially in the bootstrap and resolve() performs
+        the real, failure-prone unpickling inside the worker's try/except so
+        an inbound reconstruction failure is reported like an outbound one.
+    """
+
+    __slots__ = ("_live", "_blob")
+
+    _live: Optional[tuple]
+    _blob: Optional[bytes]
+
+    def __init__(self, live: Optional[tuple], blob: Optional[bytes]) -> None:
+        self._live = live
+        self._blob = blob
+
+    @classmethod
+    def from_live(cls, preexec_fn, fn, args, kwargs) -> "_Payload":
+        """Hold the live objects; used under fork (no inbound pickling)."""
+        return cls(live=(preexec_fn, fn, args, kwargs), blob=None)
+
+    @classmethod
+    def from_blob(cls, preexec_fn, fn, args, kwargs) -> "_Payload":
+        """Pre-pickle the payload; used under spawn/forkserver.
+
+        ForkingPickler (not plain pickle) so the same reductions
+        multiprocessing would apply to the Process args -- e.g. for a
+        nested Jobserver's queue -- still hold.  bytes() copies the buffer
+        view out so the blob itself pickles trivially when the bootstrap
+        re-pickles the Process args.  Any outbound pickling failure raises
+        here, inside submit()'s try, exactly as process.start() raised before.
+        """
+        blob = bytes(ForkingPickler.dumps((preexec_fn, fn, args, kwargs)))
+        return cls(live=None, blob=blob)
+
+    def resolve(self) -> tuple:
+        """Return (preexec_fn, fn, args, kwargs), unpickling if blob-backed.
+
+        Called inside _worker_entrypoint's try/except so a blob that fails
+        to reconstruct surfaces as an ExceptionWrapper, not a dead worker.
+        """
+        if self._blob is not None:
+            return ForkingPickler.loads(self._blob)
+        assert self._live is not None
+        return self._live
+
+
+def _worker_entrypoint(send, env, inbound: _Payload) -> None:
     """Entry point for workers to run fn(...) due to some submit(...)."""
     ignore_sigpipe()
 
@@ -1166,6 +1239,11 @@ def _worker_entrypoint(send, env, preexec_fn, fn, args, kwargs) -> None:
     # in degenerate case where client code returns an Exception
     result: Optional[Wrapper[Any]] = None
     try:
+        # Reconstruct the inbound payload here, inside the try, so an argument
+        # that pickles in the parent but fails to unpickle in the worker (e.g.
+        # a __setstate__ that raises) is reported as an ExceptionWrapper rather
+        # than crashing the bootstrap into a bare LostResult (#351).
+        preexec_fn, fn, args, kwargs = inbound.resolve()
         # None invalid in os.environ so interpret as sentinel for popping
         for key, value in env.items():
             if value is None:

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -857,12 +857,7 @@ class TestResultNotReconstructable(unittest.TestCase):
 
 
 class _BadSetState:
-    """Pickles in the parent but raises while unpickling in a worker.
-
-    __getstate__ succeeds so the object serializes cleanly in submit(),
-    but __setstate__ raises so reconstruction fails in the child -- the
-    inbound counterpart to a result that fails to rebuild in the parent.
-    """
+    """Pickles in the parent but raises while unpickling in a worker."""
 
     def __getstate__(self) -> dict:
         return {"ok": True}
@@ -872,27 +867,18 @@ class _BadSetState:
 
 
 class TestArgumentNotReconstructable(unittest.TestCase):
-    """An argument that pickles in the parent but whose reconstruction
-    raises in the worker is reported, not degraded to LostResult (#351).
-
-    Under spawn/forkserver the payload is delivered pre-pickled so the
-    worker unpickles it inside its try/except; the __setstate__ failure is
-    caught and wrapped like any exception fn itself would raise.  This is
-    the inbound counterpart to TestResultNotReconstructable (#303)."""
+    """An argument whose reconstruction raises in the worker is reported,
+    not degraded to LostResult (#351); inbound counterpart to #303."""
 
     def test_setstate_failure_is_reported_not_lost(self) -> None:
         for method in start_methods():
-            # Fork inherits parent memory: nothing is unpickled inbound, so
-            # the failure mode this guards against cannot occur there.
             if method == "fork":
-                continue
+                continue  # fork unpickles nothing inbound
             with self.subTest(method=method):
                 with Jobserver(context=method, slots=1) as js:
                     future = js.submit(
                         fn=id, args=(_BadSetState(),), timeout=5
                     )
-                    # The original exception surfaces (not a bare LostResult),
-                    # carrying the child's traceback via RemoteTraceback.
                     with self.assertRaises(RuntimeError) as ctx:
                         future.result(timeout=5)
                 self.assertIn("blows up in the child", str(ctx.exception))

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -31,7 +31,6 @@ from jobserver import (
 from jobserver._jobserver import (
     ExceptionWrapper,
     ResultWrapper,
-    _Payload,
     _worker_entrypoint,
 )
 from jobserver._queue import SPSCQueue
@@ -726,7 +725,7 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
             _worker_entrypoint(
                 send,
                 {},
-                _Payload.from_live(lambda: None, len, ((1, 2, 3),), {}),
+                (lambda: None, len, ((1, 2, 3),), {}),
             )
         self.assertIs(boom, ctx.exception)
         # No "not picklable" rewrap was sent in place of the real error.
@@ -735,9 +734,7 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
     def test_picklable_result_sent_unchanged(self) -> None:
         """A picklable result rides the happy path to a single send."""
         send = _RecordingSend()
-        _worker_entrypoint(
-            send, {}, _Payload.from_live(lambda: None, len, ((1, 2, 3),), {})
-        )
+        _worker_entrypoint(send, {}, (lambda: None, len, ((1, 2, 3),), {}))
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
         self.assertIsInstance(wrapper, ResultWrapper)
@@ -750,7 +747,7 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         _worker_entrypoint(
             send,
             {},
-            _Payload.from_live(lambda: None, _make_unpicklable_result, (), {}),
+            (lambda: None, _make_unpicklable_result, (), {}),
         )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
@@ -768,7 +765,7 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         _worker_entrypoint(
             send,
             {},
-            _Payload.from_live(lambda: None, _make_deep_result, (), {}),
+            (lambda: None, _make_deep_result, (), {}),
         )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
@@ -790,18 +787,14 @@ class TestWorkerEntrypointSendBytesErrors(unittest.TestCase):
         LostResult, but without a noisy child traceback."""
         boom = OSError(errno.EBADF, "Bad file descriptor")
         send = _RecordingSend(fail_with=boom)
-        _worker_entrypoint(
-            send, {}, _Payload.from_live(lambda: None, len, ((1, 2, 3),), {})
-        )
+        _worker_entrypoint(send, {}, (lambda: None, len, ((1, 2, 3),), {}))
         self.assertEqual([], send.payloads)
         self.assertTrue(send.closed)
 
     def test_broken_pipe_still_swallowed(self) -> None:
         """The original BrokenPipeError handling is preserved."""
         send = _RecordingSend(fail_with=BrokenPipeError())
-        _worker_entrypoint(
-            send, {}, _Payload.from_live(lambda: None, len, ((1, 2, 3),), {})
-        )
+        _worker_entrypoint(send, {}, (lambda: None, len, ((1, 2, 3),), {}))
         self.assertEqual([], send.payloads)
         self.assertTrue(send.closed)
 

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -31,6 +31,7 @@ from jobserver import (
 from jobserver._jobserver import (
     ExceptionWrapper,
     ResultWrapper,
+    _Payload,
     _worker_entrypoint,
 )
 from jobserver._queue import SPSCQueue
@@ -722,7 +723,11 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         boom = AttributeError("misbehaving connection")
         send = _RecordingSend(fail_with=boom)
         with self.assertRaises(AttributeError) as ctx:
-            _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})
+            _worker_entrypoint(
+                send,
+                {},
+                _Payload.from_live(lambda: None, len, ((1, 2, 3),), {}),
+            )
         self.assertIs(boom, ctx.exception)
         # No "not picklable" rewrap was sent in place of the real error.
         self.assertEqual([], send.payloads)
@@ -730,7 +735,9 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
     def test_picklable_result_sent_unchanged(self) -> None:
         """A picklable result rides the happy path to a single send."""
         send = _RecordingSend()
-        _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})
+        _worker_entrypoint(
+            send, {}, _Payload.from_live(lambda: None, len, ((1, 2, 3),), {})
+        )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
         self.assertIsInstance(wrapper, ResultWrapper)
@@ -741,7 +748,9 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         """A genuinely unpicklable result still degrades to the fallback."""
         send = _RecordingSend()
         _worker_entrypoint(
-            send, {}, lambda: None, _make_unpicklable_result, (), {}
+            send,
+            {},
+            _Payload.from_live(lambda: None, _make_unpicklable_result, (), {}),
         )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
@@ -756,7 +765,11 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         RecursionError that now degrades to the descriptive fallback rather
         than crashing the worker into a misleading LostResult (#343)."""
         send = _RecordingSend()
-        _worker_entrypoint(send, {}, lambda: None, _make_deep_result, (), {})
+        _worker_entrypoint(
+            send,
+            {},
+            _Payload.from_live(lambda: None, _make_deep_result, (), {}),
+        )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
         self.assertIsInstance(wrapper, ExceptionWrapper)
@@ -777,14 +790,18 @@ class TestWorkerEntrypointSendBytesErrors(unittest.TestCase):
         LostResult, but without a noisy child traceback."""
         boom = OSError(errno.EBADF, "Bad file descriptor")
         send = _RecordingSend(fail_with=boom)
-        _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})
+        _worker_entrypoint(
+            send, {}, _Payload.from_live(lambda: None, len, ((1, 2, 3),), {})
+        )
         self.assertEqual([], send.payloads)
         self.assertTrue(send.closed)
 
     def test_broken_pipe_still_swallowed(self) -> None:
         """The original BrokenPipeError handling is preserved."""
         send = _RecordingSend(fail_with=BrokenPipeError())
-        _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})
+        _worker_entrypoint(
+            send, {}, _Payload.from_live(lambda: None, len, ((1, 2, 3),), {})
+        )
         self.assertEqual([], send.payloads)
         self.assertTrue(send.closed)
 
@@ -837,3 +854,47 @@ class TestResultNotReconstructable(unittest.TestCase):
             with self.assertRaises(RuntimeError) as ctx:
                 future.result(timeout=10)
         self.assertIn("not reconstructable", str(ctx.exception))
+
+
+class _BadSetState:
+    """Pickles in the parent but raises while unpickling in a worker.
+
+    __getstate__ succeeds so the object serializes cleanly in submit(),
+    but __setstate__ raises so reconstruction fails in the child -- the
+    inbound counterpart to a result that fails to rebuild in the parent.
+    """
+
+    def __getstate__(self) -> dict:
+        return {"ok": True}
+
+    def __setstate__(self, state: dict) -> None:
+        raise RuntimeError("blows up in the child")
+
+
+class TestArgumentNotReconstructable(unittest.TestCase):
+    """An argument that pickles in the parent but whose reconstruction
+    raises in the worker is reported, not degraded to LostResult (#351).
+
+    Under spawn/forkserver the payload is delivered pre-pickled so the
+    worker unpickles it inside its try/except; the __setstate__ failure is
+    caught and wrapped like any exception fn itself would raise.  This is
+    the inbound counterpart to TestResultNotReconstructable (#303)."""
+
+    def test_setstate_failure_is_reported_not_lost(self) -> None:
+        for method in start_methods():
+            # Fork inherits parent memory: nothing is unpickled inbound, so
+            # the failure mode this guards against cannot occur there.
+            if method == "fork":
+                continue
+            with self.subTest(method=method):
+                with Jobserver(context=method, slots=1) as js:
+                    future = js.submit(
+                        fn=id, args=(_BadSetState(),), timeout=5
+                    )
+                    # The original exception surfaces (not a bare LostResult),
+                    # carrying the child's traceback via RemoteTraceback.
+                    with self.assertRaises(RuntimeError) as ctx:
+                        future.result(timeout=5)
+                self.assertIn("blows up in the child", str(ctx.exception))
+                self.assertNotIsInstance(ctx.exception, LostResult)
+                self.assertIsNotNone(ctx.exception.__cause__)


### PR DESCRIPTION
**Status: WIP prototype, rejected. Preserved for posterity; closing without merge.**

## What this prototypes

The second option from #351: deliver `(preexec_fn, fn, args, kwargs)` to the worker as an already-pickled blob that `_worker_entrypoint` unpickles itself, *inside* its `try/except`, so an inbound reconstruction failure (e.g. an argument whose `__setstate__` raises) is caught and reported like an outbound one instead of crashing multiprocessing's bootstrap and degrading to a bare `LostResult`.

Under fork the live tuple rides along (nothing is unpickled inbound, lambdas/closures still work). Under spawn/forkserver `submit()` pre-pickles with `ForkingPickler` to `bytes`; the worker branches on `isinstance(payload, bytes)` and unpickles inside the `try`.

It works: a `__setstate__`-raises argument now surfaces the original `RuntimeError` (with a `RemoteTraceback` cause) rather than `LostResult`, demonstrated by the new `TestArgumentNotReconstructable`.

## Why it was rejected

The spawn/forkserver path requires materializing the pickled payload into an owned, picklable `bytes` object so multiprocessing's own bootstrap can re-pickle it as a `Process` arg. That is one unavoidable copy of the entire serialized payload on every submission — a `memoryview` from `ForkingPickler.dumps` is not picklable, and protocol-5 out-of-band buffers don't help (the payload isn't large-buffer-backed, and we don't own the spawn transport). The per-submission byte-copy overhead is not worth the improved diagnostic, so the maintainer is declining this in favor of documenting the behavior (per #351's first option).

## Prototype commits (on top of pre-existing branch work)

- `a13def7` Prototype delivering fn/args as a pre-pickled blob
- `ed2ad57` Trim comments and docstrings to minimal
- `8f8cd4c` Simplify: drop _Payload class for a plain tuple-or-bytes payload
- `2603f67` Add Payload type alias; drop issue refs from worker comments

Closes nothing; see #351.

https://claude.ai/code/session_018eAmHdPy36R4yN8yLLAUAF

---
_Generated by [Claude Code](https://claude.ai/code/session_018eAmHdPy36R4yN8yLLAUAF)_