### PR TITLE
Stabilize benchmark measurements with warmup and repeated trials

### DIFF
--- a/draft/bench.py
+++ b/draft/bench.py
@@ -11,6 +11,15 @@ baseline.  Where meaningful, the standard library's ProcessPoolExecutor
 is measured side-by-side to quantify the "slower launch, more robust"
 tradeoff that JobserverExecutor deliberately makes.
 
+To keep timings stable rather than noisy, every configuration (including
+the serial baseline) is measured with the same discipline: a few untimed
+warmup iterations first prime imports, the page cache, and fork/spawn
+machinery; garbage collection is paused across each timed region so a
+stray collection cannot inflate a single sample; and the best (smallest)
+of several repeated measurements is reported, since the minimum is the
+sample least perturbed by transient system load.  Tune with --warmup and
+--repeat.
+
 All kernels are module-level functions (hence picklable under spawn and
 forkserver), deterministic, and stdlib-only.  Run, for example, with:
 
@@ -30,13 +39,16 @@ The six scenarios are:
 """
 
 import argparse
+import gc
 import os
 import platform
 import time
+from collections.abc import Callable, Iterator
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from multiprocessing import get_context
-from typing import Callable, Optional
+from typing import Optional
 
 from jobserver import Blocked, Jobserver, JobserverExecutor
 
@@ -121,6 +133,8 @@ class Workload:
     slots: int
     context: Optional[str]
     threshold: int
+    warmup: int = 1
+    repeat: int = 5
     serial_wall: float = 0.0
     serial_total: int = 0
     ranges: list = field(default_factory=list)
@@ -142,10 +156,50 @@ def partition(n: int, parts: int) -> list:
     return [(edges[i], edges[i + 1]) for i in range(parts)]
 
 
-def timer() -> Callable[[], float]:
-    """Start a monotonic stopwatch; the returned call yields elapsed s."""
+class _Stopwatch:
+    """Holds the elapsed seconds populated when a stopwatch() block exits."""
+
+    elapsed: float = 0.0
+
+
+@contextmanager
+def stopwatch() -> Iterator[_Stopwatch]:
+    """Time a block on the monotonic clock with garbage collection paused.
+
+    Collection is disabled across the timed region so a stray collection
+    cannot inflate a single measurement, then restored to its prior state.
+    Read the duration from the yielded object's .elapsed after the block.
+    """
+    watch = _Stopwatch()
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
     start = time.perf_counter()
-    return lambda: time.perf_counter() - start
+    try:
+        yield watch
+    finally:
+        watch.elapsed = time.perf_counter() - start
+        if gc_was_enabled:
+            gc.enable()
+
+
+def measure_best(w: "Workload", trial: Callable[[], Row]) -> Row:
+    """Warm up, then repeat trial, returning the Row with least wall time.
+
+    trial runs one full timed iteration of a single configuration and
+    returns its Row.  w.warmup untimed iterations first prime imports, the
+    page cache, and fork/spawn machinery; the best (smallest wall) of the
+    subsequent w.repeat measured iterations is kept, since the minimum is
+    the measurement least perturbed by transient system load.
+    """
+    for _ in range(w.warmup):
+        trial()
+    best: Optional[Row] = None
+    for _ in range(max(1, w.repeat)):
+        row = trial()
+        if best is None or row.wall < best.wall:
+            best = row
+    assert best is not None
+    return best
 
 
 def print_table(title: str, rows: list) -> None:
@@ -185,50 +239,52 @@ def scenario_flat(w: Workload) -> list:
     rows = []
     for slots in sorted({1, 2, w.slots}):
         for chunksize in (1, max(1, w.parts // slots)):
-            with w.jobserver(slots=slots) as js:
-                elapsed = timer()
-                total = sum(
-                    js.map(
-                        fn=count_primes,
-                        argses=w.ranges,
-                        chunksize=chunksize,
-                    )
-                )
-                wall = elapsed()
-            assert total == w.serial_total, (total, w.serial_total)
-            rows.append(
-                Row(
+
+            def trial(slots: int = slots, chunksize: int = chunksize) -> Row:
+                with w.jobserver(slots=slots) as js:
+                    with stopwatch() as sw:
+                        total = sum(
+                            js.map(
+                                fn=count_primes,
+                                argses=w.ranges,
+                                chunksize=chunksize,
+                            )
+                        )
+                assert total == w.serial_total, (total, w.serial_total)
+                return Row(
                     label=f"slots={slots} chunk={chunksize}",
-                    wall=wall,
+                    wall=sw.elapsed,
                     tasks=w.parts,
-                    speedup=w.serial_wall / wall if wall else 0.0,
+                    speedup=w.serial_wall / sw.elapsed if sw.elapsed else 0.0,
                 )
-            )
+
+            rows.append(measure_best(w, trial))
     return rows
 
 
 def scenario_nested(w: Workload) -> list:
     """Recursive divide-and-conquer sharing a single slot pool."""
     rows = []
+    leaves = max(1, (w.n - 2 + w.threshold - 1) // w.threshold)
     for slots in sorted({1, 2, w.slots}):
-        with w.jobserver(slots=slots) as js:
-            elapsed = timer()
-            total = js.submit(
-                fn=nested_count,
-                args=(js, 2, w.n, w.threshold),
-            ).result()
-            wall = elapsed()
-        assert total == w.serial_total, (total, w.serial_total)
-        leaves = max(1, (w.n - 2 + w.threshold - 1) // w.threshold)
-        rows.append(
-            Row(
+
+        def trial(slots: int = slots) -> Row:
+            with w.jobserver(slots=slots) as js:
+                with stopwatch() as sw:
+                    total = js.submit(
+                        fn=nested_count,
+                        args=(js, 2, w.n, w.threshold),
+                    ).result()
+            assert total == w.serial_total, (total, w.serial_total)
+            return Row(
                 label=f"slots={slots}",
-                wall=wall,
+                wall=sw.elapsed,
                 tasks=leaves,
-                speedup=w.serial_wall / wall if wall else 0.0,
+                speedup=w.serial_wall / sw.elapsed if sw.elapsed else 0.0,
                 note="recurses + degrades; no deadlock",
             )
-        )
+
+        rows.append(measure_best(w, trial))
     return rows
 
 
@@ -239,46 +295,50 @@ def _collect(sink: list, future: object) -> None:
 
 def scenario_callbacks(w: Workload) -> list:
     """when_done() partial sums drained via eager reclaim_resources()."""
-    sink: list = []
-    with w.jobserver() as js:
-        elapsed = timer()
-        futures = [js.submit(fn=count_primes, args=r) for r in w.ranges]
-        for future in futures:
-            future.when_done(_collect, sink, future)
-        # Eagerly reclaim until every chunk has reported its partial sum.
-        while len(sink) < len(futures):
-            js.reclaim_resources()
-        wall = elapsed()
-    assert sum(sink) == w.serial_total, (sum(sink), w.serial_total)
-    return [
-        Row(
+
+    def trial() -> Row:
+        sink: list = []
+        with w.jobserver() as js:
+            with stopwatch() as sw:
+                futures = [
+                    js.submit(fn=count_primes, args=r) for r in w.ranges
+                ]
+                for future in futures:
+                    future.when_done(_collect, sink, future)
+                # Eagerly reclaim until every chunk reports its partial sum.
+                while len(sink) < len(futures):
+                    js.reclaim_resources()
+        assert sum(sink) == w.serial_total, (sum(sink), w.serial_total)
+        return Row(
             label=f"slots={w.slots}",
-            wall=wall,
+            wall=sw.elapsed,
             tasks=w.parts,
-            speedup=w.serial_wall / wall if wall else 0.0,
+            speedup=w.serial_wall / sw.elapsed if sw.elapsed else 0.0,
             note=f"{len(sink)} callbacks fired",
         )
-    ]
+
+    return [measure_best(w, trial)]
 
 
 def scenario_sleepfn(w: Workload) -> list:
     """Overhead of an always-admitting sleep admission gate."""
     rows = []
     for gated, label in ((False, "no gate"), (True, "sleep")):
-        with w.jobserver() as js:
-            runner = js.replace_sleep(admit_always) if gated else js
-            elapsed = timer()
-            total = sum(runner.map(fn=count_primes, argses=w.ranges))
-            wall = elapsed()
-        assert total == w.serial_total, (total, w.serial_total)
-        rows.append(
-            Row(
+
+        def trial(gated: bool = gated, label: str = label) -> Row:
+            with w.jobserver() as js:
+                runner = js.replace_sleep(admit_always) if gated else js
+                with stopwatch() as sw:
+                    total = sum(runner.map(fn=count_primes, argses=w.ranges))
+            assert total == w.serial_total, (total, w.serial_total)
+            return Row(
                 label=label,
-                wall=wall,
+                wall=sw.elapsed,
                 tasks=w.parts,
-                speedup=w.serial_wall / wall if wall else 0.0,
+                speedup=w.serial_wall / sw.elapsed if sw.elapsed else 0.0,
             )
-        )
+
+        rows.append(measure_best(w, trial))
     return rows
 
 
@@ -291,36 +351,38 @@ def scenario_executor(w: Workload) -> list:
 
     def measure(label: str, make: Callable, note: str) -> None:
         # map(): in-order results
-        with make() as ex:
-            elapsed = timer()
-            total = sum(ex.map(count_primes, los, his))
-            wall = elapsed()
-        assert total == w.serial_total, (total, w.serial_total)
-        rows.append(
-            Row(
+        def map_trial() -> Row:
+            with make() as ex:
+                with stopwatch() as sw:
+                    total = sum(ex.map(count_primes, los, his))
+            assert total == w.serial_total, (total, w.serial_total)
+            return Row(
                 label=f"{label} map",
-                wall=wall,
+                wall=sw.elapsed,
                 tasks=w.parts,
-                speedup=w.serial_wall / wall if wall else 0.0,
+                speedup=w.serial_wall / sw.elapsed if sw.elapsed else 0.0,
                 note=note,
             )
-        )
+
         # submit() + as_completed(): out-of-order fan-in
-        with make() as ex:
-            elapsed = timer()
-            futures = [ex.submit(count_primes, lo, hi) for lo, hi in w.ranges]
-            total = sum(f.result() for f in as_completed(futures))
-            wall = elapsed()
-        assert total == w.serial_total, (total, w.serial_total)
-        rows.append(
-            Row(
+        def submit_trial() -> Row:
+            with make() as ex:
+                with stopwatch() as sw:
+                    futures = [
+                        ex.submit(count_primes, lo, hi) for lo, hi in w.ranges
+                    ]
+                    total = sum(f.result() for f in as_completed(futures))
+            assert total == w.serial_total, (total, w.serial_total)
+            return Row(
                 label=f"{label} submit",
-                wall=wall,
+                wall=sw.elapsed,
                 tasks=w.parts,
-                speedup=w.serial_wall / wall if wall else 0.0,
+                speedup=w.serial_wall / sw.elapsed if sw.elapsed else 0.0,
                 note=note,
             )
-        )
+
+        rows.append(measure_best(w, map_trial))
+        rows.append(measure_best(w, submit_trial))
 
     measure(
         "Jobserver",
@@ -338,23 +400,26 @@ def scenario_executor(w: Workload) -> list:
 def scenario_cancel(w: Workload) -> list:
     """Cancellation churn against genuinely PENDING futures (slots=1)."""
     submitted = max(8, w.parts)
-    with JobserverExecutor(w.jobserver(slots=1)) as ex:
-        elapsed = timer()
-        # One slow task holds the only slot; the rest queue up PENDING.
-        held = ex.submit(time.sleep, 0.2)
-        pending = [ex.submit(time.sleep, 5.0) for _ in range(submitted)]
-        cancelled = sum(1 for f in pending if f.cancel())
-        held.result()
-        wall = elapsed()
-    return [
-        Row(
+
+    def trial() -> Row:
+        with JobserverExecutor(w.jobserver(slots=1)) as ex:
+            with stopwatch() as sw:
+                # One slow task holds the only slot; the rest queue PENDING.
+                held = ex.submit(time.sleep, 0.2)
+                pending = [
+                    ex.submit(time.sleep, 5.0) for _ in range(submitted)
+                ]
+                cancelled = sum(1 for f in pending if f.cancel())
+                held.result()
+        return Row(
             label=f"submitted={submitted}",
-            wall=wall,
+            wall=sw.elapsed,
             tasks=submitted,
             speedup=0.0,
             note=f"{cancelled}/{submitted} cancelled while PENDING",
         )
-    ]
+
+    return [measure_best(w, trial)]
 
 
 SCENARIOS: dict = {
@@ -373,18 +438,33 @@ SCENARIOS: dict = {
 
 
 def build_workload(args: argparse.Namespace) -> Workload:
-    """Assemble the shared workload and measure the serial baseline."""
+    """Assemble the shared workload and measure the serial baseline.
+
+    The baseline is warmed and taken best-of-repeat just like the
+    scenarios, so the speedup ratios that divide by it stay stable.
+    """
     w = Workload(
         n=args.n,
         parts=args.parts,
         slots=args.slots,
         context=args.context,
         threshold=max(1, (args.n - 2) // (args.slots * 4)),
+        warmup=args.warmup,
+        repeat=args.repeat,
     )
     w.ranges = partition(w.n, w.parts)
-    elapsed = timer()
-    w.serial_total = sum(count_primes(lo, hi) for lo, hi in w.ranges)
-    w.serial_wall = elapsed()
+
+    def serial() -> int:
+        return sum(count_primes(lo, hi) for lo, hi in w.ranges)
+
+    for _ in range(w.warmup):
+        serial()
+    best = None
+    for _ in range(max(1, w.repeat)):
+        with stopwatch() as sw:
+            w.serial_total = serial()
+        best = sw.elapsed if best is None else min(best, sw.elapsed)
+    w.serial_wall = best or 0.0
     return w
 
 
@@ -409,11 +489,28 @@ def main() -> None:
         help="small inputs for a fast smoke run",
     )
     parser.add_argument(
+        "--warmup",
+        type=int,
+        default=1,
+        help="untimed warmup iterations per configuration (default: 1)",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=5,
+        help="timed iterations per configuration; best is kept (default: 5)",
+    )
+    parser.add_argument(
         "--only",
         default="",
         help=f"comma-separated subset of {','.join(SCENARIOS)}",
     )
     args = parser.parse_args()
+
+    if args.warmup < 0:
+        parser.error("--warmup must be >= 0")
+    if args.repeat < 1:
+        parser.error("--repeat must be >= 1")
 
     # Defaults depend on --quick unless explicitly overridden.
     if args.n is None:
@@ -432,12 +529,13 @@ def main() -> None:
         f"python={platform.python_version()} "
         f"platform={platform.system()} "
         f"cpus={cpus} "
-        f"context={args.context or get_context().get_start_method()}"
+        f"context={args.context or get_context().get_start_method()} "
+        f"warmup={w.warmup} repeat={w.repeat}"
     )
     print(
         f"n={w.n:,} parts={w.parts} slots={w.slots} "
         f"threshold={w.threshold:,} primes={w.serial_total:,} "
-        f"serial={w.serial_wall:.3f}s"
+        f"serial={w.serial_wall:.3f}s (best of {w.repeat})"
     )
 
     for name in chosen:


### PR DESCRIPTION
## Summary
Refactored the benchmark suite to produce more stable and reproducible timing measurements by implementing warmup iterations and repeated trial collection with best-of-N reporting.

## Key Changes

- **New measurement discipline**: Added `--warmup` and `--repeat` command-line arguments to control untimed warmup iterations and the number of timed measurements per configuration. The best (smallest) wall time is reported, as it's least perturbed by transient system load.

- **Stopwatch context manager**: Replaced the simple `timer()` function with a `stopwatch()` context manager that:
  - Pauses garbage collection during measurement to prevent stray collections from inflating timings
  - Restores the prior GC state after measurement
  - Stores elapsed time in a `_Stopwatch` object for cleaner semantics

- **Measurement abstraction**: Introduced `measure_best()` function that encapsulates the warmup + repeated trial + best-of-N pattern, reducing code duplication across scenarios.

- **Consistent baseline measurement**: Updated `build_workload()` to measure the serial baseline using the same discipline (warmup + repeat + best-of-N) as the scenarios, ensuring speedup ratios remain stable.

- **Refactored all scenarios**: Updated `scenario_flat()`, `scenario_nested()`, `scenario_callbacks()`, `scenario_sleepfn()`, `scenario_executor()`, and `scenario_cancel()` to use the new `measure_best()` pattern with trial closures.

- **Import cleanup**: Moved `Callable` and `Iterator` from `typing` to `collections.abc` (Python 3.9+ style), added `gc` and `contextmanager` imports.

- **Documentation**: Enhanced module docstring to explain the measurement methodology and tuning parameters.

## Notable Implementation Details

- Trial functions are defined as closures within scenario loops to capture loop variables (e.g., `slots`, `chunksize`) while allowing `measure_best()` to call them multiple times.
- The serial baseline now reports "best of N" in output for transparency about measurement methodology.
- Default values: `--warmup=1` and `--repeat=5` provide a reasonable balance between stability and runtime.

https://claude.ai/code/session_01Wb8bZKCnwpDoLXqdsY8CsT