### PR TITLE
Support arguments and keyword arguments in replace_preexec

### DIFF
--- a/examples/ex09_preexec.py
+++ b/examples/ex09_preexec.py
@@ -5,9 +5,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Example 9 shows replace_preexec with a callable and a context manager.
 
-The replace_preexec callable runs in the worker before the task function.  If
-it returns None, it acts as a plain pre-execution hook; if it returns a context
-manager, the task function runs inside it, gaining entry/exit semantics.
+The replace_preexec callable runs fn(*args, **kwargs) in the worker before the
+task function.  A non-None return is assumed to be a context manager wrapping
+the task function's execution.
 """
 
 import logging
@@ -18,11 +18,11 @@ from jobserver import Jobserver
 
 def main() -> None:
     """Shows replace_preexec with a callable and a context manager factory."""
-    with Jobserver(context="spawn", slots=2) as jobserver:
-        # Plain callable: configure logging in the worker
-        future_plain = jobserver.replace_preexec(configure_logging).submit(
-            fn=task_logger_level
-        )
+    # replace_preexec(...) configures logging in all workers
+    with Jobserver(context="spawn", slots=2).replace_preexec(
+        logging.basicConfig, level=logging.DEBUG
+    ) as jobserver:
+        future_plain = jobserver.submit(fn=task_logger_level)
         info("plain preexec: level=%s", future_plain.result())
 
         # Context manager factory: basicConfig on enter, shutdown on exit
@@ -30,11 +30,6 @@ def main() -> None:
             fn=task_logger_level,
         )
         info("context manager preexec: level=%s", future_cm.result())
-
-
-def configure_logging() -> None:
-    """A preexec callable that configures logging in the worker."""
-    logging.basicConfig(level=logging.DEBUG)
 
 
 def task_logger_level() -> int:

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -860,13 +860,22 @@ class Jobserver:
     under fork.
     """
 
-    __slots__ = ("_resources", "_envdiff", "_preexec", "_sleep")
+    __slots__ = (
+        "_resources",
+        "_envdiff",
+        "_preexec_fn",
+        "_preexec_args",
+        "_preexec_kwargs",
+        "_sleep",
+    )
 
     _resources: Resources
     # A read-only diff applied to the child's os.environ (None unsets a name).
     # Stored as a MappingProxyType so a shared sibling handle cannot mutate it.
     _envdiff: types.MappingProxyType[str, Optional[str]]
