### PR TITLE
Catch all pickle failures in worker result-send fallback

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -39,7 +39,6 @@ from typing import (
 )
 
 from ._compat import (
-    PICKLE_DUMP_ERRORS,
     ignore_sigpipe,
     pipe_buf,
     sched_getaffinity0,
@@ -1363,7 +1362,8 @@ def _worker_entrypoint(send, envdiff, preexec, fn, args, kwargs) -> None:
             if result is not None:
                 try:
                     payload = ForkingPickler.dumps(result)
-                except PICKLE_DUMP_ERRORS as pe:
+                except Exception as pe:
+                    # Pickling user types can produce arbitrary exceptions.
                     payload = ForkingPickler.dumps(
                         ExceptionWrapper(
                             RuntimeError(

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -694,6 +694,18 @@ def _make_deep_result() -> object:
     return x
 
 
+class _ReduceRaisesRuntimeError(Exception):
+    """An exception whose __reduce__ raises RuntimeError when pickled."""
+
+    def __reduce__(self) -> typing.Any:
+        raise RuntimeError("__reduce__ refuses to pickle")
+
+
+def _raise_reduce_runtimeerror() -> object:
+    """Raise an exception whose __reduce__ raises RuntimeError."""
+    raise _ReduceRaisesRuntimeError()
+
+
 class _RecordingSend:
     """Stand-in for a worker's pipe end recording send_bytes payloads.
 
@@ -773,6 +785,20 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         than crashing the worker into a misleading LostResult (#343)."""
         send = _RecordingSend()
         _worker_entrypoint(send, {}, lambda: None, _make_deep_result, (), {})
+        self.assertEqual(1, len(send.payloads))
+        wrapper = ForkingPickler.loads(send.payloads[0])
+        self.assertIsInstance(wrapper, ExceptionWrapper)
+        with self.assertRaises(RuntimeError) as ctx:
+            wrapper.unwrap()
+        self.assertIn("not picklable", str(ctx.exception))
+        self.assertTrue(send.closed)
+
+    def test_reduce_raising_runtimeerror_uses_fallback(self) -> None:
+        """A __reduce__ raising RuntimeError uses the fallback (#390)."""
+        send = _RecordingSend()
+        _worker_entrypoint(
+            send, {}, lambda: None, _raise_reduce_runtimeerror, (), {}
+        )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
         self.assertIsInstance(wrapper, ExceptionWrapper)


### PR DESCRIPTION
## Problem

When a worker raises an exception whose `__reduce__` raises `RuntimeError`, pickling the `ExceptionWrapper` in `_worker_entrypoint`'s `finally` block raised a `RuntimeError` that fell outside the curated `PICKLE_DUMP_ERRORS` tuple. The error escaped the `except PICKLE_DUMP_ERRORS` handler, fell through `except OSError` (pipe I/O only), the pipe closed without a result, and the parent saw `EOFError` → an undiagnosable `LostResult`.

## Fix

Implements **Option 3** from #390:

- The first `ForkingPickler.dumps(result)` — which serializes user-provided data — now catches `except Exception`. This is a last-chance handler in a child process about to exit; any escape strictly loses diagnostic information, so a broad catch is appropriate here.
- The fallback `dumps` pickles a library-built `RuntimeError` and string that are guaranteed picklable, so it stays unguarded: if it ever fails, that's a library bug worth surfacing rather than hiding.
- The two `JobserverExecutor` call sites (`_executor.py:167`, `_executor.py:568`) stay on `PICKLE_DUMP_ERRORS` unchanged, as recommended.

The now-unused `PICKLE_DUMP_ERRORS` import was removed from `_jobserver.py`.

## Testing

Added `test_reduce_raising_runtimeerror_uses_fallback`, which exercises an exception whose `__reduce__` raises `RuntimeError` and asserts the descriptive "not picklable" fallback is sent instead of a silent `LostResult`. The existing #284 send-error test still passes (the broadened catch wraps only the first `dumps`, not `send_bytes`).

Full `./ci` passes (unit tests, examples, ruff, mypy, black, sdist build).

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGsCdsni5iTyQyVBy98tm6)_