### PR TITLE
Fix test cleanup to prevent orphaned worker processes

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -228,6 +228,13 @@ def helper_exec_grandchild_then_die(q: SPSCQueue[int]) -> typing.NoReturn:
     os._exit(0)  # worker dies WITHOUT sending a result
 
 
+def helper_sleep_with_pid(pid_path: str, duration: float = 60) -> None:
+    """Write own PID to a file and sleep, so the caller can kill us."""
+    with open(pid_path, "w") as f:
+        f.write(str(os.getpid()))
+    time.sleep(duration)
+
+
 def helper_preexec_fn() -> None:
     """Mutates os.environ so that the change can be observed."""
     os.environ["JOBSERVER_TEST_ENVIRON"] = "PREEXEC_FN"

--- a/test/test_executor_lifecycle.py
+++ b/test/test_executor_lifecycle.py
@@ -40,6 +40,7 @@ from .helpers import (
     barrier_wait,
     create_marker,
     helper_return,
+    helper_sleep_with_pid,
     silence_forkserver,
     wait_until,
 )
@@ -463,24 +464,38 @@ class TestResourceLeaks(unittest.TestCase):
         Without the fix EOF never arrives until the worker exits.
         With the fix the worker closes the fd via preexec_fn promptly.
         """
-        with Jobserver(context=FAST, slots=1) as js:
-            exe = JobserverExecutor(js)
-            try:
-                # Long sleep so the worker outlives the prompt-fail window.
-                f = exe.submit(time.sleep, 60)
-                # Wait until the future is RUNNING (worker is live, dispatcher
-                # has dispatched and is still alive).
-                wait_until(lambda: f.running(), timeout=TIMEOUT)
-                self.assertTrue(f.running())
-                pid = exe._dispatcher.pid
-                os.kill(pid, signal.SIGKILL)
-                # Must raise BrokenExecutor well before the 60 s worker exits.
-                with self.assertRaises(
-                    (concurrent.futures.BrokenExecutor, RuntimeError)
-                ):
-                    f.result(timeout=10)
-            finally:
-                exe.shutdown(wait=False)
+        with tempfile.TemporaryDirectory() as tmp:
+            pid_path = os.path.join(tmp, "worker.pid")
+            with Jobserver(context=FAST, slots=1) as js:
+                exe = JobserverExecutor(js)
+                try:
+                    # Long sleep so the worker outlives the prompt-fail
+                    # window.  The helper writes its PID so cleanup can
+                    # kill the orphaned worker (which otherwise holds
+                    # inherited pipe FDs open until the sleep expires).
+                    f = exe.submit(helper_sleep_with_pid, pid_path)
+                    # Wait until the future is RUNNING (worker is live,
+                    # dispatcher has dispatched and is still alive).
+                    wait_until(lambda: f.running(), timeout=TIMEOUT)
+                    self.assertTrue(f.running())
+                    wait_until(
+                        lambda: os.path.exists(pid_path), timeout=TIMEOUT
+                    )
+                    worker_pid = int(open(pid_path).read())
+                    os.kill(exe._dispatcher.pid, signal.SIGKILL)
+                    # Must raise BrokenExecutor well before the 60 s
+                    # worker exits.
+                    with self.assertRaises(
+                        (concurrent.futures.BrokenExecutor, RuntimeError)
+                    ):
+                        f.result(timeout=10)
+                finally:
+                    exe.shutdown(wait=False)
+                    try:
+                        os.kill(worker_pid, signal.SIGKILL)
+                        os.waitpid(worker_pid, 0)
+                    except (OSError, NameError):
+                        pass
 
     def test_submit_after_dispatcher_death(self) -> None:
         """submit() after dispatcher death raises RuntimeError."""


### PR DESCRIPTION
## Summary
This change improves the test for dispatcher death handling by properly cleaning up orphaned worker processes. The test now captures the worker's PID and ensures it's killed during cleanup, preventing long-running processes from persisting after the test completes.

## Key Changes
- Added `helper_sleep_with_pid()` helper function that writes its PID to a file before sleeping, allowing the test to identify and clean up the worker process
- Modified `test_dispatcher_death_with_running_worker_fails_promptly()` to:
  - Use a temporary directory to store the worker PID file
  - Wait for the PID file to be created before killing the dispatcher
  - Capture the worker PID for cleanup
  - Add a finally block that kills the orphaned worker process and waits for it to exit
- Updated test imports to include the new `helper_sleep_with_pid` function

## Implementation Details
The test previously relied on `time.sleep(60)` which would leave the worker process running for a full minute after the dispatcher was killed. The new approach:
1. Writes the worker's PID to a file so the test can identify it
2. Explicitly kills the worker process in cleanup rather than waiting for it to naturally exit
3. Uses `os.waitpid()` to ensure the process is fully reaped
4. Handles potential errors gracefully with try/except to avoid cleanup failures

https://claude.ai/code/session_01FLuVjCPf27t7GA6CT6QQA2