### PR TITLE
Fix __call__ name collision when forwarding a kwarg named 'fn'

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -1046,7 +1046,7 @@ class Jobserver:
     def __exit__(self, *exc: Any) -> None:
         self._resources.__exit__(*exc)
 
-    def __call__(self, fn: Callable[..., T], *args, **kwargs) -> Future[T]:
+    def __call__(self, fn: Callable[..., T], /, *args, **kwargs) -> Future[T]:
         """
         Submit running fn(*args, **kwargs) to this Jobserver.
 

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -36,6 +36,7 @@ from .helpers import (
     helper_noop,
     helper_recurse,
     helper_return,
+    helper_return_kwargs,
     start_methods,
 )
 
@@ -62,6 +63,12 @@ class TestJobserverBasic(unittest.TestCase):
             self.assertEqual(4, h.result())
             self.assertEqual("2", g.result())
             self.assertEqual(3, f.result())
+
+    def test_call_kwarg_named_fn(self) -> None:
+        """__call__ forwards a kwarg named 'fn' without collision."""
+        with Jobserver() as js:
+            f = js(helper_return_kwargs, fn="sentinel")
+            self.assertEqual({"fn": "sentinel"}, f.result())
 
     def test_basic(self) -> None:
         """Basic submission up to the slot limit fires callbacks."""


### PR DESCRIPTION
## Summary

- Make the `fn` parameter of `Jobserver.__call__` positional-only (`/`) so callers can pass `fn=...` as a keyword argument to the submitted callable without colliding with `__call__`'s own parameter.
- Add a regression test that exercises `js(helper_return_kwargs, fn="sentinel")`.

## Test plan

- [x] New test `test_call_kwarg_named_fn` fails before the fix (`TypeError: got multiple values for argument 'fn'`)
- [x] New test passes after the fix
- [x] Full CI suite passes (286 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWopXfwpunCZHDfVapTGbY

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWopXfwpunCZHDfVapTGbY)_