### PR TITLE
Import PICKLE_DUMP_ERRORS from compat module

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -39,6 +39,7 @@ from typing import (
 )
 
 from ._compat import (
+    PICKLE_DUMP_ERRORS,
     ignore_sigpipe,
     pipe_buf,
     sched_getaffinity0,


### PR DESCRIPTION
This change adds an import for `PICKLE_DUMP_ERRORS` from the `._compat` module in the jobserver implementation.

## Summary
Added the `PICKLE_DUMP_ERRORS` constant to the imports from the compatibility module, making it available for use in the jobserver implementation.

## Key Changes
- Imported `PICKLE_DUMP_ERRORS` from `._compat` alongside existing imports (`ignore_sigpipe`, `pipe_buf`, `sched_getaffinity0`)

## Details
This import addition suggests that `PICKLE_DUMP_ERRORS` is a compatibility constant that will be used elsewhere in the `_jobserver.py` module, likely for handling pickle-related errors in a cross-platform manner.

https://claude.ai/code/session_013W7PTyqXVDwgkchYN5c2cA