-    _preexec: Callable
+    _preexec_fn: Callable
+    _preexec_args: tuple[Any, ...]
+    _preexec_kwargs: types.MappingProxyType[str, Any]
     _sleep: Callable
 
     def __init__(
@@ -887,7 +896,9 @@ class Jobserver:
         """
         self._resources = Resources(context, slots)
         self._envdiff = types.MappingProxyType({})
-        self._preexec = noop
+        self._preexec_fn = noop
+        self._preexec_args = ()
+        self._preexec_kwargs = types.MappingProxyType({})
         self._sleep = noop
 
     def __getstate__(self) -> tuple:
@@ -903,17 +914,23 @@ class Jobserver:
         return (
             self._resources,
             dict(self._envdiff),
-            self._preexec,
+            self._preexec_fn,
+            self._preexec_args,
+            dict(self._preexec_kwargs),
             self._sleep,
         )
 
     def __setstate__(self, state: tuple) -> None:
         """Set instance state."""
-        assert isinstance(state, tuple) and len(state) == 4
-        resources, envdiff, preexec, sleep = state
+        assert isinstance(state, tuple) and len(state) == 6
+        resources, envdiff, preexec_fn, preexec_args, preexec_kwargs, sleep = (
+            state
+        )
         self._resources = resources
         self._envdiff = types.MappingProxyType(dict(envdiff))
-        self._preexec = preexec
+        self._preexec_fn = preexec_fn
+        self._preexec_args = tuple(preexec_args)
+        self._preexec_kwargs = types.MappingProxyType(dict(preexec_kwargs))
         self._sleep = sleep
 
     # Use typing.Self once Python 3.11 is the minimum version
@@ -925,7 +942,9 @@ class Jobserver:
         other = Jobserver.__new__(Jobserver)
         other._resources = self._resources
         other._envdiff = self._envdiff
-        other._preexec = self._preexec
+        other._preexec_fn = self._preexec_fn
+        other._preexec_args = self._preexec_args
+        other._preexec_kwargs = self._preexec_kwargs
         other._sleep = self._sleep
         return other
 
@@ -993,21 +1012,25 @@ class Jobserver:
 
     def replace_preexec(
         self,
-        replacement: Callable[[], Union[None, AbstractContextManager]],
+        replacement: Callable[..., Union[None, AbstractContextManager]],
         /,
+        *args: Any,
+        **kwargs: Any,
     ) -> "Jobserver":
         """
         Return a Jobserver invoking replacement in the child just before fn.
 
-        replacement() may return None (a plain pre-execution hook) or a
-        context manager that wraps fn execution with entry/exit semantics, so
-        fn runs inside it.  A context manager's __exit__ may suppress
-        exceptions from fn, in which case the result is None.  Shares this
+        The replacement(*args, **kwargs) may return None or a context
+        manager that wraps fn execution with entry/exit semantics, so fn
+        runs inside it.  A context manager's __exit__ may suppress
+        exceptions, in which case the result is None.  Shares this
         Jobserver's slots.
         """
         if callable(replacement):
             other = self.__copy__()
-            other._preexec = replacement
+            other._preexec_fn = replacement
+            other._preexec_args = args
+            other._preexec_kwargs = types.MappingProxyType(kwargs)
             return other
         raise TypeError(
             f"preexec must be callable, got {type(replacement).__name__}"
@@ -1155,13 +1178,15 @@ class Jobserver:
             process = resources.context.Process(  # type: ignore
                 target=_worker_entrypoint,
                 # Ship a plain dict: MappingProxyType is unpicklable < 3.12.
-                args=(
-                    send,
-                    dict(self._envdiff),
-                    self._preexec,
-                    fn,
-                    args,
-                    kwargs,
+                kwargs=dict(
+                    send=send,
+                    envdiff=dict(self._envdiff),
+                    preexec_fn=self._preexec_fn,
+                    preexec_args=self._preexec_args,
+                    preexec_kwargs=dict(self._preexec_kwargs),
+                    fn=fn,
+                    args=args,
+                    kwargs=kwargs,
                 ),
                 daemon=False,
                 name="Jobserver-worker",
@@ -1318,7 +1343,16 @@ class Jobserver:
         )
 
 
-def _worker_entrypoint(send, envdiff, preexec, fn, args, kwargs) -> None:
+def _worker_entrypoint(
+    send: Any,
+    envdiff: dict[str, Optional[str]],
+    preexec_fn: Callable[..., Any],
+    preexec_args: tuple[Any, ...],
+    preexec_kwargs: dict[str, Any],
+    fn: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> None:
     """
     Entry point for workers to run fn(...) due to some submit(...).
 
@@ -1345,7 +1379,7 @@ def _worker_entrypoint(send, envdiff, preexec, fn, args, kwargs) -> None:
         # pre-call value of None so the result becomes ResultWrapper(None).
         raw = None
         with ExitStack() as stack:
-            cm = preexec()
+            cm = preexec_fn(*preexec_args, **preexec_kwargs)
             if cm is not None:
                 stack.enter_context(cm)
             raw = fn(*args, **kwargs)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -290,15 +290,23 @@ def helper_preexec_fn() -> None:
     os.environ["JOBSERVER_TEST_ENVIRON"] = "PREEXEC_FN"
 
 
+def helper_setenv(key: str, value: str) -> None:
+    """Set an environment variable; picklable across start methods."""
+    os.environ[key] = value
+
+
 class HelperContextManager:
     """A picklable context manager recording entry/exit via os.environ."""
 
+    def __init__(self, key: str = "JOBSERVER_TEST_CM") -> None:
+        self._key = key
+
     def __enter__(self):
-        os.environ["JOBSERVER_TEST_CM"] = "ENTERED"
+        os.environ[self._key] = "ENTERED"
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        os.environ["JOBSERVER_TEST_CM"] = "EXITED"
+        os.environ[self._key] = "EXITED"
         return False
 
 

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -11,7 +11,6 @@ replace_sleep scheduling control, and how derived handles apply in submit().
 """
 
 import errno
-import functools
 import itertools
 import os
 import signal
@@ -36,6 +35,7 @@ from jobserver._queue import SPSCQueue
 
 from .helpers import (
     TIMEOUT,
+    HelperContextManager,
     HelperReconstructOnUnpickle,
     helper_callback,
     helper_close_own_pipe,
@@ -53,6 +53,7 @@ from .helpers import (
     helper_return_kwargs,
     helper_return_raise_on_unpickle,
     helper_return_reconstruct_on_unpickle,
+    helper_setenv,
     start_methods,
 )
 
@@ -409,9 +410,7 @@ class TestJobserverWorker(unittest.TestCase):
             with self.subTest(method=method):
                 with Jobserver(context=method, slots=1) as js:
                     f = js.replace_preexec(
-                        functools.partial(
-                            helper_raise, RuntimeError, "preexec failed"
-                        )
+                        helper_raise, RuntimeError, "preexec failed"
                     ).submit(
                         fn=helper_return,
                         args=(1,),
@@ -713,6 +712,34 @@ class TestJobserverWorker(unittest.TestCase):
                     )
                     self.assertEqual("SENTINEL", f.result(timeout=5))
 
+    def test_preexec_fn_with_args_kwargs(self) -> None:
+        """replace_preexec forwards *args and **kwargs to the callable."""
+        key = "JOBSERVER_TEST_ENVIRON"
+        self.assertIsNone(os.environ.get(key, None))
+        for method in start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=method, slots=1) as js:
+                    f = js.replace_preexec(
+                        helper_setenv, key, "VIA_ARGS"
+                    ).submit(
+                        fn=os.getenv, args=(key, "SENTINEL"), timeout=5
+                    )
+                    self.assertEqual("VIA_ARGS", f.result(timeout=5))
+
+    def test_preexec_fn_cm_with_kwargs(self) -> None:
+        """replace_preexec forwards **kwargs to a context manager factory."""
+        key = "JOBSERVER_TEST_CM_KEYED"
+        self.assertIsNone(os.environ.get(key, None))
+        for method in start_methods():
+            with self.subTest(method=method):
+                with Jobserver(context=method, slots=1) as js:
+                    f = js.replace_preexec(
+                        HelperContextManager, key=key
+                    ).submit(
+                        fn=os.getenv, args=(key, "SENTINEL"), timeout=5
+                    )
+                    self.assertEqual("ENTERED", f.result(timeout=5))
+
 
 def _make_unpicklable_result() -> object:
     """Return a locally-defined class instance that cannot be pickled."""
@@ -788,7 +815,10 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         boom = AttributeError("misbehaving connection")
         send = _RecordingSend(fail_with=boom)
         with self.assertRaises(AttributeError) as ctx:
-            _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})
+            _worker_entrypoint(
+                send, {}, lambda: None, (), {},
+                len, ((1, 2, 3),), {},
+            )
         self.assertIs(boom, ctx.exception)
         # No "not picklable" rewrap was sent in place of the real error.
         self.assertEqual([], send.payloads)
@@ -796,7 +826,10 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
     def test_picklable_result_sent_unchanged(self) -> None:
         """A picklable result rides the happy path to a single send."""
         send = _RecordingSend()
-        _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})
+        _worker_entrypoint(
+            send, {}, lambda: None, (), {},
+            len, ((1, 2, 3),), {},
+        )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
         self.assertIsInstance(wrapper, ResultWrapper)
@@ -807,7 +840,7 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         """A genuinely unpicklable result still degrades to the fallback."""
         send = _RecordingSend()
         _worker_entrypoint(
-            send, {}, lambda: None, _make_unpicklable_result, (), {}
+            send, {}, lambda: None, (), {}, _make_unpicklable_result, (), {}
         )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
@@ -822,7 +855,10 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         RecursionError that now degrades to the descriptive fallback rather
         than crashing the worker into a misleading LostResult (#343)."""
         send = _RecordingSend()
-        _worker_entrypoint(send, {}, lambda: None, _make_deep_result, (), {})
+        _worker_entrypoint(
+            send, {}, lambda: None, (), {},
+            _make_deep_result, (), {},
+        )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
         self.assertIsInstance(wrapper, ExceptionWrapper)
@@ -835,7 +871,7 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         """A __reduce__ raising RuntimeError uses the fallback (#390)."""
         send = _RecordingSend()
         _worker_entrypoint(
-            send, {}, lambda: None, _raise_reduce_runtimeerror, (), {}
+            send, {}, lambda: None, (), {}, _raise_reduce_runtimeerror, (), {}
         )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
@@ -857,14 +893,20 @@ class TestWorkerEntrypointSendBytesErrors(unittest.TestCase):
         LostResult, but without a noisy child traceback."""
         boom = OSError(errno.EBADF, "Bad file descriptor")
         send = _RecordingSend(fail_with=boom)
-        _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})
+        _worker_entrypoint(
+            send, {}, lambda: None, (), {},
+            len, ((1, 2, 3),), {},
+        )
         self.assertEqual([], send.payloads)
         self.assertTrue(send.closed)
 
     def test_broken_pipe_still_swallowed(self) -> None:
         """The original BrokenPipeError handling is preserved."""
         send = _RecordingSend(fail_with=BrokenPipeError())
-        _worker_entrypoint(send, {}, lambda: None, len, ((1, 2, 3),), {})
+        _worker_entrypoint(
+            send, {}, lambda: None, (), {},
+            len, ((1, 2, 3),), {},
+        )
         self.assertEqual([], send.payloads)
         self.assertTrue(send.closed)
 
@@ -879,6 +921,8 @@ class TestKwargsNameCollisions(unittest.TestCase):
             "send",
             "env",
             "preexec_fn",
+            "preexec_args",
+            "preexec_kwargs",
             "fn",
             "args",
             "kwargs",

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -721,9 +721,7 @@ class TestJobserverWorker(unittest.TestCase):
                 with Jobserver(context=method, slots=1) as js:
                     f = js.replace_preexec(
                         helper_setenv, key, "VIA_ARGS"
-                    ).submit(
-                        fn=os.getenv, args=(key, "SENTINEL"), timeout=5
-                    )
+                    ).submit(fn=os.getenv, args=(key, "SENTINEL"), timeout=5)
                     self.assertEqual("VIA_ARGS", f.result(timeout=5))
 
     def test_preexec_fn_cm_with_kwargs(self) -> None:
@@ -735,9 +733,7 @@ class TestJobserverWorker(unittest.TestCase):
                 with Jobserver(context=method, slots=1) as js:
                     f = js.replace_preexec(
                         HelperContextManager, key=key
-                    ).submit(
-                        fn=os.getenv, args=(key, "SENTINEL"), timeout=5
-                    )
+                    ).submit(fn=os.getenv, args=(key, "SENTINEL"), timeout=5)
                     self.assertEqual("ENTERED", f.result(timeout=5))
 
 
@@ -816,8 +812,14 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         send = _RecordingSend(fail_with=boom)
         with self.assertRaises(AttributeError) as ctx:
             _worker_entrypoint(
-                send, {}, lambda: None, (), {},
-                len, ((1, 2, 3),), {},
+                send,
+                {},
+                lambda: None,
+                (),
+                {},
+                len,
+                ((1, 2, 3),),
+                {},
             )
         self.assertIs(boom, ctx.exception)
         # No "not picklable" rewrap was sent in place of the real error.
@@ -827,8 +829,14 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         """A picklable result rides the happy path to a single send."""
         send = _RecordingSend()
         _worker_entrypoint(
-            send, {}, lambda: None, (), {},
-            len, ((1, 2, 3),), {},
+            send,
+            {},
+            lambda: None,
+            (),
+            {},
+            len,
+            ((1, 2, 3),),
+            {},
         )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
@@ -856,8 +864,14 @@ class TestWorkerEntrypointPickleFallback(unittest.TestCase):
         than crashing the worker into a misleading LostResult (#343)."""
         send = _RecordingSend()
         _worker_entrypoint(
-            send, {}, lambda: None, (), {},
-            _make_deep_result, (), {},
+            send,
+            {},
+            lambda: None,
+            (),
+            {},
+            _make_deep_result,
+            (),
+            {},
         )
         self.assertEqual(1, len(send.payloads))
         wrapper = ForkingPickler.loads(send.payloads[0])
@@ -894,8 +908,14 @@ class TestWorkerEntrypointSendBytesErrors(unittest.TestCase):
         boom = OSError(errno.EBADF, "Bad file descriptor")
         send = _RecordingSend(fail_with=boom)
         _worker_entrypoint(
-            send, {}, lambda: None, (), {},
-            len, ((1, 2, 3),), {},
+            send,
+            {},
+            lambda: None,
+            (),
+            {},
+            len,
+            ((1, 2, 3),),
+            {},
         )
         self.assertEqual([], send.payloads)
         self.assertTrue(send.closed)
@@ -904,8 +924,14 @@ class TestWorkerEntrypointSendBytesErrors(unittest.TestCase):
         """The original BrokenPipeError handling is preserved."""
         send = _RecordingSend(fail_with=BrokenPipeError())
         _worker_entrypoint(
-            send, {}, lambda: None, (), {},
-            len, ((1, 2, 3),), {},
+            send,
+            {},
+            lambda: None,
+            (),
+            {},
+            len,
+            ((1, 2, 3),),
+            {},
         )
         self.assertEqual([], send.payloads)
         self.assertTrue(send.closed)


### PR DESCRIPTION
## Summary
This change extends the `replace_preexec` API to support passing arguments and keyword arguments to the preexec callable, enabling more flexible pre-execution hooks without requiring `functools.partial` or lambda wrappers.

## Key Changes

- **Extended `replace_preexec` signature**: Now accepts `*args` and `**kwargs` that are forwarded to the replacement callable
  - Changed from `replacement: Callable[[], ...]` to `replacement: Callable[..., ...]`
  - Signature: `replace_preexec(replacement, /, *args, **kwargs)`

- **Updated `Jobserver` internal state management**:
  - Split `_preexec` into three separate slots: `_preexec_fn`, `_preexec_args`, and `_preexec_kwargs`
  - Updated `__slots__`, `__getstate__`, `__setstate__`, and `__copy__` to handle the new structure
  - Increased pickle state tuple length from 4 to 6 elements

- **Modified `_worker_entrypoint` signature**:
  - Changed from positional `args` tuple to keyword arguments for clarity
  - Now accepts `preexec_args` and `preexec_kwargs` separately
  - Invokes preexec as `preexec_fn(*preexec_args, **preexec_kwargs)` instead of `preexec()`

- **Updated `submit` method**:
  - Changed Process creation to use keyword arguments instead of positional args
  - Passes preexec components separately to the worker entrypoint

- **Enhanced test helpers**:
  - Added `helper_setenv` function for testing argument passing
  - Updated `HelperContextManager` to accept optional `key` parameter for testing kwargs

## Notable Implementation Details

- Arguments and keyword arguments are stored as immutable types (`tuple` and `MappingProxyType`) to maintain thread-safety and prevent accidental mutations
- The change is backward compatible at the API level—existing code using `replace_preexec(callable)` continues to work
- Updated example code demonstrates the new capability with `logging.basicConfig` being configured via kwargs
- All pickle state handling properly converts between mutable and immutable types for serialization

https://claude.ai/code/session_01BZzr5ZXButJmqQmRFuCqty