### PR TITLE
Add CHANGELOG.md for the initial PyPI release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v3.0
+
+- Initial PyPI release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
 Homepage = "https://github.com/RhysU/jobserver"
 Repository = "https://github.com/RhysU/jobserver"
 Issues = "https://github.com/RhysU/jobserver/issues"
+Changelog = "https://github.com/RhysU/jobserver/blob/master/CHANGELOG.md"
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
Adds a `CHANGELOG.md` ahead of the `v3.0` tag and links it from `pyproject.toml`.

- New `CHANGELOG.md` with a `v3.0` section reading "Initial PyPI release".
- Added a `Changelog` entry under `[project.urls]` pointing at the file on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDFUyVp92qSAK8fp3m2CZz)_