### PR TITLE
Pre-release quality pass

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+# draft/ holds internal design notes, an unimplemented-feature plan, and a
+# benchmark harness; none belong in the published source distribution.
+prune draft

--- a/README.md
+++ b/README.md
@@ -96,6 +96,6 @@ Examples
 Testing
 -------
 
-Tested with CPython 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14 per [ci](ci) script.<br>
+Tested with CPython 3.9, 3.10, 3.11, 3.12, 3.13, and 3.14 with [ci](ci) script.<br>
 Implementation passes both PEP 8 (per `ruff`) and type-hinting (per `mypy`).<br>
 [![Build Status](https://circleci.com/gh/RhysU/jobserver.svg?style=shield)](https://app.circleci.com/pipelines/github/RhysU/jobserver)

--- a/draft/bench.py
+++ b/draft/bench.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/ex01_basic.py
+++ b/examples/ex01_basic.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/ex02_lifecycle.py
+++ b/examples/ex02_lifecycle.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/ex03_nested.py
+++ b/examples/ex03_nested.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/ex04_cancel.py
+++ b/examples/ex04_cancel.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/ex05_death.py
+++ b/examples/ex05_death.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/ex06_sleep.py
+++ b/examples/ex06_sleep.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/ex07_callbacks.py
+++ b/examples/ex07_callbacks.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/ex08_environment.py
+++ b/examples/ex08_environment.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/ex09_preexec.py
+++ b/examples/ex09_preexec.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/ex10_timeouts.py
+++ b/examples/ex10_timeouts.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/ex11_pdeathsig.py
+++ b/examples/ex11_pdeathsig.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/examples/ex12_executor.py
+++ b/examples/ex12_executor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/jobserver/__init__.py
+++ b/src/jobserver/__init__.py
@@ -39,6 +39,8 @@ Implementation passes both PEP 8 (per ruff) and type-hinting (per mypy).
 Refer to https://github.com/RhysU/jobserver for the upstream project.
 """
 
+from importlib.metadata import PackageNotFoundError, version
+
 from ._executor import JobserverExecutor
 from ._jobserver import (
     Blocked,
@@ -47,6 +49,12 @@ from ._jobserver import (
     Jobserver,
     LostResult,
 )
+
+try:
+    __version__ = version("jobserver")
+except PackageNotFoundError:  # pragma: no cover
+    # An uninstalled source tree has no distribution metadata to query.
+    __version__ = "0.0.0+unknown"
 
 __all__ = (
     "Blocked",

--- a/src/jobserver/_compat.py
+++ b/src/jobserver/_compat.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/jobserver/_executor.py
+++ b/src/jobserver/_executor.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/jobserver/_jobserver.py
+++ b/src/jobserver/_jobserver.py
@@ -399,11 +399,12 @@ class Future(Generic[T]):
 
     def done(self, timeout: Optional[float] = 0) -> bool:
         """
-        Never raising Blocked, returns True if result(timeout=0) must succeed.
+        Never raising Blocked, returns True if result(timeout=0) won't block.
 
         Returns whether completion can be confirmed within the timeout.
-        Timeout is given in seconds with None meaning to block indefinitely.
-        Never raises Blocked but instead returns False on unavailable result.
+        True means result() will not raise Blocked. Timeout is given in
+        seconds with None meaning to block indefinitely. Never raises
+        Blocked but instead returns False on unavailable result.
 
         May raise CallbackRaised from at most one registered callback.
         See CallbackRaised documentation for callback error semantics.
@@ -421,7 +422,7 @@ class Future(Generic[T]):
         signal: Union[None, int, signal.Signals] = None,
     ) -> bool:
         """
-        Waiting at most timeout, return True if result(timeout=0) must succeed.
+        Waiting at most timeout, return True if result(timeout=0) won't block.
 
         First, sends any provided signal to any underlying, running process.
         Second, returns True once the result pipe yields a result or closes

--- a/src/jobserver/_request.py
+++ b/src/jobserver/_request.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/src/jobserver/_response.py
+++ b/src/jobserver/_response.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/test_executor_basic.py
+++ b/test/test_executor_basic.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/test_executor_concurrency.py
+++ b/test/test_executor_concurrency.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/test_executor_lifecycle.py
+++ b/test/test_executor_lifecycle.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/test_jobserver_design.py
+++ b/test/test_jobserver_design.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/test_jobserver_slots.py
+++ b/test/test_jobserver_slots.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -72,7 +72,3 @@ class TestLargeSlots(unittest.TestCase):
         for bad in ("2", 2.0):
             with self.assertRaises(TypeError):
                 Jobserver(context=FAST, slots=bad)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/test_py_typed.py
+++ b/test/test_py_typed.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/test_repr.py
+++ b/test/test_repr.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2019-2026 Rhys Ulerich <rhys.ulerich@gmail.com>
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""The package exposes a usable __version__ string."""
+
+import unittest
+from importlib.metadata import version
+
+import jobserver
+
+
+class TestVersion(unittest.TestCase):
+    """jobserver.__version__ is present and matches distribution metadata."""
+
+    def test_version_is_nonempty_str(self) -> None:
+        """__version__ must be a non-empty string."""
+        # Deliberately format-agnostic: a development checkout reports
+        # something like '0.1.dev50+g025f09e26', so asserting an X.Y.Z
+        # release shape here would fail on untagged builds.
+        self.assertIsInstance(jobserver.__version__, str)
+        self.assertTrue(jobserver.__version__)
+
+    def test_version_matches_metadata(self) -> None:
+        """__version__ must agree with importlib.metadata for the install."""
+        # The test suite runs against an installed (editable) jobserver, so
+        # the distribution metadata is queryable; the uninstalled-tree
+        # fallback in __init__ is not exercised here.
+        self.assertEqual(jobserver.__version__, version("jobserver"))


### PR DESCRIPTION
## Summary

A final quality/cleanup pass ahead of a release. CI is green (294 tests OK; examples, `ruff`, `mypy`, `black --check`, and the sdist build all pass), and all examples were verified to run from a clean install of the built sdist.

## Changes

- **Expose `jobserver.__version__`** via `importlib.metadata.version("jobserver")`, with a `PackageNotFoundError` → `"0.0.0+unknown"` fallback for an uninstalled source tree. Adds `test/test_version.py`, deliberately format-agnostic so it passes on untagged development versions (e.g. `0.1.devN+g…`).
- **Prune `draft/` from the source distribution** via a new `MANIFEST.in`. The directory holds internal design notes, an unimplemented-feature plan, and a benchmark harness — none of which belong in the published sdist. Verified absent from the rebuilt artifact.
- **Normalize copyright headers** to the `2019-2026` project span across all source, test, and draft files.
- **README:** "Tested … per `ci` script" → "with `ci` script".
- **`Future.done()` / `Future.wait()` docstrings:** replace the misleading "must succeed" with "won't block", and note that a `True` only means `result()` will not raise `Blocked`.
- **Remove dead `if __name__ == "__main__"` guards** from test modules (the suite runs via `unittest` discovery). Examples keep theirs since they are run as scripts.

## Not included (release-time, by design)

- Tagging the release so `setuptools-scm` emits a clean public version instead of the `.devN+g…` local version PyPI rejects.
- Reconciling the `Development Status :: 5 - Production/Stable` classifier with the tagged version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqPLuGQG27MbUS32FJK45m)_