### PR TITLE
test: cover executor forward progress under slot saturation

### DIFF
--- a/test/test_executor_concurrency.py
+++ b/test/test_executor_concurrency.py
@@ -54,6 +54,38 @@ class TestConcurrencyStress(unittest.TestCase):
                 results = [f.result(timeout=TIMEOUT) for f in futures]
             self.assertEqual(list(range(n)), results)
 
+    def test_drains_saturating_work_to_completion(self) -> None:
+        """Executor makes forward progress by recycling a saturated slot.
+
+        On a single-slot executor, run map() (recycling the lone slot
+        across several workers), then hold that slot with one task while a
+        second queues PENDING behind it, and block on the second's result,
+        the holder's result, and a wait=True shutdown at exit.  Forward
+        progress requires the dispatcher to reap the finished holder and
+        recycle its slot -- the end-to-end path examples/ex12 exercises but
+        the unit suite otherwise covers only piecewise: saturation that
+        shuts down without waiting, and result-waiting with slack slots.  A
+        regression that breaks the reap deadlocks here, not merely fails a
+        state check.  Exercised across every start method.
+        """
+        for method in start_methods(threaded=True):
+            with self.subTest(method=method):
+                with Jobserver(context=method, slots=1) as js:
+                    with JobserverExecutor(js) as exe:
+                        # map() recycles the lone slot across workers, priming
+                        # the dispatcher's state for the reuse that follows.
+                        self.assertEqual(
+                            list(exe.map(len, ["a", "bb", "ccc"])),
+                            [1, 2, 3],
+                        )
+                        # holder occupies the lone slot; follow queues behind.
+                        holder = exe.submit(time.sleep, 0.1)
+                        follow = exe.submit(len, (1, 2, 3))
+                        # follow runs only once holder's slot recycles.
+                        self.assertEqual(follow.result(timeout=TIMEOUT), 3)
+                        self.assertIsNone(holder.result(timeout=TIMEOUT))
+                    # with-exit -> shutdown(wait=True) returns, no hang.
+
     def test_mixed_workload(self) -> None:
         """Mixed workload: success, exception, cancel, death."""
         with Jobserver(context=FAST, slots=4) as js:


### PR DESCRIPTION
## What

Adds one executor test, `test_drains_saturating_work_to_completion`, to `test/test_executor_concurrency.py`. Test-only; no production changes.

## Why

The suite covered the executor's slot dynamics only *piecewise*:

- saturation, then `shutdown(wait=False, cancel_futures=True)` — never waits for the slot to recycle (`test_pending_when_slots_full`);
- result-waiting, but with slack slots so nothing must be reaped to progress (`test_repeated_cycles`, etc.).

The *intersection* — blocking for completion of work that **saturates** the slots, which requires the dispatcher to reap a finished worker and recycle its slot — was exercised only by `examples/ex12`, run end-to-end by `./ci`. A change that breaks slot reclamation therefore passed every unit test while deadlocking the example.

## What it does

On a single-slot `JobserverExecutor`: run `map()` (recycling the lone slot across workers), then hold that slot with one task while a second queues behind it, and block on both results plus the `wait=True` shutdown at exit. Forward progress requires reaping each finished worker and recycling its slot. Runs across start methods via `start_methods(threaded=True)`.

## Validation

It genuinely closes the gap rather than being vacuous: it **passes** on the current blocking reap (~1.4s) and **deadlocks** under a non-blocking, sentinel-driven reap that the rest of the suite waves through. Lint/format clean; the executor suites run 99 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhHXBoZVEpLBojMH7rceeM)_