### PR TITLE
Replace flaky returned-Connection test with deterministic branch tests (#410)

### DIFF
--- a/test/helpers.py
+++ b/test/helpers.py
@@ -180,12 +180,6 @@ def helper_marker_return(directory: str, arg: T) -> T:
     return arg
 
 
-def helper_return_connection(context):
-    """Return a live Connection that pickles but cannot rebuild remotely."""
-    recv, _send = context.Pipe(duplex=False)
-    return recv
-
-
 class HelperRaiseOnUnpickle:
     """A value that pickles cleanly in the child but raises in the parent.
 
@@ -209,6 +203,31 @@ class HelperRaiseOnUnpickle:
 def helper_return_raise_on_unpickle(klass: type) -> HelperRaiseOnUnpickle:
     """Return a value whose __setstate__ raises klass() in the parent."""
     return HelperRaiseOnUnpickle(klass)
+
+
+class HelperReconstructOnUnpickle:
+    """A value that pickles in the child and rebuilds cleanly in the parent.
+
+    The deterministic success analogue of HelperRaiseOnUnpickle: __setstate__
+    runs in the parent and restores the carried payload rather than raising,
+    standing in for a returned resource whose remote rebuild succeeds.
+    """
+
+    def __init__(self, payload: typing.Any) -> None:
+        self.payload = payload
+
+    def __getstate__(self) -> dict:
+        return {"payload": self.payload}
+
+    def __setstate__(self, state: dict) -> None:
+        self.payload = state["payload"]
+
+
+def helper_return_reconstruct_on_unpickle(
+    payload: typing.Any,
+) -> HelperReconstructOnUnpickle:
+    """Return a value whose __setstate__ rebuilds payload in the parent."""
+    return HelperReconstructOnUnpickle(payload)
 
 
 def helper_raise(klass: type, *args) -> typing.NoReturn:

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -21,6 +21,7 @@ import time
 import typing
 import unittest
 from multiprocessing import get_context
+from multiprocessing.connection import Connection
 from multiprocessing.reduction import ForkingPickler
 
 from jobserver import (
@@ -901,17 +902,36 @@ class TestResultNotReconstructable(unittest.TestCase):
         "fork" in start_methods(), "requires fork start method"
     )
     def test_returned_connection_does_not_leak_filenotfounderror(self) -> None:
-        """Returning a live Connection pickles in the child but fails to
-        rebuild in the parent; report it via RuntimeError rather than
-        leaking FileNotFoundError from recv()."""
+        """Returning a live Connection races the child's resource-sharer
+        thread (which serves the FD over a Unix socket) against the child's
+        exit, so the parent's rebuild has three timing-dependent outcomes,
+        all legitimate (#303, #410):
+
+          * the rebuild raises FileNotFoundError, reported as
+            RuntimeError("Result not reconstructable: ...");
+          * the resource sharer dies mid-handshake, the result pipe closes
+            with EOF, reported as LostResult; or
+          * the FD handshake wins and a live Connection rebuilds.
+
+        The invariant under test is that every outcome is a clean library
+        result; a raw OS error (e.g. FileNotFoundError) must never leak out
+        of result().  Any such leak is not caught below and fails the test.
+        """
         # Keep the context object: it is handed to the worker to build a
         # Connection, so it cannot collapse to a bare start-method string.
         context = get_context("fork")
         with Jobserver(context=context, slots=2) as js:
             future = js.submit(fn=helper_return_connection, args=(context,))
-            with self.assertRaises(RuntimeError) as ctx:
-                future.result(timeout=10)
-        self.assertIn("not reconstructable", str(ctx.exception))
+            try:
+                result = future.result(timeout=10)
+            except RuntimeError as e:
+                self.assertIn("not reconstructable", str(e))
+            except LostResult:
+                pass  # resource sharer lost the race; pipe closed with EOF
+            else:
+                # The FD handshake won: a usable Connection rebuilt cleanly.
+                self.assertIsInstance(result, Connection)
+                result.close()
 
     def test_worker_closes_send_pipe_yields_lost_result(self) -> None:
         """A worker that sabotages its result pipe produces LostResult."""

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -20,8 +20,6 @@ import threading
 import time
 import typing
 import unittest
-from multiprocessing import get_context
-from multiprocessing.connection import Connection
 from multiprocessing.reduction import ForkingPickler
 
 from jobserver import (
@@ -38,6 +36,7 @@ from jobserver._queue import SPSCQueue
 
 from .helpers import (
     TIMEOUT,
+    HelperReconstructOnUnpickle,
     helper_callback,
     helper_close_own_pipe,
     helper_current_process_name,
@@ -51,9 +50,9 @@ from .helpers import (
     helper_preexec_suppressing_cm,
     helper_raise,
     helper_return,
-    helper_return_connection,
     helper_return_kwargs,
     helper_return_raise_on_unpickle,
+    helper_return_reconstruct_on_unpickle,
     start_methods,
 )
 
@@ -896,42 +895,65 @@ class TestKwargsNameCollisions(unittest.TestCase):
 
 class TestResultNotReconstructable(unittest.TestCase):
     """A value that pickles in the child but cannot be rebuilt in the
-    parent must surface a clean library error, not a raw OS error (#303)."""
+    parent must surface a clean library error, not a raw OS error (#303).
 
-    @unittest.skipUnless(
-        "fork" in start_methods(), "requires fork start method"
-    )
-    def test_returned_connection_does_not_leak_filenotfounderror(self) -> None:
-        """Returning a live Connection races the child's resource-sharer
-        thread (which serves the FD over a Unix socket) against the child's
-        exit, so the parent's rebuild has three timing-dependent outcomes,
-        all legitimate (#303, #410):
+    Returning a live Connection was the original real-world trigger, but it
+    is inherently flaky: rebuilding the Connection in the parent races the
+    child's resource-sharer thread against the child's exit, so the same
+    submission can take any of three branches (#410).  These tests pin each
+    branch deterministically by returning a value whose __setstate__ chooses
+    the outcome -- no resource sharer, no thread, no race:
 
-          * the rebuild raises FileNotFoundError, reported as
-            RuntimeError("Result not reconstructable: ...");
-          * the resource sharer dies mid-handshake, the result pipe closes
-            with EOF, reported as LostResult; or
-          * the FD handshake wins and a live Connection rebuilds.
+      * raising a non-EOF error (e.g. FileNotFoundError) -> RuntimeError;
+      * raising EOFError, indistinguishable from an empty pipe -> LostResult;
+      * rebuilding cleanly -> the value is returned intact.
+    """
 
-        The invariant under test is that every outcome is a clean library
-        result; a raw OS error (e.g. FileNotFoundError) must never leak out
-        of result().  Any such leak is not caught below and fails the test.
-        """
-        # Keep the context object: it is handed to the worker to build a
-        # Connection, so it cannot collapse to a bare start-method string.
-        context = get_context("fork")
-        with Jobserver(context=context, slots=2) as js:
-            future = js.submit(fn=helper_return_connection, args=(context,))
-            try:
-                result = future.result(timeout=10)
-            except RuntimeError as e:
-                self.assertIn("not reconstructable", str(e))
-            except LostResult:
-                pass  # resource sharer lost the race; pipe closed with EOF
-            else:
-                # The FD handshake won: a usable Connection rebuilt cleanly.
-                self.assertIsInstance(result, Connection)
-                result.close()
+    def test_unreconstructable_result_reports_runtime_error(self) -> None:
+        """A result that pickles in the child but raises a non-EOF error
+        while rebuilding in the parent surfaces as RuntimeError rather than
+        leaking the raw OS error (#303); the deterministic analogue of a
+        returned Connection whose rebuild hits FileNotFoundError (#410)."""
+        for method in start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=method, slots=2) as js:
+                    f = js.submit(
+                        fn=helper_return_raise_on_unpickle,
+                        args=(FileNotFoundError,),
+                    )
+                    with self.assertRaises(RuntimeError) as ctx:
+                        f.result(timeout=TIMEOUT)
+                    self.assertIn("not reconstructable", str(ctx.exception))
+
+    def test_unpickle_eoferror_reports_lost_result(self) -> None:
+        """An EOFError raised while rebuilding the result is indistinguishable
+        from the result pipe closing empty, so it surfaces as LostResult; the
+        deterministic analogue of a returned Connection whose resource sharer
+        dies mid-handshake (#410)."""
+        for method in start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=method, slots=2) as js:
+                    f = js.submit(
+                        fn=helper_return_raise_on_unpickle,
+                        args=(EOFError,),
+                    )
+                    with self.assertRaises(LostResult):
+                        f.result(timeout=TIMEOUT)
+
+    def test_reconstructable_result_round_trips(self) -> None:
+        """A result whose __setstate__ rebuilds cleanly in the parent is
+        returned intact; the deterministic analogue of a returned Connection
+        whose FD handshake wins (#410)."""
+        for method in start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=method, slots=2) as js:
+                    f = js.submit(
+                        fn=helper_return_reconstruct_on_unpickle,
+                        args=("rebuilt",),
+                    )
+                    result = f.result(timeout=TIMEOUT)
+                    self.assertIsInstance(result, HelperReconstructOnUnpickle)
+                    self.assertEqual("rebuilt", result.payload)
 
     def test_worker_closes_send_pipe_yields_lost_result(self) -> None:
         """A worker that sabotages its result pipe produces LostResult."""


### PR DESCRIPTION
Closes #410.

## Problem

`test_returned_connection_does_not_leak_filenotfounderror` intermittently failed on Python 3.12. It returned a live `Connection` to drive the #303 contract ("a result pickles in the child but cannot be rebuilt in the parent → surface a clean library error, not a raw OS error"). But rebuilding a `Connection` in the parent races the child's resource-sharer thread (which serves the FD over a Unix socket) against the child's exit, so the same submission nondeterministically took **one of three** branches in `Future._drain`'s `recv()`, while the test asserted only one.

Reproduced under CPU contention (mimicking a loaded CI runner): in 6000 in-process iterations the outcome split ~97.1% `RuntimeError`, ~2.4% `LostResult`, ~0.5% clean success — and the real unittest failed ~1/120 under load with the exact traceback from the issue.

## Fix

A `Connection` is not required to exercise the contract. Replace the single flaky test with three deterministic tests that pin each `recv()` branch by returning a value whose `__setstate__` chooses the outcome — no resource sharer, no thread, no race, and valid on **every** start method (the old test was fork-only):

- `FileNotFoundError` in `__setstate__` → `RuntimeError("not reconstructable")`
- `EOFError` in `__setstate__` (indistinguishable from an empty pipe) → `LostResult`
- a clean rebuild → the value is returned intact

Adds `HelperReconstructOnUnpickle` for the success case and drops the now-unused `helper_return_connection`.

The two commits are kept separate intentionally: the first broadens the original test to accept any clean outcome (a stopgap), the second replaces it with the deterministic tests so the assertions are tightened rather than weakened.

## Verification

- All tests pass on every start method.
- **6000 branch-exercises under heavy CPU load → 0 failures** (where the old test failed ~1/120), plus 7/7 full-class runs under load.
- `ruff`, `mypy` (19 files), and `black` all clean.
- Full suite: 289 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)