### PR TITLE
Fix ResourceWarning leak to stderr from test

### DIFF
--- a/test/test_jobserver_warnings.py
+++ b/test/test_jobserver_warnings.py
@@ -50,10 +50,15 @@ class TestResourceWarning(unittest.TestCase):
             warnings.simplefilter("always")
             del js
             gc.collect()
+            del _f
+            gc.collect()
         rw = [w for w in caught if issubclass(w.category, ResourceWarning)]
-        self.assertEqual(len(rw), 1)
-        self.assertRegex(str(rw[0].message), r"Finalizing .* running Future")
-        self.assertIsNotNone(rw[0].source)
+        js_rw = [w for w in rw if "running Future" in str(w.message)]
+        self.assertEqual(len(js_rw), 1)
+        self.assertRegex(
+            str(js_rw[0].message), r"Finalizing .* running Future"
+        )
+        self.assertIsNotNone(js_rw[0].source)
 
     def test_no_warning_when_properly_closed(self) -> None:
         """__del__ is silent after the context manager cleans up."""


### PR DESCRIPTION
## Summary

- Finalize the `_f` Future inside the `catch_warnings` scope so its `__del__` warning is captured rather than leaking to stderr
- Filter assertions to the Jobserver-specific `ResourceWarning` (the Future also emits its own when finalized)

Closes #419

## Test plan

- [x] `uv run -m unittest test.test_jobserver_warnings.TestResourceWarning.test_warning_emitted_with_running_future` passes with no `ResourceWarning` on stderr
- [x] `./ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JsirA3QugMKiMXz2ifNxJV

---
_Generated by [Claude Code](https://claude.ai/code/session_01JsirA3QugMKiMXz2ifNxJV)_