### PR TITLE
Fix ResourceWarning: unclosed file in test_executor_lifecycle

### DIFF
--- a/test/test_executor_lifecycle.py
+++ b/test/test_executor_lifecycle.py
@@ -16,6 +16,7 @@ import concurrent.futures
 import gc
 import multiprocessing
 import os
+import pathlib
 import signal
 import tempfile
 import threading
@@ -481,7 +482,7 @@ class TestResourceLeaks(unittest.TestCase):
                     wait_until(
                         lambda: os.path.exists(pid_path), timeout=TIMEOUT
                     )
-                    worker_pid = int(open(pid_path).read())
+                    worker_pid = int(pathlib.Path(pid_path).read_text())
                     os.kill(exe._dispatcher.pid, signal.SIGKILL)
                     # Must raise BrokenExecutor well before the 60 s
                     # worker exits.


### PR DESCRIPTION
## Summary

- Replace bare `open(pid_path).read()` with `pathlib.Path(pid_path).read_text()` to avoid leaking a file handle until GC collects it

Closes #416

## Test plan

- [x] Reproduced the `ResourceWarning` with `uv run python -W all -m unittest test.test_executor_lifecycle.TestResourceLeaks.test_dispatcher_death_with_running_worker_fails_promptly`
- [x] Confirmed the warning is gone after the fix
- [x] `./ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtJjqTZMBLvzY41zDiQ5oa

---
_Generated by [Claude Code](https://claude.ai/code/session_01QtJjqTZMBLvzY41zDiQ5oa)_