### PR TITLE
Catch BaseException from result deserialization in Future.wait()

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -474,7 +474,10 @@ class Future(Generic[T]):
                 self._wrapper = self._connection.recv()
             except EOFError:
                 self._wrapper = ExceptionWrapper(LostResult())
-            except Exception as e:
+            except KeyboardInterrupt:
+                # A Ctrl-C may be local or may sneak in from the recv() itself.
+                raise
+            except BaseException as e:
                 # A value can pickle in the child yet fail to reconstitute
                 # in the parent (e.g. a returned Connection raises
                 # FileNotFoundError deep in recv()).


### PR DESCRIPTION
## Summary

Fixes #396.

A worker return value whose `__setstate__` raises a `BaseException` (`SystemExit`, `KeyboardInterrupt`) would escape the `except Exception` guard around `recv()` in `Future.wait()` and propagate into the parent — potentially terminating the interpreter (e.g. exit code 99 in the reported repro).

This applies **Option B** from the issue: widen the guard to `except BaseException`, but re-raise `KeyboardInterrupt` first so an interactive Ctrl-C during the `recv()` window still propagates.

## Change

```python
except EOFError:
    self._wrapper = ExceptionWrapper(LostResult())
except KeyboardInterrupt:
    # A Ctrl-C may be local or may sneak in from the recv() itself.
    raise
except BaseException as e:
    self._wrapper = ExceptionWrapper(
        RuntimeError(f"Result not reconstructable: {e!r}")
    )
```

The handler ordering matters: `KeyboardInterrupt` is matched before the broader `BaseException`, so a real Ctrl-C wins while `SystemExit`/`GeneratorExit` from a malicious or buggy `__setstate__` get wrapped into the existing `RuntimeError`.

## Known limitation

As noted in the issue, a `__setstate__` that raises `KeyboardInterrupt` *itself* still escapes — this approach cannot distinguish a deserialization-raised interrupt from a user-pressed one, since both surface through the same `recv()` call. Closing that gap would require Option C (isolating the I/O phase from the unpickle phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0125hbtLJDNsBgVwXcBGwSEn)_