### PR TITLE
Document that when_done callbacks must not raise BaseException

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -355,6 +355,10 @@ class Future(Generic[T]):
 
         Returns a seqno identifying this registration.  Should fn raise,
         the resulting CallbackRaised reports it via CallbackRaised.seqno.
+
+        Callbacks must not raise BaseException (e.g. KeyboardInterrupt,
+        SystemExit); only Exception subclasses are wrapped in
+        CallbackRaised -- a BaseException propagates uncaught.
         """
         # _when_done assigns and returns the seqno under the same lock.
         # self._callbacks_seqno is an int, so the partial curries a copy.


### PR DESCRIPTION
## Summary

Adds a sentence to the `when_done()` docstring in `_jobserver.py` clarifying that callbacks must not raise `BaseException` (e.g. `KeyboardInterrupt`, `SystemExit`). Only `Exception` subclasses are wrapped in `CallbackRaised`; a `BaseException` propagates uncaught through `result()`/`wait()`/`done()`.

This documents existing intentional behavior (`_callback_wrapper` only catches `Exception`) that was previously undocumented on the user-facing API.

Closes #385

## Testing

- `./ci` passes (unit tests, examples, ruff, mypy, black, sdist build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JpwJPteHvk2c6t666DUHaV)_