### PR TITLE
Reject non-finite timeouts (NaN, Inf) with ValueError

### DIFF
--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -6,6 +6,7 @@
 """FixedBytesQueue, MPMCQueue, SPSCQueue, and related utility functions."""
 
 import abc
+import math
 import os
 import queue
 import threading
@@ -55,6 +56,8 @@ def timeout_to_deadline(timeout: Optional[float]) -> float:
     if timeout is None:
         return _MAX_TIMEOUT_SECS + time.monotonic()
     if isinstance(timeout, (int, float)) and not isinstance(timeout, bool):
+        if not math.isfinite(timeout):
+            raise ValueError(f"timeout must be finite, got {timeout!r}")
         if timeout < 0:
             raise ValueError(f"timeout must be non-negative, got {timeout!r}")
         return timeout + time.monotonic()

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -320,3 +320,12 @@ class TimeoutToDeadlineTest(unittest.TestCase):
             with self.assertRaises(ValueError) as cm:
                 timeout_to_deadline(bad)
             self.assertIn("non-negative", str(cm.exception))
+
+    def test_non_finite_raises_valueerror(self) -> None:
+        """NaN/Inf timeouts are rejected: NaN silently disables every
+        deadline check and busy-spins, while Inf is an undocumented alias
+        for None.  Use None to block indefinitely (#389)."""
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.assertRaises(ValueError) as cm:
+                timeout_to_deadline(bad)
+            self.assertIn("finite", str(cm.exception))


### PR DESCRIPTION
## Problem

`timeout=float('nan')` silently bypassed all deadline checks. `timeout_to_deadline(NaN)` passed the `isinstance(timeout, (int, float))` guard and returned `NaN`. Since `time.monotonic() >= NaN` is always `False` (IEEE 754), the deadline never expired and the wait loop busy-spun with `timeout=0` polls — pegging a CPU core with no way to time out. `timeout=float('inf')` merely aliased `None` as an undocumented accident.

## Fix

Add a `math.isfinite()` check to `timeout_to_deadline()` in `_queue.py` that rejects `NaN`, `Inf`, and `-Inf` with a `ValueError`. Combined with the existing negative-timeout guard (#383), the full validation is now: timeout must be `None` or a finite non-negative number. `None` remains the canonical spelling for "block indefinitely."

## Testing

- Added `test_non_finite_raises_valueerror` covering `nan`, `inf`, and `-inf`.
- `./ci` passes (unit tests, examples, ruff, mypy, black, sdist build).

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDyHGxDduQ8TCXAMkUqQ3G)_