### PR TITLE
Test slot self-healing after a KeyboardInterrupt escapes from __setstate__

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -186,6 +186,31 @@ def helper_return_connection(context):
     return recv
 
 
+class HelperRaiseOnUnpickle:
+    """A value that pickles cleanly in the child but raises in the parent.
+
+    Pickling calls __getstate__ (which succeeds), so the worker sends the
+    value normally.  Unpickling in the parent calls __setstate__, which
+    raises the carried BaseException from deep inside recv() (see #396).
+    The class carries its exception type in state so spawn/forkserver can
+    rebuild it by reference.
+    """
+
+    def __init__(self, klass: type) -> None:
+        self._klass = klass
+
+    def __getstate__(self) -> dict:
+        return {"klass": self._klass}
+
+    def __setstate__(self, state: dict) -> typing.NoReturn:
+        raise state["klass"]()
+
+
+def helper_return_raise_on_unpickle(klass: type) -> HelperRaiseOnUnpickle:
+    """Return a value whose __setstate__ raises klass() in the parent."""
+    return HelperRaiseOnUnpickle(klass)
+
+
 def helper_raise(klass: type, *args) -> typing.NoReturn:
     """Helper raising the requested Exception class."""
     raise klass(*args)

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -50,6 +50,7 @@ from .helpers import (
     helper_return,
     helper_return_connection,
     helper_return_kwargs,
+    helper_return_raise_on_unpickle,
     start_methods,
 )
 
@@ -909,3 +910,42 @@ class TestResultNotReconstructable(unittest.TestCase):
             with self.assertRaises(RuntimeError) as ctx:
                 future.result(timeout=10)
         self.assertIn("not reconstructable", str(ctx.exception))
+
+
+class TestUnpickleInterruptSelfHeals(unittest.TestCase):
+    """A KeyboardInterrupt raised by a result's __setstate__ still escapes
+    Future.wait() by design: the #396 fix re-raises KeyboardInterrupt to
+    preserve interactive Ctrl-C, so it cannot tell a real Ctrl-C apart from
+    one smuggled in by a malicious __setstate__.  The escape orphans the
+    Future and leaks its slot, but the leak must be transient: the next
+    submit() reclaims the slot, leaving the Jobserver fully usable."""
+
+    def test_slot_reclaimed_after_unpickle_keyboardinterrupt(self) -> None:
+        """The single leaked slot is recovered by the following submit()."""
+        for method in start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=method, slots=1) as js:
+                    # The lone slot's worker returns a value whose
+                    # __setstate__ raises KeyboardInterrupt in the parent.
+                    evil = js.submit(
+                        fn=helper_return_raise_on_unpickle,
+                        args=(KeyboardInterrupt,),
+                    )
+                    with self.assertRaises(KeyboardInterrupt):
+                        evil.result(timeout=TIMEOUT)
+
+                    # The escape consumed the slot without restoring it and
+                    # left evil orphaned.  Acquiring the lone slot for fresh
+                    # work is only possible if submit()'s reclaim() pass
+                    # self-heals the orphan (EOFError -> LostResult), firing
+                    # its token-restore callback.
+                    healed = js.submit(
+                        fn=helper_return, args=(42,), timeout=TIMEOUT
+                    )
+                    self.assertEqual(42, healed.result(timeout=TIMEOUT))
+
+                    # The orphan converges to LostResult once its drained
+                    # pipe reports EOF; it never re-raises KeyboardInterrupt.
+                    self.assertTrue(evil.done(timeout=TIMEOUT))
+                    with self.assertRaises(LostResult):
+                        evil.result(timeout=0)


### PR DESCRIPTION
## Summary

Follow-up to #396 / #397. Adds regression coverage for the self-healing behavior documented in #396.

The #396 fix (Option B) re-raises `KeyboardInterrupt` from result deserialization to preserve interactive Ctrl-C. As a known, accepted limitation, that means a worker return value whose `__setstate__` raises `KeyboardInterrupt` still escapes `Future.wait()` — orphaning the Future and leaking its slot. This PR confirms that leak is **transient**: the next `submit()`'s `reclaim()` pass drains the orphan (`EOFError → LostResult`), fires its `_restore_token` callback, and recovers the slot so the Jobserver stays usable.

## Test

`TestUnpickleInterruptSelfHeals` in `test/test_jobserver_worker.py`, parametrized over every start method with `slots=1`:

1. Submit a worker returning a value whose `__setstate__` raises `KeyboardInterrupt` → `result()` re-raises it, orphaning the Future and consuming the lone slot.
2. Submit normal work → succeeds only if `reclaim()` self-heals the orphan and restores the token. Asserting `== 42` proves the slot was recovered (a broken self-heal would block until timeout and fail).
3. The orphan converges to `LostResult` and never re-raises `KeyboardInterrupt`.

A picklable `HelperRaiseOnUnpickle` (carries its exception type in state so spawn/forkserver can rebuild it by reference) is added to `test/helpers.py`.

## Verification

`./ci` passes end to end: 270 unit tests OK, examples run, ruff clean, mypy clean (19 files), black clean (37 files), sdist builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0125hbtLJDNsBgVwXcBGwSEn)_