### PR TITLE
Make `fn` parameter positional-only in callback functions

### DIFF
--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -231,7 +231,7 @@ _PRIORITY_USER = 1
 _PRIORITY_AFTER = 2
 
 
-def _callback_wrapper(seqno: int, fn, *args, **kwargs) -> None:
+def _callback_wrapper(seqno: int, fn, /, *args, **kwargs) -> None:
     """Call fn(*args, **kwargs) wrapping any Exception in CallbackRaised.
 
     The seqno is the when_done(...) sequence number from registering fn
@@ -339,7 +339,7 @@ class Future(Generic[T]):
                 source=self,
             )
 
-    def when_done(self, fn: Callable, *args: Any, **kwargs: Any) -> int:
+    def when_done(self, fn: Callable, /, *args: Any, **kwargs: Any) -> int:
         """
         Register fn(*args, **kwargs) for execution after Future.done(...).
 

--- a/test/test_jobserver_callbacks.py
+++ b/test/test_jobserver_callbacks.py
@@ -361,3 +361,16 @@ class TestJobserverCallbacks(unittest.TestCase):
             f.when_done(on_done)
             self.assertEqual(1, f.result(timeout=5))
             self.assertEqual([42], results)
+
+    def test_when_done_kwarg_named_fn(self) -> None:
+        """when_done() forwards a kwarg named 'fn' without collision."""
+        result: dict = {}
+
+        def capture(**kwargs: object) -> None:
+            result.update(kwargs)
+
+        with Jobserver(context=FAST, slots=1) as js:
+            f = js.submit(fn=helper_return, args=(1,))
+            f.when_done(capture, fn="sentinel")
+            self.assertEqual(1, f.result())
+            self.assertEqual({"fn": "sentinel"}, result)


### PR DESCRIPTION
## Summary
This change makes the `fn` parameter positional-only in callback-related functions to prevent naming collisions when users pass a keyword argument named `fn` to their callbacks.

## Key Changes
- Modified `_callback_wrapper()` function signature to make `fn` positional-only using `/` syntax
- Modified `Future.when_done()` method signature to make `fn` positional-only using `/` syntax
- Added test case `test_when_done_kwarg_named_fn()` to verify that kwargs named `fn` are properly forwarded to callbacks without collision

## Implementation Details
By making the `fn` parameter positional-only, users can now safely pass `fn` as a keyword argument to their callback functions without it being confused with the callback function itself. For example:
```python
f.when_done(capture, fn="sentinel")
```
The `fn="sentinel"` kwarg is now correctly forwarded to the `capture` callback instead of conflicting with the `fn` parameter that specifies which function to call.

https://claude.ai/code/session_01SWopXfwpunCZHDfVapTGbY