### PR TITLE
Add Quick Start section to README

### DIFF
--- a/README-PyPI.md
+++ b/README-PyPI.md
@@ -5,6 +5,20 @@ Jobserver
 
 A nestable Jobserver with thread-safe futures, callbacks, and type-hinting
 
+Quick Start
+-----------
+
+Try it interactively, for example with `uv`:
+
+```
+$ uv run --with jobserver --with IPython python -m IPython --no-banner
+In [1]: from jobserver import Jobserver
+In [2]: jobserver = Jobserver()
+In [3]: future = jobserver(len, (0, 1, 2))
+In [4]: future.result()
+Out[4]: 3
+```
+
 Purpose
 -------
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,21 @@ Jobserver
 
 A nestable Jobserver with thread-safe futures, callbacks, and type-hinting
 
+Quick Start
+-----------
+
 This package is [available from PyPI](https://pypi.org/project/jobserver/): `pip install jobserver`
+
+Try it interactively, for example with `uv`:
+
+```
+$ uv run --with jobserver --with IPython python -m IPython --no-banner
+In [1]: from jobserver import Jobserver
+In [2]: jobserver = Jobserver()
+In [3]: future = jobserver(len, (0, 1, 2))
+In [4]: future.result()
+Out[4]: 3
+```
 
 Purpose
 -------


### PR DESCRIPTION
## Summary

Adds a **Quick Start** section near the top of the README so a reader can install and try the package immediately. It leads with the PyPI install line and shows a short interactive `uv`/IPython session that submits a job and collects its result:

```
$ uv run --with jobserver --with IPython python -m IPython --no-banner
In [1]: from jobserver import Jobserver
In [2]: jobserver = Jobserver()
In [3]: future = jobserver(len, (0, 1, 2))
In [4]: future.result()
Out[4]: 3
```

The PyPI-flavored `README-PyPI.md` is regenerated from the same source (it omits the `pip install` line, which is redundant on the PyPI page itself).

## Testing

- `./ci` passes end-to-end (unit tests, examples, ruff, mypy, black, README-PyPI render, and sdist build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XupVXgXSFmws51AVd9TmGe)_