### PR TITLE
docs: note executor's dependency on synchronous slot restoration

### DIFF
--- a/draft/CONSTRAINTS.md
+++ b/draft/CONSTRAINTS.md
@@ -38,6 +38,22 @@ is not, on its own, the fastest option.
    which deadlocks the executor. This is what forces the *blocking* join
    rather than a deferred, sentinel-driven completion.
 
+   The executor splits work across two process contexts sharing one
+   `slots` pipe: `map()` runs `js.map()` synchronously in the **caller**
+   process, while `submit()` dispatches through the long-lived
+   **dispatcher** process. A slot consumed by a map worker in the caller
+   must become available to a submit worker spawned by the dispatcher, and
+   vice versa -- but neither process can reap the other's children. This
+   only works because `js.map()` honors a contract: **by the time it
+   returns, its workers are fully reaped and their slots are back in the
+   pipe.** Master satisfies this for free via the blocking `join()`; a
+   deferred reap that lets `map()` return with a recv'd-but-unexited worker
+   strands that worker's slot across the process boundary and hangs the
+   executor. The fix for such a completion-path change therefore belongs in
+   the Jobserver (restore the synchronous "slots back before `map()`
+   returns" contract), not in the executor: there is no isolatable executor
+   bug, only an implicit dependency on this Jobserver guarantee.
+
 ## Supporting constraints
 
 - **No background threads** -- the exit wait cannot be offloaded to a


### PR DESCRIPTION
Expands constraint (5) in `draft/CONSTRAINTS.md` to make explicit a coupling that was previously implicit.

`JobserverExecutor` splits work across two process contexts sharing one `slots` pipe:

- `map()` runs `js.map()` synchronously in the **caller** process,
- `submit()` dispatches through the long-lived **dispatcher** process.

A slot consumed by a map worker in the caller must become available to a submit worker spawned by the dispatcher (and vice versa), yet neither process can reap the other's children. This only works because `js.map()` honors a contract: by the time it returns, its workers are fully reaped and their slots are back in the pipe. Master satisfies this for free via the blocking `join()`.

A deferred, sentinel-driven reap that lets `map()` return with a recv'd-but-unexited worker strands that worker's slot across the process boundary and hangs the executor. The note records that the fix for any such completion-path change belongs in the Jobserver (restore the synchronous "slots back before `map()` returns" contract), **not** in the executor — there is no isolatable executor bug, only an implicit dependency on this Jobserver guarantee.

Documentation only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhHXBoZVEpLBojMH7rceeM)_