### PR TITLE
Source queue pipe ends from fds, a FIFO, or a context

### DIFF
--- a/src/jobserver/_queue.py
+++ b/src/jobserver/_queue.py
@@ -18,18 +18,25 @@ from multiprocessing.connection import Connection
 from multiprocessing.context import BaseContext
 from multiprocessing.reduction import ForkingPickler
 from multiprocessing.synchronize import Lock
-from typing import Any, Generic, Optional, TypeVar, Union, final
+from typing import Any, Callable, Generic, Optional, TypeVar, Union, final
 
 from ._compat import pipe_buf
 
 __all__ = (
+    "EndsFactory",
     "FixedBytesQueue",
     "MPMCQueue",
     "SPSCQueue",
-    "timeout_to_deadline",
+    "Source",
     "deadline_to_timeout",
+    "from_fds",
+    "from_fifo",
     "resolve_context",
+    "timeout_to_deadline",
 )
+
+EndsFactory = Callable[[], tuple[Connection, Connection]]
+Source = Union[None, str, BaseContext, EndsFactory]
 
 T = TypeVar("T")
 
@@ -82,6 +89,62 @@ def resolve_context(context: Union[None, str, BaseContext]) -> BaseContext:
     return context
 
 
+def from_fds(read_fd: int, write_fd: int) -> EndsFactory:
+    """A source over a private dup of the given fds."""
+
+    def from_fds_make() -> tuple[Connection, Connection]:
+        rd = os.dup(read_fd)
+        try:
+            wd = os.dup(write_fd)
+        except BaseException:
+            os.close(rd)
+            raise
+        return (
+            Connection(rd, readable=True, writable=False),
+            Connection(wd, readable=False, writable=True),
+        )
+
+    return from_fds_make
+
+
+def from_fifo(path: str) -> EndsFactory:
+    """A source over a named FIFO the queue will own."""
+
+    def from_fifo_make() -> tuple[Connection, Connection]:
+        rd = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+        try:
+            wd = os.open(path, os.O_WRONLY)
+        except BaseException:
+            os.close(rd)
+            raise
+        os.set_blocking(rd, True)
+        return (
+            Connection(rd, readable=True, writable=False),
+            Connection(wd, readable=False, writable=True),
+        )
+
+    return from_fifo_make
+
+
+def to_ends_factory(source: Source, /) -> EndsFactory:
+    """Pass a source through, or wrap a context as a pipe source."""
+    if callable(source):
+        return source
+    context = resolve_context(source)
+    return lambda: context.Pipe(duplex=False)
+
+
+def check_fixedlen(fixedlen: int) -> None:
+    """Validate a fixedlen token length."""
+    if not isinstance(fixedlen, int):
+        raise TypeError(f"fixedlen: int, got {type(fixedlen).__name__}")
+    pb = pipe_buf()
+    if not 1 <= fixedlen < pb:
+        raise ValueError(
+            f"fixedlen must satisfy 1 <= fixedlen < {pb}, got {fixedlen!r}"
+        )
+
+
 def _conn_repr(conn: Optional[Connection]) -> str:
     """Describe a pipe end for __repr__, tolerating closed fds."""
     if conn is None:
@@ -106,10 +169,8 @@ class AbstractQueue(Generic[T], abc.ABC):
     _reader: Optional[Connection]
     _writer: Optional[Connection]
 
-    def __init__(self, context: Union[None, str, BaseContext] = None) -> None:
-        """Use given context with default of multiprocessing.get_context()."""
-        context = resolve_context(context)
-        self._reader, self._writer = context.Pipe(duplex=False)
+    def __init__(self, state: Callable[[], tuple[Any, ...]], /) -> None:
+        self.__setstate__(state())
 
     def __repr__(self) -> str:
         return (
@@ -227,10 +288,9 @@ class AbstractPicklingQueue(AbstractQueue[T]):
         """Restore this queue's locks from _getstate_locks() output."""
         ...
 
-    def __init__(self, context: Union[None, str, BaseContext] = None) -> None:
-        """Use given context with default of multiprocessing.get_context()."""
-        super().__init__(context)
-        self.__setstate__((self._reader, self._writer, None))
+    def __init__(self, source: Source = None, /) -> None:
+        ends = to_ends_factory(source)
+        super().__init__(lambda: (*ends(), None))
 
     def __getstate__(self) -> tuple[Any, ...]:
         return (*super().__getstate__(), self._getstate_locks())
@@ -317,14 +377,21 @@ class MPMCQueue(AbstractPicklingQueue[T]):
     across pickling, providing genuine cross-process mutual exclusion.
     """
 
-    __slots__ = ("_context",)
+    __slots__ = ()
 
-    def __init__(self, context: Union[None, str, BaseContext] = None) -> None:
-        """Use given context with default of multiprocessing.get_context()."""
-        # Retain the resolved context so _setstate_locks can mint IPC locks
-        # from it at construction, before any locks have been inherited.
-        self._context = resolve_context(context)
-        super().__init__(self._context)
+    def __init__(
+        self,
+        source: Source = None,
+        /,
+        *,
+        context: Union[None, str, BaseContext] = None,
+    ) -> None:
+        if context is None and not callable(source):
+            context = source
+        ctx = resolve_context(context)
+        ends = to_ends_factory(source if callable(source) else ctx)
+        locks = (ctx.Lock(), ctx.Lock())
+        AbstractQueue.__init__(self, lambda: (*ends(), locks))
 
     def _getstate_locks(self) -> tuple[Lock, Lock]:
         # Preserve the IPC locks so cross-process mutual exclusion survives
@@ -332,13 +399,8 @@ class MPMCQueue(AbstractPicklingQueue[T]):
         return (self._read_lock, self._write_lock)
 
     def _setstate_locks(self, state_locks: Any) -> None:
-        if state_locks is None:
-            # Fresh construction: mint new IPC locks from the context.
-            self._read_lock = self._context.Lock()
-            self._write_lock = self._context.Lock()
-        else:
-            # Unpickled into another process: reuse the inherited locks.
-            self._read_lock, self._write_lock = state_locks
+        # Minted at construction, inherited on unpickle: always a real pair.
+        self._read_lock, self._write_lock = state_locks
 
 
 @final
@@ -354,21 +416,15 @@ class FixedBytesQueue(AbstractQueue[bytes]):
 
     def __init__(
         self,
-        context: Union[None, str, BaseContext] = None,
+        source: Source = None,
+        /,
         *,
         fixedlen: int,
     ) -> None:
         """Use fixedlen-byte tokens; requires 1 <= fixedlen < pipe_buf()."""
-        if not isinstance(fixedlen, int):
-            raise TypeError(f"fixedlen: int, got {type(fixedlen).__name__}")
-        pb = pipe_buf()
-        if not 1 <= fixedlen < pb:
-            raise ValueError(
-                f"fixedlen must satisfy 1 <= fixedlen < {pb}, "
-                f"got {fixedlen!r}"
-            )
-        super().__init__(context)
-        self.__setstate__((self._reader, self._writer, fixedlen))
+        check_fixedlen(fixedlen)
+        ends = to_ends_factory(source)
+        super().__init__(lambda: (*ends(), fixedlen))
 
     def __getstate__(self) -> tuple[Any, ...]:
         return (*super().__getstate__(), self._fixedlen)

--- a/test/test_executor_basic.py
+++ b/test/test_executor_basic.py
@@ -487,7 +487,7 @@ class TestResponsesPutFailedFallback(unittest.TestCase):
         class LocalError(Exception):
             pass
 
-        with SPSCQueue(context=FAST) as q:
+        with SPSCQueue(FAST) as q:
             _responses_put_failed(q, 7, LocalError("boom"))
             resp = q.get(timeout=TIMEOUT)
         self.assertIsInstance(resp, _response.Failed)
@@ -497,7 +497,7 @@ class TestResponsesPutFailedFallback(unittest.TestCase):
 
     def test_picklable_exc_passes_through(self) -> None:
         """A picklable exception reaches the consumer unchanged."""
-        with SPSCQueue(context=FAST) as q:
+        with SPSCQueue(FAST) as q:
             _responses_put_failed(q, 3, ValueError("kept"))
             resp = q.get(timeout=TIMEOUT)
         self.assertIsInstance(resp, _response.Failed)

--- a/test/test_jobserver_basic.py
+++ b/test/test_jobserver_basic.py
@@ -286,7 +286,7 @@ class TestJobserverBasic(unittest.TestCase):
         ):
             with self.subTest(method=method, check_done=check_done):
                 with (
-                    SPSCQueue(context=method) as mq,
+                    SPSCQueue(method) as mq,
                     Jobserver(context=method, slots=1) as js,
                 ):
                     delay = 0.02  # Impacts test runtime on success path

--- a/test/test_jobserver_worker.py
+++ b/test/test_jobserver_worker.py
@@ -169,7 +169,7 @@ class TestJobserverWorker(unittest.TestCase):
         for method in start_methods():
             with self.subTest(method=method):
                 # The grandchild reports its pid here so the test can reap it.
-                with SPSCQueue(context=method) as q:
+                with SPSCQueue(method) as q:
                     with Jobserver(context=method, slots=1) as js:
                         f = js.submit(
                             fn=helper_fork_orphan_then_die, args=(q,)
@@ -217,7 +217,7 @@ class TestJobserverWorker(unittest.TestCase):
         """
         for method in start_methods():
             with self.subTest(method=method):
-                with SPSCQueue(context=method) as q:
+                with SPSCQueue(method) as q:
                     with Jobserver(context=method, slots=1) as js:
                         f = js.submit(
                             fn=helper_exec_grandchild_then_die, args=(q,)
@@ -252,7 +252,7 @@ class TestJobserverWorker(unittest.TestCase):
         invalid_sig = max(signal.valid_signals()) + 1
         for method in start_methods():
             with self.subTest(method=method):
-                with SPSCQueue(context=method) as mq:
+                with SPSCQueue(method) as mq:
                     with Jobserver(context=method, slots=1) as js:
                         f = js.submit(fn=helper_nonblocking, args=(mq,))
                         try:

--- a/test/test_queue.py
+++ b/test/test_queue.py
@@ -13,6 +13,7 @@ and the resolve_context / timeout_to_deadline helpers.
 import copy
 import os
 import queue
+import tempfile
 import threading
 import time
 import unittest
@@ -25,6 +26,8 @@ from jobserver._queue import (
     FixedBytesQueue,
     MPMCQueue,
     SPSCQueue,
+    from_fds,
+    from_fifo,
     resolve_context,
     timeout_to_deadline,
 )
@@ -49,7 +52,7 @@ class TestSPSCQueue(unittest.TestCase):
         """Copying of SPSCQueue is explicitly allowed."""
         for method in start_methods():
             with self.subTest(method=method):
-                with SPSCQueue(context=method) as mq1:
+                with SPSCQueue(method) as mq1:
                     mq2 = copy.copy(mq1)
                     mq3 = copy.deepcopy(mq1)
                     mq1.put(1)
@@ -132,8 +135,8 @@ class TestMPMCQueue(unittest.TestCase):
             with self.subTest(method=method):
                 ctx = get_context(method)
                 with (
-                    MPMCQueue(context=ctx) as inq,
-                    MPMCQueue(context=ctx) as outq,
+                    MPMCQueue(ctx) as inq,
+                    MPMCQueue(ctx) as outq,
                 ):
                     proc = ctx.Process(
                         target=_mpmc_echo_double, args=(inq, outq)
@@ -306,6 +309,63 @@ class TestFixedBytesQueue(unittest.TestCase):
                     self.assertEqual(b"PING", outq.get(timeout=30))
                     proc.join(30)
                     self.assertEqual(0, proc.exitcode)
+
+
+class TestEndpointSources(unittest.TestCase):
+    """from_fds / from_fifo as the pipe source for any queue type."""
+
+    def test_from_fds_roundtrips_all_queues(self) -> None:
+        """Every queue type works over an inherited fd pair, surviving a
+        getstate/setstate round-trip before put/get."""
+        cases = (
+            (lambda s: FixedBytesQueue(s, fixedlen=1), b"J"),
+            (lambda s: SPSCQueue(s), "hi"),
+            (lambda s: MPMCQueue(s), ("tuple", 1)),
+        )
+        for factory, item in cases:
+            with self.subTest(item=item):
+                r, w = os.pipe()
+                q = factory(from_fds(r, w))
+                os.close(r)  # the queue holds its own dups
+                os.close(w)
+                clone = type(q).__new__(type(q))
+                clone.__setstate__(q.__getstate__())
+                with clone:
+                    clone.put(item)
+                    self.assertEqual(item, clone.get(timeout=1))
+
+    def test_from_fds_keeps_caller_fds(self) -> None:
+        """from_fds dups, so the caller's fds stay usable afterward."""
+        r, w = os.pipe()
+        try:
+            with FixedBytesQueue(from_fds(r, w), fixedlen=1) as q:
+                q.put(b"J")
+                self.assertEqual(b"J", q.get(timeout=1))
+            os.write(w, b"Z")  # queue closed its dups, not the originals
+            self.assertEqual(b"Z", os.read(r, 1))
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_from_fds_preserves_token_values(self) -> None:
+        """Opaque byte values survive verbatim (the GNU Make guarantee)."""
+        r, w = os.pipe()
+        os.write(w, b"\x00\x7f\xff")
+        q = FixedBytesQueue(from_fds(r, w), fixedlen=1)
+        os.close(r)  # the queue holds its own dups
+        os.close(w)
+        with q:
+            got = sorted(q.get(timeout=1) for _ in range(3))
+        self.assertEqual([b"\x00", b"\x7f", b"\xff"], got)
+
+    def test_from_fifo_roundtrip(self) -> None:
+        """A named FIFO backs a queue end to end."""
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "fifo")
+            os.mkfifo(path)
+            with FixedBytesQueue(from_fifo(path), fixedlen=1) as q:
+                q.put(b"J")
+                self.assertEqual(b"J", q.get(timeout=1))
 
 
 class TestResolveContext(unittest.TestCase):


### PR DESCRIPTION
Unify how all three queues acquire their pipe behind a single
positional-only first argument: a context (None/str/BaseContext) mints a
private pipe as before, while a callable is treated as a source yielding
a (reader, writer) pair.  Two such sources are added -- from_fds (a
private dup of inherited fds, e.g. a GNU Make jobserver pipe; the caller
keeps ownership) and from_fifo (a named FIFO the queue owns).  Backed by
the lockless, value-preserving FixedBytesQueue this is the groundwork for
MAKEFLAGS jobserver participation, but every queue type gains it.

AbstractQueue.__init__ now just installs whatever state its source
yields via __setstate__, the canonical installer; subclasses compose
their own state tail, so their constructors collapse to one line.

MPMCQueue mints its context-bound IPC locks at construction and carries
them in the state tuple, dropping the _context slot entirely.  A SemLock
cannot be shared across start methods, so the lock context remains
explicit (via context= or a context passed as the source); only that
fork-vs-spawn binding kept it from being eliminated too.

Migrate the few context= keyword call sites to positional form and cover
the new sources across all three queue types.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012U7TKWAsLi28HTt3y5VCmA