### PR TITLE
Reject negative timeouts with ValueError

### DIFF
--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -55,6 +55,8 @@ def timeout_to_deadline(timeout: Optional[float]) -> float:
     if timeout is None:
         return _MAX_TIMEOUT_SECS + time.monotonic()
     if isinstance(timeout, (int, float)) and not isinstance(timeout, bool):
+        if timeout < 0:
+            raise ValueError(f"timeout must be non-negative, got {timeout!r}")
         return timeout + time.monotonic()
     raise TypeError(
         f"timeout: None or a real number, got {type(timeout).__name__}"

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -312,3 +312,11 @@ class TimeoutToDeadlineTest(unittest.TestCase):
             with self.assertRaises(TypeError) as cm:
                 timeout_to_deadline(bad)
             self.assertIn("timeout", str(cm.exception))
+
+    def test_negative_raises_valueerror(self) -> None:
+        """A negative timeout is rejected so caller bugs surface as
+        ValueError instead of an immediately-expired deadline (#383)."""
+        for bad in (-1, -0.001, -5.0):
+            with self.assertRaises(ValueError) as cm:
+                timeout_to_deadline(bad)
+            self.assertIn("non-negative", str(cm.exception))


### PR DESCRIPTION
## Problem

`timeout_to_deadline()` accepted negative timeout values without complaint. A call like `result(timeout=-1)` silently produced a deadline in the past (adding a negative number to `time.monotonic()`), so every subsequent check expired immediately and `Blocked` was raised. The same applied to `submit(timeout=...)`, `wait(timeout=...)`, and `done(timeout=...)`, all of which route through this helper.

This undocumented behavior could mask caller bugs — e.g. a computed timeout that accidentally goes negative looked like a legitimate `Blocked` rather than surfacing the real problem.

## Change

Add a `timeout >= 0` guard to `timeout_to_deadline()` in `_queue.py` that raises `ValueError` for negative values, matching `threading.Lock.acquire()` behavior and catching caller mistakes early. Added a unit test covering negative `int` and `float` inputs.

`./ci` passes (unit tests, examples, ruff, mypy, black, sdist build).

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbZoL2jDNvjc1Z1riGWiDT)_