### PR TITLE
WIP: test: assert at most `slots` workers run concurrently

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -128,6 +128,34 @@ def create_marker(path: str) -> str:
     return "ran"
 
 
+def helper_concurrency_peak(
+    arrive_dir: str, slots: int, dwell: float = 0.05
+) -> int:
+    """Return the peak number of workers seen concurrently inside fn.
+
+    Each worker drops a per-pid marker on entry and removes it before
+    returning, so the directory's file count reflects only workers
+    currently executing.  A worker waits (bounded) until it observes at
+    least slots peers, then dwells briefly so the peak is jointly visible.
+    The caller takes the max of every worker's return value to recover the
+    true peak; with a correct slot promise it equals slots and never more.
+    """
+    marker = os.path.join(arrive_dir, str(os.getpid()))
+    create_marker(marker)
+    try:
+        deadline = time.monotonic() + 10.0
+        peak = 0
+        while time.monotonic() < deadline:
+            peak = max(peak, len(os.listdir(arrive_dir)))
+            if peak >= slots:
+                break
+            time.sleep(0.005)
+        time.sleep(dwell)
+        return max(peak, len(os.listdir(arrive_dir)))
+    finally:
+        os.remove(marker)
+
+
 def raising_at_position(i: int, fail_at: int) -> int:
     if i == fail_at:
         raise ValueError(f"fail at {fail_at}")

--- a/test/test_jobserver_design.py
+++ b/test/test_jobserver_design.py
@@ -12,12 +12,13 @@ in detail above their respective classes below.
 
 import os
 import signal
+import tempfile
 import time
 import unittest
 
 from jobserver import Blocked, Jobserver, LostResult
 
-from .helpers import start_methods
+from .helpers import TIMEOUT, helper_concurrency_peak, start_methods
 
 # ---------------------------------------------------------------------------
 # Recursive submission deadlocks without consume=0 (GitHub issue #17).
@@ -73,6 +74,42 @@ class TestDesignConsume(unittest.TestCase):
                     f = js.submit(fn=_recurse, args=(js, 2), timeout=5)
                     with self.assertRaises(Blocked):
                         f.result(timeout=10)
+
+    def test_at_most_slots_workers_run_concurrently(self) -> None:
+        """At most slots workers execute fn at once -- the slot promise.
+
+        Existing tests cover the admission gate (the over-budget submit
+        raises Blocked); this observes execution directly.  With more work
+        than slots, the peak number of workers simultaneously inside fn
+        equals slots and never exceeds it.  A slot is held across fn (it is
+        returned only once the result is received, after fn returns), so a
+        finished-but-still-exiting worker never lets an extra fn run.
+        """
+        slots = 3
+        for method in start_methods():
+            with self.subTest(method=method):
+                with tempfile.TemporaryDirectory() as arrive_dir:
+                    with Jobserver(context=method, slots=slots) as js:
+                        futures = [
+                            js.submit(
+                                fn=helper_concurrency_peak,
+                                args=(arrive_dir, slots),
+                                timeout=TIMEOUT,
+                            )
+                            for _ in range(3 * slots)
+                        ]
+                        peaks = [f.result(timeout=TIMEOUT) for f in futures]
+                observed = max(peaks)
+                self.assertLessEqual(
+                    observed,
+                    slots,
+                    f"{observed} workers ran at once; slots={slots}",
+                )
+                self.assertEqual(
+                    observed,
+                    slots,
+                    f"slots under-utilized: peak {observed} < {slots}",
+                )
 
     def test_consume_0_permits_arbitrary_depth(self) -> None:
         """consume=0 is the implicit free token, avoiding deadlock."""


### PR DESCRIPTION
## What

Adds a single test, `test_at_most_slots_workers_run_concurrently`, plus the
`helper_concurrency_peak` helper it relies on. No production code changes.

## Why

The slot count is a concurrency promise — no more than `slots` workers execute
`fn` at once — but the suite only ever checked the *admission gate*: that an
over-budget `submit()` raises `Blocked` (e.g. `test_consume_1_deadlocks_beyond_slot_count`).
Nothing observed the execution itself, so a slot-accounting bug that let an
extra worker actually run, or one that serialized below `slots`, could slip
through green.

## How

Each worker drops a per-pid marker file on entry and removes it before
returning, so the directory's file count reflects only workers currently
inside `fn`. With more work than slots, the peak count observed across workers
must equal `slots` and never exceed it. This guards both bounds (over- and
under-utilization) and runs across start methods via `start_methods()`.

Because a slot is held across `fn` (it is released only once the result is
received, after `fn` returns), a finished-but-still-exiting worker never lets
an extra `fn` run — so the assertion is exact.

## Test

`./ci` is green on this branch (286 tests, ruff/mypy/black clean, sdist builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhHXBoZVEpLBojMH7rceeM)_