### PR TITLE
Prune CI- and development-only files from the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,8 @@
 # draft/ holds internal design notes, an unimplemented-feature plan, and a
 # benchmark harness; none belong in the published source distribution.
 prune draft
+
+# Development- and CI-only files with no purpose in an installable sdist.
+prune .circleci
+exclude .gitignore
+exclude .coveragerc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ prune draft
 prune .circleci
 exclude .gitignore
 exclude .coveragerc
+exclude ci


### PR DESCRIPTION
Trims files from the published source distribution that have no purpose once installed.

`MANIFEST.in` now prunes:
- `.circleci/`
- `.gitignore`
- `.coveragerc`
- `ci`

Retained intentionally: `README.md`, `LICENSE`, `examples/`, and `test/`.

Verified by building the sdist locally and confirming the excluded paths are absent while the retained ones remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)