### PR TITLE
Fix ResourceWarning in test_duplication_futures

### DIFF
--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -419,7 +419,8 @@ class TestJobserverBasic(unittest.TestCase):
                     if method != "fork":
                         with self.assertRaises(TypeError):
                             js.submit(fn=type, args=(f,))
-                    f.result(timeout=10)
+                    if not f.done(timeout=10):
+                        self.fail("Future not done within timeout")
 
     # No behavioral assertions made around pickling, however.
     def test_duplication_jobserver(self) -> None:

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -419,6 +419,7 @@ class TestJobserverBasic(unittest.TestCase):
                     if method != "fork":
                         with self.assertRaises(TypeError):
                             js.submit(fn=type, args=(f,))
+                    f.result(timeout=10)
 
     # No behavioral assertions made around pickling, however.
     def test_duplication_jobserver(self) -> None:


### PR DESCRIPTION
## Summary

- Drain the submitted Future via `f.result(timeout=10)` at the end of each `subTest` iteration in `test_duplication_futures`, preventing `ResourceWarning` from an uncollected Future on context-manager exit.

Closes #417

## Test plan

- [x] `uv run -m unittest test.test_jobserver_basic.TestJobserverBasic.test_duplication_futures` passes with no `ResourceWarning` on stderr
- [x] `./ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZvhmF6YaoHKM9v58JeNCX

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZvhmF6YaoHKM9v58JeNCX)_